### PR TITLE
fix computing of hash in pastecode example

### DIFF
--- a/examples/jsf/pastecode/src/main/java/org/jboss/weld/examples/pastecode/session/HashComputer.java
+++ b/examples/jsf/pastecode/src/main/java/org/jboss/weld/examples/pastecode/session/HashComputer.java
@@ -61,8 +61,8 @@ public class HashComputer
          if ((buf[i] & 0xff) < 0x10)
          {
             strBuf.append("0");
-            strBuf.append(Long.toString(buf[i] & 0xff, 16));
          }
+         strBuf.append(Long.toString(buf[i] & 0xff, 16));
       }
       if (strBuf.length() <= 6)
       {


### PR DESCRIPTION
Before this change the hash for private messages is almost always /h00000, with this fix the hash is already correct (like /h6d5fg).
