### PR TITLE
Weld 676

### DIFF
--- a/impl/src/main/java/org/jboss/weld/resolution/TypeSafeResolver.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/TypeSafeResolver.java
@@ -55,7 +55,7 @@ public abstract class TypeSafeResolver<R extends Resolvable, T>
          {
             Key that = (Key) obj;
             return that.getResolvable().getClass().equals(this.getResolvable().getClass())
-                  && that.getResolvable().isEqualTo(that.getResolvable());
+                  && that.getResolvable().isEqualTo(this.getResolvable());
          }
          else
          {


### PR DESCRIPTION
This may help with WELD-676, but I cannot be 100% sure. TypeSafeResolver.Key had a bug in equals(), so if there was a hash collision the wrong bean may be resolved.
