### PR TITLE
Weld 768

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/bytecode/ConstructorUtils.java
+++ b/impl/src/main/java/org/jboss/weld/util/bytecode/ConstructorUtils.java
@@ -26,6 +26,8 @@ import javassist.bytecode.ExceptionsAttribute;
 import javassist.bytecode.MethodInfo;
 import javassist.bytecode.Opcode;
 
+import org.jboss.weld.bean.proxy.ProxyFactory;
+
 /**
  * Utility class for working with constructors in the low level javassist API
  * 
@@ -81,6 +83,10 @@ public class ConstructorUtils
          int localVariableCount = BytecodeUtils.loadParameters(b, descriptor);
          // now we have the parameters on the stack
          b.addInvokespecial(file.getSuperclass(), "<init>", descriptor);
+         // now set constructed to true
+         b.addAload(0);
+         b.addIconst(1);
+         b.addPutfield(file.getName(), ProxyFactory.CONSTRUCTED_FLAG_NAME, "Z");
          b.addOpcode(Opcode.RETURN);
          CodeAttribute ca = b.toCodeAttribute();
          // set the initial field values

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Baz.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Baz.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.proxy;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named
+@RequestScoped
+class Baz implements Serializable
+{
+   private int count = 0;
+
+   public Baz()
+   {
+      init();
+   }
+
+   public void init()
+   {
+      count++;
+   }
+   
+   public int getCount()
+   {
+      return count;
+   }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/ProxyTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/ProxyTest.java
@@ -61,4 +61,12 @@ public class ProxyTest
       Assert.assertEquals(Foo.MESSAGE, foo.getMsg(0, 0L, 0D, false, 'a', 0F, (short) 0));
       Assert.assertEquals(Foo.MESSAGE, foo.getRealMsg(0, 0L, 0D, false, 'a', 0F, (short) 0));
    }
+
+   @Test
+   public void testSelfInvocationInConstructor()
+   {
+      Bean<?> bean = beanManager.resolve(beanManager.getBeans("baz"));
+      Baz baz = (Baz) beanManager.getReference(bean, Baz.class, beanManager.createCreationalContext(bean));
+      Assert.assertEquals(1, baz.getCount());
+   }
 }


### PR DESCRIPTION
This should fix the proxy problems, I also added a test for another problem I found, where virtual methods called from the proxy constructor would be delegated to the bean instance (actually this used to happen pre 1.1.0.Beta1, after Beta1 the bean instance was not ready yet so we were getting a NPE instead).
