### PR TITLE
Documentation compatibility with Maven and Publican

### DIFF
--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -41,6 +41,7 @@
             <version>2.3.3</version>
             <configuration>
                <sourceDirectory>${jdocbookSourceDirectory}</sourceDirectory>
+               <sourceDocumentName>Weld_-_JSR-299_Reference_Implementation.xml</sourceDocumentName>
             </configuration>
          </plugin>
          <plugin>

--- a/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.ent
+++ b/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.ent
@@ -1,0 +1,4 @@
+<!ENTITY HOLDER "Red Hat, Inc">
+<!ENTITY YEAR "2010">
+<!ENTITY JBPAPP "JBoss Enterprise Application Platform">
+<!ENTITY VER "6">

--- a/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.xml
+++ b/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding="utf-8"?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
    "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd"  [ ]>
-<book lang="en">
+<book>
 
    <xi:include href="Book_Info.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
    
@@ -32,7 +32,7 @@
    
    <toc/>
    
-   <part id="1">
+   <part id="part-1">
       <title>Beans</title>
       
       <xi:include href="part1.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -45,7 +45,7 @@
      
    </part>
 
-   <part id="2">
+   <part id="part-2">
       <title>Getting Start with Weld, the CDI Reference Implementation</title>
       
       <xi:include href="part2.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -55,7 +55,7 @@
 
    </part>
    
-   <part id="3">
+   <part id="part-3">
       <title>Loose coupling with strong typing</title>
       
       <xi:include href="part3.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -71,7 +71,7 @@
 
    </part>
    
-   <part id="4">
+   <part id="part-4">
       <title>CDI and the Java EE ecosystem</title>
       
       <xi:include href="part4.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
@@ -83,7 +83,7 @@
    
    <xi:include href="next.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />
    
-   <part id="5">
+   <part id="part-5">
       <title>Weld Reference Guide</title>
       
       <xi:include href="part5.xml" xmlns:xi="http://www.w3.org/2001/XInclude" />

--- a/docs/reference/src/main/docbook/en-US/weldexamples.xml
+++ b/docs/reference/src/main/docbook/en-US/weldexamples.xml
@@ -1155,13 +1155,13 @@ public class TranslatorControllerBean implements TranslatorController {
    @Remove public void remove() {}
 
 }]]></programlisting>
-
-   </section>
    
    <para>
       That concludes our short tour of the Weld starter examples. For more information on Weld, please visit <ulink
       url="http://www.seamframework.org/Weld">http://www.seamframework.org/Weld</ulink>.
    </para>
+
+   </section>
 
 <!--
 vim:et:ts=3:sw=3:tw=120

--- a/docs/reference/src/main/docbook/publican.cfg
+++ b/docs/reference/src/main/docbook/publican.cfg
@@ -3,5 +3,5 @@
 
 debug: 1
 xml_lang: en-US
-# brand: JBoss
+brand: JBoss
 


### PR DESCRIPTION
These changes make the documentation buildable with Maven (for the Weld project) and Publican (for the EAP6 product documentation).
- moved publican.cfg file from reference to 
    reference/src/main/docbook alongside the lang directories
- uncommented brand: JBoss in publican.cfg
- removed lang="en" from the book tag
- renamed master.xml to Weld_-_JSR-299_Reference_Implementation.xml
- modified the reference/pom.xml to use the 
    Weld_-_JSR-299_Reference_Implementation.xml file 
    instead of the master.xml file as a base by adding 
    sourceDocumentName element to maven-jdocbook-plugin 
    configuration.
- added the Weld_-_JSR-299_Reference_Implementation.ent file for Publican
- altered the part ids in Weld_-_JSR-299_Reference_Implementation.xml
    to part-# instead of just #, since Publican does not allow ids to
    start with a digit.
- moved the para tag that was outside the last section in
    weldexamples.xml, inside the section, since publican does not
    allow trailing paragraphs.
