### PR TITLE
Weld 732

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/AbstractBeanDeployer.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/AbstractBeanDeployer.java
@@ -219,7 +219,7 @@ public class AbstractBeanDeployer<E extends BeanDeployerEnvironment>
    
    protected <X> void createObserverMethods(RIBean<X> declaringBean, WeldClass<X> annotatedClass)
    {
-      for (WeldMethod<?, ? super X> method : annotatedClass.getDeclaredWeldMethodsWithAnnotatedParameters(Observes.class))
+      for (WeldMethod<?, ? super X> method : annotatedClass.getWeldMethodsWithAnnotatedParameters(Observes.class))
       {
          createObserverMethod(declaringBean, method);
       }

--- a/impl/src/main/java/org/jboss/weld/introspector/WeldClass.java
+++ b/impl/src/main/java/org/jboss/weld/introspector/WeldClass.java
@@ -158,7 +158,7 @@ public interface WeldClass<T> extends WeldAnnotated<T, Class<T>>, AnnotatedType<
    public WeldMethod<?, ?> getDeclaredWeldMethod(Method method);
 
    /**
-    * Gets all with parameters annotated with annotationType
+    * Gets declared with parameters annotated with annotationType
     * 
     * @param annotationType The annotation to match
     * @return A set of abstracted methods with the given annotation. Returns an
@@ -166,6 +166,15 @@ public interface WeldClass<T> extends WeldAnnotated<T, Class<T>>, AnnotatedType<
     */
    public Collection<WeldMethod<?, ? super T>> getDeclaredWeldMethodsWithAnnotatedParameters(Class<? extends Annotation> annotationType);
 
+   /**
+    * Gets all with parameters annotated with annotationType
+    * 
+    * @param annotationType The annotation to match
+    * @return A set of abstracted methods with the given annotation. Returns an
+    *         empty set if there are no matches
+    */
+   public Collection<WeldMethod<?, ? super T>> getWeldMethodsWithAnnotatedParameters(Class<? extends Annotation> annotationType);
+   
    /**
     * Gets the superclass.
     * 

--- a/impl/src/main/java/org/jboss/weld/introspector/jlr/WeldClassImpl.java
+++ b/impl/src/main/java/org/jboss/weld/introspector/jlr/WeldClassImpl.java
@@ -547,6 +547,20 @@ public class WeldClassImpl<T> extends AbstractWeldAnnotated<T, Class<T>> impleme
       return Collections.unmodifiableCollection(declaredMethodsByAnnotatedParameters.get(annotationType));
    }
 
+   public Collection<WeldMethod<?, ? super T>> getWeldMethodsWithAnnotatedParameters(Class<? extends Annotation> annotationType)
+   {
+      // TODO should be cached
+      ArrayList<WeldMethod<?, ? super T>> methods = new ArrayList<WeldMethod<?, ? super T>>();
+      for (WeldMethod<?, ?> method : getWeldMethods())
+      {
+         if (!method.getWeldParameters(annotationType).isEmpty())
+         {
+            methods.add((WeldMethod<?, ? super T>) method);
+         }
+      }
+      return Collections.unmodifiableCollection(methods);
+   }
+
    public WeldMethod<?, ?> getWeldMethod(Method methodDescriptor)
    {
       // TODO Should be cached
@@ -651,7 +665,7 @@ public class WeldClassImpl<T> extends AbstractWeldAnnotated<T, Class<T>> impleme
    {
       return Modifier.isFinal(getJavaClass().getModifiers());
    }
-   
+
    public boolean isGeneric()
    {
       return getJavaClass().getTypeParameters().length > 0;

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/AbstractTestObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/AbstractTestObserver.java
@@ -1,0 +1,23 @@
+package org.jboss.weld.tests.event.observer.superclass;
+
+import javax.enterprise.event.Observes;
+
+public abstract class AbstractTestObserver
+{
+   private TestEvent testEvent;
+
+   public TestEvent getTestEvent()
+   {
+      return testEvent;
+   }
+
+   void observe(@Observes TestEvent event)
+   {
+      this.testEvent = event;
+   }
+
+   public void reset()
+   {
+      testEvent = null;
+   }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/Disabled.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/Disabled.java
@@ -1,0 +1,12 @@
+package org.jboss.weld.tests.event.observer.superclass;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Disabled {
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/DisabledTestObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/DisabledTestObserver.java
@@ -1,0 +1,12 @@
+package org.jboss.weld.tests.event.observer.superclass;
+
+@Disabled
+public class DisabledTestObserver extends TestObserver {
+
+	@Override
+	// observation disabled because this overrides the observer method without
+	// the @Observes
+	void observe(TestEvent event) {
+		super.observe(event);
+	}
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/ReEnabled.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/ReEnabled.java
@@ -1,0 +1,12 @@
+package org.jboss.weld.tests.event.observer.superclass;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import javax.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ReEnabled {
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/ReEnabledTestObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/ReEnabledTestObserver.java
@@ -1,0 +1,12 @@
+package org.jboss.weld.tests.event.observer.superclass;
+
+import javax.enterprise.event.Observes;
+
+@ReEnabled
+public class ReEnabledTestObserver extends DisabledTestObserver {
+	@Override
+	// reenables observation by overriding and adding @Observes
+	void observe(@Observes TestEvent event) {
+		super.observe(event);
+	}
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/SuperclassObserversTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/SuperclassObserversTest.java
@@ -1,0 +1,79 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.event.observer.superclass;
+
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class SuperclassObserversTest {
+	@Deployment
+	public static Archive<?> deploy() {
+		return ShrinkWrap.create(BeanArchive.class).addPackage(
+				SuperclassObserversTest.class.getPackage());
+	}
+
+	@Inject
+	Event<TestEvent> event;
+
+	@Inject
+	private TestObserver observer;
+
+	@Inject
+	@Disabled
+	private DisabledTestObserver disabled;
+
+	@Inject
+	@ReEnabled
+	private ReEnabledTestObserver reenabled;
+
+	@Test
+	public void testObserverMethodFromSuperclassInvoked() {
+		observer.reset();
+
+		assert observer.getTestEvent() == null;
+		event.fire(new TestEvent());
+		assert observer.getTestEvent() != null;
+	}
+
+	@Test
+	public void testObserverMethodOnOverridesWithoutAnnotNotInvoked() {
+		disabled.reset();
+
+		assert disabled.getTestEvent() == null;
+		event.fire(new TestEvent());
+		assert disabled.getTestEvent() == null;
+	}
+
+	@Test
+	public void testObserverMethodOnOverridesWithAnnotAreInvoked() {
+		reenabled.reset();
+
+		assert reenabled.getTestEvent() == null;
+		event.fire(new TestEvent());
+		assert reenabled.getTestEvent() != null;
+	}
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/TestEvent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/TestEvent.java
@@ -1,0 +1,6 @@
+package org.jboss.weld.tests.event.observer.superclass;
+
+public class TestEvent
+{
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/TestObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/observer/superclass/TestObserver.java
@@ -1,0 +1,9 @@
+package org.jboss.weld.tests.event.observer.superclass;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class TestObserver extends AbstractTestObserver
+{
+
+}


### PR DESCRIPTION
integration tests fail because i believe there is a bug in the tck.

test fails in EventTest:149
    147: StockPrice price = new StockPrice();
    148: Set<ObserverMethod<? super StockPrice>> observers = getCurrentManager().resolveObserverMethods(price);
    149: assert observers.size() == 1;

the one and only one expected observer method is:
    StockWatcher#public void observeStockPrice(@Observes StockPrice price)

however, according to section 4.2 of the spec:
    If X declares an initializer, non-static observer, @PostConstruct or @PreDestroy method x() then
    Y inherits x() if and only if neither Y nor any intermediate class that is a subclass of X and a
    superclass of Y overrides the method x().
so the two observer methods from IntermediateStockWatcher and IndirectStockWatcher subclasses of StockWatcher should also be considered.
