### PR TITLE
Extension speed

### DIFF
--- a/impl/src/main/java/org/jboss/weld/introspector/jlr/WeldMethodImpl.java
+++ b/impl/src/main/java/org/jboss/weld/introspector/jlr/WeldMethodImpl.java
@@ -179,7 +179,12 @@ public class WeldMethodImpl<T, X> extends AbstractWeldCallable<T, X, Method> imp
 
    public T invokeOnInstance(Object instance, Object... parameters) throws IllegalArgumentException, SecurityException, IllegalAccessException, InvocationTargetException, NoSuchMethodException
    {
-      Method method = SecureReflections.lookupMethod(instance.getClass(), getName(), getParameterTypesAsArray());
+      Method method = this.method;
+      // we only look up the method if we really need to, as it is slow
+      if (method.getDeclaringClass() != instance.getClass())
+      {
+         method = SecureReflections.lookupMethod(instance.getClass(), getName(), getParameterTypesAsArray());
+      }
       return SecureReflections.<T>invoke(instance, method, parameters);
    }
 


### PR DESCRIPTION
This minor optimisation knocks around seconds off startup time when solder is present in my 10,000 bean benchmark. This brings the startup speed with solder down to ~17s, as opposed to ~16s without solder.
