### PR TITLE
Publican best practices

### DIFF
--- a/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.xml
+++ b/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.xml
@@ -25,7 +25,7 @@
       <para>
          Note that this reference guide was started while changes were still being made to the specification. We've done
          our best to update it for accuracy.  If you discover a conflict between what is written in this guide and the
-         specification, the specification is the authority&#8212;assume it is correct. If you believe you have found an error
+         specification, the specification is the authority&mdash;assume it is correct. If you believe you have found an error
          in the specification, please report it to the JSR-299 EG.
       </para>
    </preface>

--- a/docs/reference/src/main/docbook/en-US/beans.xml
+++ b/docs/reference/src/main/docbook/en-US/beans.xml
@@ -70,7 +70,7 @@
   
       <para>
          Note that not all clients of a bean are beans themselves. Other objects such as servlets or message-driven
-         beans&#8212;which are by nature not injectable, contextual objects&#8212;may also obtain references to beans by
+         beans&mdash;which are by nature not injectable, contextual objects&mdash;may also obtain references to beans by
          injection.
       </para>
 
@@ -91,6 +91,7 @@
             <listitem><para>A set of interceptor bindings</para></listitem>
             <listitem><para>A bean implementation</para></listitem>
          </itemizedlist>
+         
          
          <para>Furthermore, a bean may or may not be an alternative.</para>
 
@@ -142,14 +143,12 @@ public class BookShopBean
    ...
 }]]></programlisting> 
 
-         <note>
-            <para>
-               The bean types of a session bean include local interfaces and the bean class local view (if any). 
-               EJB remote interfaces are not considered bean types of a session bean. You can't inject an EJB using
-               its remote interface unless you define a <emphasis>resource</emphasis>, which we'll meet in 
-               <xref linkend="resources"/>.
-            </para>
-         </note>
+         <para>
+            The bean types of a session bean include local interfaces and the bean class local view (if any). 
+            EJB remote interfaces are not considered bean types of a session bean. You can't inject an EJB using
+            its remote interface unless you define a <emphasis>resource</emphasis>, which we'll meet in 
+            <xref linkend="resources"/>.
+         </para>
 
          <para>
             Bean types may be restricted to an explicit set by annotating the bean with the <literal>@Typed</literal>
@@ -190,13 +189,13 @@ public @interface CreditCard {}]]></programlisting>
             from time to time. 
          </para>
          
-         <tip>
+         <note>
             <para>
                Pay attention to the names of the built-in annotations in CDI and EJB. You'll notice that they are 
                often adjectives. We encourage you to follow this convention when creating your custom annotations, 
                since they serve to describe the behaviors and roles of the class.
             </para>
-         </tip>
+         </note>
             
          <para>
             Now that we have defined a qualifier annotation, we can use it to disambiguate an injection point. The 
@@ -205,13 +204,6 @@ public @interface CreditCard {}]]></programlisting>
          </para>
 
          <programlisting role="JAVA"><![CDATA[@Inject @CreditCard PaymentProcessor paymentProcessor]]></programlisting>
-
-         <note>
-            <para>
-               If an injection point does not explicitly specify a qualifier, it has the default qualifier, 
-               <literal>@Default</literal>.
-            </para>
-         </note>
 
          <para>
             For each injection point, the container searches for a bean which satisfies the contract, one which has
@@ -231,7 +223,7 @@ public class CreditCardPaymentProcessor
 
          <note>
             <para>
-               If a bean does not explicitly specify a qualifier, it has the default qualifier, <literal>@Default</literal>.
+               If a bean or an injection point does not explicitly specify a qualifier, it has the default qualifier, <literal>@Default</literal>.
             </para>
          </note>
          
@@ -250,7 +242,7 @@ public class CreditCardPaymentProcessor
          </para>
          
          <!--
-         <tip>
+         <note>
             <para>
                If you're expecting more than one bean to satisfy the contract, you can inject an <literal>Instance</literal>,
                object which let's you iterate over all the beans which satisfy the contract. For example, we can iterate
@@ -259,7 +251,7 @@ public class CreditCardPaymentProcessor
             <programlisting role="JAVA">@Inject void init(@Any Instance&lt;PaymentProcessor&gt; paymentProcessorInstance) {
     for (PaymentProcessor pp: paymentProcessorInstance) { ... }
 }</programlisting>
-         </tip>
+         </note>
          -->
            
       </section>
@@ -469,8 +461,6 @@ class ShoppingCart implements Serializable { ... }]]></programlisting>
             container treats any class that satisfies the following conditions as a managed bean:
          </para>
 
-         <blockquote>
-
          <itemizedlist>
             <listitem>
                <para>It is not a non-static inner class.</para>
@@ -489,7 +479,7 @@ class ShoppingCart implements Serializable { ... }]]></programlisting>
             </listitem>
             <listitem>
                <para>
-                  It has an appropriate constructor&#8212;either:
+                  It has an appropriate constructor&mdash;either:
                </para>
                <itemizedlist>
                   <listitem>
@@ -501,9 +491,7 @@ class ShoppingCart implements Serializable { ... }]]></programlisting>
                </itemizedlist>
             </listitem>
          </itemizedlist>
-         
-         </blockquote>
-         
+
          <note>
            <para>
              According to this definition, JPA entities are technically managed beans. However, entities have their own 
@@ -541,14 +529,12 @@ class ShoppingCart implements Serializable { ... }]]></programlisting>
             and so on.
          </para>
 
-         <note>
-            <para>
-               Message-driven and entity beans are by nature non-contextual objects and may not be injected into other
-               objects. However, message-driven beans can take advantage of some CDI functionality, such as dependency 
-               injection, interceptors and decorators. In fact, CDI will perform injection into any session or 
-               message-driven bean, even those which are not contextual instances.
-            </para>
-         </note>
+         <para>
+            Message-driven and entity beans are by nature non-contextual objects and may not be injected into other
+            objects. However, message-driven beans can take advantage of some CDI functionality, such as dependency 
+            injection, interceptors and decorators. In fact, CDI will perform injection into any session or 
+            message-driven bean, even those which are not contextual instances.
+         </para>
 
          <para>
             The unrestricted set of bean types for a session bean contains all local interfaces of the bean and their
@@ -565,7 +551,7 @@ class ShoppingCart implements Serializable { ... }]]></programlisting>
          <para>
             Stateful session beans may define a <emphasis>remove method</emphasis>, annotated <literal>@Remove</literal>, 
             that is used by the application to indicate that an instance should be destroyed. However, for a contextual 
-            instance of the bean&#8212;an instance under the control of CDI&#8212;this method may only be called by the 
+            instance of the bean&mdash;an instance under the control of CDI&mdash;this method may only be called by the 
             application if the bean has scope <literal>@Dependent</literal>. For beans with other scopes, the application 
             must let the container destroy the bean.
          </para>
@@ -667,10 +653,10 @@ public class RandomNumberGenerator {
 
          <para>
             We can't write a bean class that is itself a random number. But we can certainly write a method that returns 
-            a random number. By making the method a producer method, we allow the return value of the method&#8212;in this 
-            case an <literal>Integer</literal>&#8212;to be injected. We can even specify a qualifier&#8212;in this case 
-            <literal>@Random</literal>, a scope&#8212;which in this case defaults to <literal>@Dependent</literal>, 
-            and an EL name&#8212;which in this case defaults to <literal>randomNumber</literal> according to the JavaBeans 
+            a random number. By making the method a producer method, we allow the return value of the method&mdash;in this 
+            case an <literal>Integer</literal>&mdash;to be injected. We can even specify a qualifier&mdash;in this case 
+            <literal>@Random</literal>, a scope&mdash;which in this case defaults to <literal>@Dependent</literal>, 
+            and an EL name&mdash;which in this case defaults to <literal>randomNumber</literal> according to the JavaBeans 
             property name convention. Now we can get a random number anywhere:
          </para>
    
@@ -713,17 +699,15 @@ public class RandomNumberGenerator {
             </listitem>
          </itemizedlist>
 
-         <note>
-            <para>
-               Producer methods and fields may have a primitive bean type. For the purpose of resolving dependencies,
-               primitive types are considered to be identical to their corresponding wrapper types in 
-               <literal>java.lang</literal>.
-            </para>
-         </note>
+         <para>
+            Producer methods and fields may have a primitive bean type. For the purpose of resolving dependencies,
+            primitive types are considered to be identical to their corresponding wrapper types in 
+            <literal>java.lang</literal>.
+         </para>
 
          <para>
             If the producer method has method parameters, the container will look for a bean that satisfies the type
-            and qualifiers of each parameter and pass it to the method automatically&#8212;another form of 
+            and qualifiers of each parameter and pass it to the method automatically&mdash;another form of 
             dependency injection.
          </para>
    
@@ -740,7 +724,7 @@ public class RandomNumberGenerator {
 
          <para>
             A <emphasis>producer field</emphasis> is a simpler alternative to a producer method. A producer field is 
-            declared by annotating a field of a bean class with the <literal>@Produces</literal> annotation&#8212;the 
+            declared by annotating a field of a bean class with the <literal>@Produces</literal> annotation&mdash;the 
             same annotation used for producer methods.
          </para>
 

--- a/docs/reference/src/main/docbook/en-US/configure.xml
+++ b/docs/reference/src/main/docbook/en-US/configure.xml
@@ -82,13 +82,13 @@
          hierarchy).
       </para>
       
-      <tip>
+      <note>
          <para>
             If you specify just a system property name, Weld will activate the filter if that system property
             has been set (with any value). If you also specify the system property value, then Weld will only
             activate the filter if the system property's value matches exactly.
          </para>
-      </tip>
+      </note>
       
       <para>
          The fourth filter shows more a advanced configurations, where we use multiple activation conditions to 
@@ -96,17 +96,16 @@
       </para>
       
       <para>
-         You can combine as many activation conditions as you like (<emphasis>all</emphasis> must be true for the filter to be activated).
+         You can combine as many activation conditions as you like (<emphasis>all</emphasis> must be true for the 
+         filter to be activated).
          If you want to a filter that is active if <emphasis>any</emphasis> of the activation conditions are true,
          then you need multiple identical filters, each with different activation conditions.
       </para>
       
-      <tip>
-         <para>
-            In general, the semantics defined by Ant's pattern sets 
-            (http://ant.apache.org/manual/dirtasks.html#patternset) are followed.
-         </para>
-      </tip>
+      <para>
+         In general, the semantics defined by Ant's pattern sets 
+         (http://ant.apache.org/manual/dirtasks.html#patternset) are followed.
+      </para>
 
    </section>
 

--- a/docs/reference/src/main/docbook/en-US/contexts.xml
+++ b/docs/reference/src/main/docbook/en-US/contexts.xml
@@ -26,14 +26,12 @@
          after calling activate.
       </para>
       
-      <tip>
-         <para>
-            Weld automatically controls context lifecycle in many scenarios such as Http Requests,
-            EJB remote invocations, and MDB invocations. Many of the extensions for CDI offer context
-            lifecycle for other environments, it's worth checking to see if there is a suitable extension
-            before deciding to manage the context yourself.
-         </para>
-      </tip>
+      <para>
+         Weld automatically controls context lifecycle in many scenarios such as Http Requests,
+         EJB remote invocations, and MDB invocations. Many of the extensions for CDI offer context
+         lifecycle for other environments, it's worth checking to see if there is a suitable extension
+         before deciding to manage the context yourself.
+      </para>
       
       <para>
          Weld provides a number of built in contexts, which are shown in <xref linkend="contexts.available"/>.
@@ -67,7 +65,8 @@
                <entry morerows="1" valign="top"><code>@RequestScoped</code></entry>
                <entry><code>@Bound</code></entry>
                <entry><code>RequestContext</code></entry>               
-               <entry morerows="1" valign="top">A request context bound to a manually propagated map, useful for testing or non-Servlet environments</entry>
+               <entry morerows="1" valign="top">A request context bound to a manually propagated map, 
+                  useful for testing or non-Servlet environments</entry>
             </row>
             <row>
                <entry><code>@Default</code></entry>
@@ -77,7 +76,8 @@
                <entry morerows="1" valign="top"><code>@RequestScoped</code></entry>
                <entry><code>@Http</code></entry>
                <entry><code>RequestContext</code></entry>               
-               <entry morerows="1" valign="top">A request context bound to a Servlet request, used for any Servlet based request context</entry>
+               <entry morerows="1" valign="top">A request context bound to a Servlet request, used for 
+                  any Servlet based request context</entry>
             </row>
             <row>
                <entry><code>@Default</code></entry>
@@ -87,7 +87,8 @@
                <entry morerows="1" valign="top"><code>@RequestScoped</code></entry>
                <entry><code>@Ejb</code></entry>
                <entry><code>RequestContext</code></entry>               
-               <entry morerows="1" valign="top">A request context bound to a an interceptor's invocation context, used for EJB invocations outside of Servlet requests</entry>
+               <entry morerows="1" valign="top">A request context bound to a an interceptor's invocation 
+                  context, used for EJB invocations outside of Servlet requests</entry>
             </row>
             <row>
                <entry><code>@Default</code></entry>
@@ -97,7 +98,9 @@
                <entry morerows="1" valign="top"><code>@ConversationScoped</code></entry>
                <entry><code>@Bound</code></entry>
                <entry><code>ConversationContext</code></entry>               
-               <entry morerows="1" valign="top">A conversation context bound to two manually propagated maps (one which represents the request and one which represents the session), useful for testing or non-Servlet environments</entry>
+               <entry morerows="1" valign="top">A conversation context bound to two manually propagated maps 
+                  (one which represents the request and one which represents the session), useful for testing 
+                  or non-Servlet environments</entry>
             </row>
             <row>
                <entry><code>@Default</code></entry>
@@ -107,7 +110,8 @@
                <entry morerows="1" valign="top"><code>@ConversationScoped</code></entry>
                <entry><code>@Http</code></entry>
                <entry><code>ConversationContext</code></entry>               
-               <entry morerows="1" valign="top">A conversation context bound to a Servlet request, used for any Servlet based conversation context</entry>
+               <entry morerows="1" valign="top">A conversation context bound to a Servlet request, used for 
+                  any Servlet based conversation context</entry>
             </row>
             <row>
                <entry><code>@Default</code></entry>
@@ -117,7 +121,8 @@
                <entry morerows="1" valign="top"><code>@SessionScoped</code></entry>
                <entry><code>@Bound</code></entry>
                <entry><code>SessionContext</code></entry>               
-               <entry morerows="1" valign="top">A session context bound to a manually propagated map, useful for testing or non-Servlet environments</entry>
+               <entry morerows="1" valign="top">A session context bound to a manually propagated map, useful 
+                  for testing or non-Servlet environments</entry>
             </row>
             <row>
                <entry><code>@Default</code></entry>
@@ -127,7 +132,8 @@
                <entry morerows="1" valign="top"><code>@SessionScoped</code></entry>
                <entry><code>@Http</code></entry>
                <entry><code>SessionContext</code></entry>               
-               <entry morerows="1" valign="top">A session context bound to a Servlet request, used for any Servlet based session context</entry>
+               <entry morerows="1" valign="top">A session context bound to a Servlet request, used for any 
+                  Servlet based session context</entry>
             </row>
             <row>
                <entry><code>@Default</code></entry>
@@ -137,13 +143,15 @@
                <entry><code>@ApplicationScoped</code></entry>
                <entry><code>@Default</code></entry>
                <entry><code>ApplicationContext</code></entry>               
-               <entry>An application context backed by an application scoped singleton, it is unmanaged and unbound but does offer an option to destroy all entries</entry>
+               <entry>An application context backed by an application scoped singleton, it is unmanaged and 
+                  unbound but does offer an option to destroy all entries</entry>
             </row>
             <row>
                <entry><code>@SingletonScoped</code></entry>
                <entry><code>@Default</code></entry>
                <entry><code>SingletonContext</code></entry>               
-               <entry>A singleton context backed by an application scoped singleton, it is unmanaged and unbound but does offer an option to destroy all entries</entry>
+               <entry>A singleton context backed by an application scoped singleton, it is unmanaged and 
+                  unbound but does offer an option to destroy all entries</entry>
             </row>
          </tbody>
          </tgroup>
@@ -263,11 +271,11 @@
       non-transient conversations in a session can be obtained from the conversation context, as can the current conversation.
    </para>
    
-   <tip>
+   <note>
       <para>
          Weld's conversations are not assigned ids until they become non-transient.
       </para>
-   </tip>
+   </note>
 
    </section>
 

--- a/docs/reference/src/main/docbook/en-US/ee.xml
+++ b/docs/reference/src/main/docbook/en-US/ee.xml
@@ -53,7 +53,7 @@
             </para>
          </note>
          
-         <tip>
+         <note>
             <para>
                Oh, you <emphasis>really</emphasis> want to inject the <literal>FacesContext</literal>? Alright then, try
                this producer method:
@@ -63,7 +63,7 @@
       return FacesContext.getCurrentInstance();
    }
 }]]></programlisting>
-         </tip>
+         </note>
          
       </section>
 
@@ -263,7 +263,7 @@ public void sendMessage(String price) {
       <title>Packaging and deployment</title>
     
       <para>
-         CDI doesn't define any special deployment archive. You can package beans in jars, ejb jars or wars&#8212;any
+         CDI doesn't define any special deployment archive. You can package beans in jars, ejb jars or wars&mdash;any
          deployment location in the application classpath. However, the archive must be a "bean archive". That means
          each archive that contains beans <emphasis>must</emphasis> include a file named <literal>beans.xml</literal> in
          the <literal>META-INF</literal> directory of the classpath or <literal>WEB-INF</literal> directory of the web

--- a/docs/reference/src/main/docbook/en-US/environments.xml
+++ b/docs/reference/src/main/docbook/en-US/environments.xml
@@ -12,12 +12,10 @@
          to the classpath or <literal>WEB-INF/beans.xml</literal> to the web root!
       </para>
       
-      <note>
-         <para>
-            Additionally, Weld Servlet supports JBoss EAP 5.1, to do this use the <literal>jboss5</literal> variant
-            of Weld Servlet.
-         </para>
-      </note>
+      <para>
+         Additionally, Weld Servlet supports JBoss EAP 5.1, to do this use the <literal>jboss5</literal> variant
+         of Weld Servlet.
+      </para>
          
    </section>
    
@@ -53,8 +51,8 @@
          <literal>weld-servlet.jar</literal> within the <literal>WEB-INF/lib</literal> directory relative to the web
          root. <literal>weld-servlet.jar</literal> is an "uber-jar", meaning it bundles all the bits of Weld and CDI
          required for running in a Servlet container, for your convenience. Alternatively, you can use its component
-         jars. A list of transitive dependencies can be found in the META-INF/DEPENDENCIES.txt file inside the
-         <literal>weld-servlet.jar</literal> artifact.
+         jars. A list of transitive dependencies can be found in the <literal>META-INF/DEPENDENCIES.txt</literal> file 
+         inside the <literal>weld-servlet.jar</literal> artifact.
       </para>
       
       <para>
@@ -401,14 +399,12 @@ public class HelloWorld
   </decorator>
 </beans>]]></programlisting>
 
-            <note>
-               <para>It is not necessary to use @ThreadScoped in all
-                  multithreaded applications. The thread context is not intended 
-                  as a replacement for defining your own application-specific contexts.
-                  It is generally only useful in situtations where you would otherwise
-                  have used ThreadLocal directly, which are typically rare.
-               </para>
-            </note>
+            <para>It is not necessary to use @ThreadScoped in all
+               multithreaded applications. The thread context is not intended 
+               as a replacement for defining your own application-specific contexts.
+               It is generally only useful in situtations where you would otherwise
+               have used ThreadLocal directly, which are typically rare.
+            </para>
 
         </section>
 

--- a/docs/reference/src/main/docbook/en-US/events.xml
+++ b/docs/reference/src/main/docbook/en-US/events.xml
@@ -75,7 +75,7 @@ public @interface Updated {}]]></programlisting>
       <programlisting role="JAVA"><![CDATA[public void afterDocumentUpdate(@Observes @Updated Document document) { ... }]]></programlisting>
 
       <para>
-         An observer method need not specify any event qualifiers&#8212;in this case it is interested in
+         An observer method need not specify any event qualifiers&mdash;in this case it is interested in
          <emphasis>only unqualified</emphasis> events of a particular type. If it does specify qualifiers, it's only interested
          in events which have those qualifiers.
       </para>

--- a/docs/reference/src/main/docbook/en-US/extend.xml
+++ b/docs/reference/src/main/docbook/en-US/extend.xml
@@ -234,14 +234,14 @@ MyBean(MyExtension myExtension) {
          interface makes this very easy. 
       </para>
       
-      <tip>
+      <note>
       <para>
          We recommend that frameworks let CDI take over the job of actually instantiating the framework-controlled 
          objects. That way, the framework-controlled objects can take advantage of constructor injection. However, 
          if the framework requires use of a constructor with a special signature, the framework will need to 
          instatiate the object itself, and so only method and field injection will be supported.
       </para>
-      </tip>
+      </note>
       
       <programlisting role="JAVA"><![CDATA[//get the BeanManager from JNDI
 BeanManager beanManager = (BeanManager) new InitialContext().lookup("java:comp/BeanManager");
@@ -548,10 +548,6 @@ ctx.release();  //clean up dependent objects
    } 
    
 }]]></programlisting>
-
-      <para>
-         
-      </para>
 
       <para>The <literal>AnnotatedType</literal> is not the only thing that can be wrapped by an extension.</para>
 

--- a/docs/reference/src/main/docbook/en-US/gettingstarted.xml
+++ b/docs/reference/src/main/docbook/en-US/gettingstarted.xml
@@ -152,7 +152,7 @@ $> run]]></programlisting>
          url="http://localhost:8080/weld-numberguess">http://localhost:8080/weld-numberguess</ulink>.
       </para>
 
-      <tip>
+      <note>
          <para>
             The Ant build script includes additional targets for JBoss AS to deploy and undeploy the archive in either 
             exploded or packaged format and to tidy things up.
@@ -184,7 +184,7 @@ $> run]]></programlisting>
                </para>
             </listitem>
          </itemizedlist>
-      </tip>
+      </note>
 
       <para>
          The second starter example, <literal>weld-translator</literal>, will translate your text into Latin. (Well,
@@ -339,7 +339,7 @@ $> ant package]]></programlisting>
          <programlisting><![CDATA[$> cd examples/jsf/numberguess
 $> ant tomcat.deploy]]></programlisting> 
          
-         <tip>
+         <note>
             <para>
                The Ant build script includes additional targets for Tomcat to deploy and undeploy the archive in either
                exploded or packaged format. They are the same target names used for JBoss AS, prefixed with "tomcat.".
@@ -366,7 +366,7 @@ $> ant tomcat.deploy]]></programlisting>
                   </para>
                </listitem>
             </itemizedlist>
-         </tip>
+         </note>
    
          <para>
             If you haven't already, start Tomcat. You can either start Tomcat from a Linux shell:

--- a/docs/reference/src/main/docbook/en-US/injection.xml
+++ b/docs/reference/src/main/docbook/en-US/injection.xml
@@ -4,7 +4,7 @@
    <title>Dependency injection and programmatic lookup</title>
 
    <para>
-      One of the most significant features of CDI&#8212;certainly the most recognized&#8212;is dependency injection;
+      One of the most significant features of CDI&mdash;certainly the most recognized&mdash;is dependency injection;
       excuse me, <emphasis>typesafe</emphasis> dependency injection.
    </para>
 
@@ -31,11 +31,9 @@
 
 }]]></programlisting>
 
-      <note>
-         <para>
-            A bean can only have one injectable constructor.
-         </para>
-      </note>
+      <para>
+         A bean can only have one injectable constructor.
+      </para>
 
       <para>
          <emphasis>Initializer method</emphasis> parameter injection:
@@ -108,11 +106,11 @@
       <para>(The only complication is that the container might call initializer methods declared by a superclass 
       before initializing injected fields declared by a subclass.)</para>
 
-      <tip>
+      <note>
          <para>
             One major advantage of constructor injection is that it allows the bean to be immutable.
          </para>
-      </tip>
+      </note>
       
       <para>
          CDI also supports parameter injection for some other methods that are invoked by the container. For instance, 
@@ -272,7 +270,6 @@ PaymentProcessor getPaymentProcessor(@Synchronous PaymentProcessor syncPaymentPr
       Therefore, by explicitly specifying <literal>@Any</literal> at an injection point, you suppress the default
       qualifier, without otherwise restricting the beans that are eligible for injection.</para>
       
-      <tip>
       <para>This is especially useful if you want to iterate over all beans with a certain bean type. For example:</para>
       <programlisting role="JAVA"><![CDATA[@Inject 
 void initServices(@Any Instance<Service> services) { 
@@ -280,7 +277,6 @@ void initServices(@Any Instance<Service> services) {
       service.init();
    }
 }]]></programlisting>
-      </tip>
       
    </section>
 
@@ -452,10 +448,8 @@ public class MockPaymentProcessor implements PaymentProcessor {
          bean type and a producer method that returns the same bean type.
       </para>
       
-      <tip>
-         <para>Just remember: "There can be only one."</para>
-      </tip>
-      
+      <para>Just remember: "There can be only one."</para>
+   
       <para>
          On the other hand, if you really do have an optional or multivalued injection point, you should change
          the type of your injection point to <literal>Instance</literal>, as we'll see in <xref linkend="lookup"/>.
@@ -478,7 +472,7 @@ public class MockPaymentProcessor implements PaymentProcessor {
       <para>
          Imagine that a bean bound to the application scope held a direct reference to a bean bound to the request
          scope. The application-scoped bean is shared between many different requests. However, each request should see
-         a different instance of the request scoped bean&#8212;the current one!
+         a different instance of the request scoped bean&mdash;the current one!
       </para>
   
       <para>
@@ -661,12 +655,10 @@ extends AnnotationLiteral<Asynchronous> implements Asynchronous {}]]></programli
       <programlisting role="JAVA"><![CDATA[PaymentProcessor p = paymentProcessorSource
    .select(new AnnotationLiteral<Asynchronous>() {});]]></programlisting>
    
-      <note>
-         <para>
-            We can't use an anonymous class to implement a qualifier type with members.
-         </para>
-      </note>
-      
+      <para>
+         However, we can't use an anonymous class to implement a qualifier type with members.
+      </para>
+               
       <para>
          Now, finally, we can pass the qualifier to the <literal>select()</literal> method of <literal>Instance</literal>.
       </para>

--- a/docs/reference/src/main/docbook/en-US/interceptors.xml
+++ b/docs/reference/src/main/docbook/en-US/interceptors.xml
@@ -290,7 +290,7 @@ public class ShoppingCart {
       <para>
          Well, fortunately, CDI works around this missing feature of Java. We may annotate one interceptor binding type
          with other interceptor binding types (termed a <emphasis>meta-annotation</emphasis>). The interceptor bindings
-         are transitive &#8212; any bean with the first interceptor binding inherits the interceptor bindings declared as
+         are transitive &mdash; any bean with the first interceptor binding inherits the interceptor bindings declared as
          meta-annotations.
       </para>
 
@@ -334,7 +334,7 @@ public class ShoppingCart {
          </listitem>
          <listitem>
             <para>
-               the interceptor ordering is non-global &#8212; it is determined by the order in which interceptors are
+               the interceptor ordering is non-global &mdash; it is determined by the order in which interceptors are
                listed at the class level.
             </para>
          </listitem>

--- a/docs/reference/src/main/docbook/en-US/intro.xml
+++ b/docs/reference/src/main/docbook/en-US/intro.xml
@@ -37,7 +37,7 @@
          With very few exceptions, almost every concrete Java class that has a constructor with no parameters (or a
          constructor designated with the annotation <literal>@Inject</literal>) is a bean. This includes every
          JavaBean and every EJB session bean. If you've already got some JavaBeans or session beans lying around,
-         they're already beans&#8212;you won't need any additional special metadata. There's just little one thing you 
+         they're already beans&mdash;you won't need any additional special metadata. There's just little one thing you 
          need to do before you can start injecting them into stuff: you need to put them in an archive (a jar, or a
          Java EE module such as a war or EJB jar) that contains a special marker file: <literal>META-INF/beans.xml</literal>.
       </para>
@@ -45,9 +45,9 @@
       <para>
          The JavaBeans and EJBs you've been writing every day, up until now, have not been able to take advantage 
          of the new services defined by the CDI specification. But you'll be able to use every one of them with 
-         CDI&#8212;allowing the container to create and destroy instances of your beans and associate them with a 
+         CDI&mdash;allowing the container to create and destroy instances of your beans and associate them with a 
          designated context, injecting them into other beans, using them in EL expressions, specializing them with 
-         qualifier annotations, even adding interceptors and decorators to them&#8212;without modifying your 
+         qualifier annotations, even adding interceptors and decorators to them&mdash;without modifying your 
          existing code. At most, you'll need to add some annotations.
       </para>
 
@@ -171,14 +171,12 @@ public class TranslateController {
          </calloutlist>
       </programlistingco>
 
-      <tip>
-         <para>
-            Notice the controller bean is request-scoped and named. Since this combination is so common in web
-            applications, there's a built-in annotation for it in CDI that we could have used as a shorthand. When the
-            (stereotype) annotation <literal>@Model</literal> is declared on a class, it creates a request-scoped and
-            named bean.
-         </para>
-      </tip>
+      <para>
+         Notice the controller bean is request-scoped and named. Since this combination is so common in web
+         applications, there's a built-in annotation for it in CDI that we could have used as a shorthand. When the
+         (stereotype) annotation <literal>@Model</literal> is declared on a class, it creates a request-scoped and
+         named bean.
+      </para>
 
       <para>
          Alternatively, we may obtain an instance of <literal>TextTranslator</literal> programmatically from an injected
@@ -199,8 +197,8 @@ public void translate() {
     
       <para>
          At system initialization time, the container must validate that exactly one bean exists which satisfies each
-         injection point. In our example, if no implementation of <literal>Translator</literal> is available&#8212;if 
-         the <literal>SentenceTranslator</literal> EJB was not deployed&#8212;the container would inform us of an
+         injection point. In our example, if no implementation of <literal>Translator</literal> is available&mdash;if 
+         the <literal>SentenceTranslator</literal> EJB was not deployed&mdash;the container would inform us of an
          <emphasis>unsatisfied dependency</emphasis>. If more than one implementation of <literal>Translator</literal> 
          were available, the container would inform us of the <emphasis>ambiguous dependency</emphasis>.
       </para>

--- a/docs/reference/src/main/docbook/en-US/part3.xml
+++ b/docs/reference/src/main/docbook/en-US/part3.xml
@@ -67,7 +67,7 @@
   
    <para>
       You don't see string-based identifiers in CDI code, not because the framework is hiding them from you using clever
-      defaulting rules&#8212;so-called "configuration by convention"&#8212;but because there are simply no strings
+      defaulting rules&mdash;so-called "configuration by convention"&mdash;but because there are simply no strings
       there to begin with!
    </para>
 

--- a/docs/reference/src/main/docbook/en-US/resources.xml
+++ b/docs/reference/src/main/docbook/en-US/resources.xml
@@ -83,11 +83,11 @@ PaymentService paymentService;]]></programlisting>
                </listitem>
             </itemizedlist>
             
-            <tip>
+            <note>
                <para>It might feel strange to be declaring resources in Java code. Isn't this stuff that might be
                deployment-specific? Certainly, and that's why it makes sense to declare your resources in a class
                annotated <literal>@Alternative</literal>.</para>
-            </tip>
+            </note>
 
          </section>
          

--- a/docs/reference/src/main/docbook/en-US/ri-spi.xml
+++ b/docs/reference/src/main/docbook/en-US/ri-spi.xml
@@ -8,7 +8,7 @@
       integration SPI. In this Appendix we will briefly discuss the steps needed. 
    </para>
    
-   <tip>
+   <note>
       <title>Enterprise Services</title>
       <para>
          If you just want to use managed beans, and not take advantage of enterprise services (EE resource injection,
@@ -16,7 +16,7 @@
          deployments, then the generic servlet support provided by the "Weld: Servlets" extension will be sufficient,
          and will work in any container supporting the Servlet API.
       </para>
-   </tip>
+   </note>
     
    <para>
       All SPIs and APIs described have extensive JavaDoc, which spell out the detailed contract between the container
@@ -65,7 +65,7 @@
          </para>
          
          <para>
-            The CDI specification discusses <emphasis>Bean Deployment Archives</emphasis> (BDAs)&#8212;archives which
+            The CDI specification discusses <emphasis>Bean Deployment Archives</emphasis> (BDAs)&mdash;archives which
             are marked as containing beans which should be deployed to the CDI container, and made available for
             injection and resolution. Weld reuses this description of <emphasis>Bean Deployment Archives</emphasis> in
             its deployment structure SPI. Each deployment exposes the BDAs which it contains; each BDA may also
@@ -105,7 +105,7 @@
 
          <para>
             <literal>BeanDeploymentArchive</literal> provides three methods which allow it's contents to be discovered
-            by Weld&#8212;<literal>BeanDeploymentArchive.getBeanClasses()</literal> must return all the classes in the
+            by Weld&mdash;<literal>BeanDeploymentArchive.getBeanClasses()</literal> must return all the classes in the
             BDA, <literal>BeanDeploymentArchive.getBeansXml()</literal> must return a data structure representing the 
             <code>beans.xml</code> deployment descriptor for the archive, and 
             <literal>BeanDeploymentArchive.getEjbs()</literal> must provide an EJB descriptor for every EJB in the BDA,
@@ -127,7 +127,7 @@
             describes all the beans resolvable by BDA X.
          </para>
          
-         <tip>
+         <note>
             <title>Matching the classloader structure for the deployment</title>
             
             <para>
@@ -136,19 +136,19 @@
                X can be loaded by another in BDA Y, it is accessible, and therefore BDA Y's accessible BDAs should
                include BDA X. 
             </para>
-         </tip>
+         </note>
          
          <para>
             To specify the directly accessible BDAs, the container should provide an implementation of
             <literal>BeanDeploymentArchive.getBeanDeploymentArchives()</literal>.
          </para>
          
-         <tip>
+         <note>
             <para>
                Weld allows the container to describe a circular graph, and will convert a graph to a tree as part of the
                deployment process.
             </para>
-         </tip>
+         </note>
          
          <para>
             Certain services are provided for the whole deployment, whilst some are provided per-BDA. BDA services are
@@ -213,12 +213,10 @@
             injection is provided by Weld, the resolved resource must be serializable.
          </para>
           
-         <tip>
-            <para>
-               If you use a non-EE environment then you may implement any of the EE service SPIs, and Weld will provide
-               the associated functionality. There is no need to implement those services you don't need!
-            </para>
-         </tip>
+         <para>
+            If you use a non-EE environment then you may implement any of the EE service SPIs, and Weld will provide
+            the associated functionality. There is no need to implement those services you don't need!
+         </para>
          
       </section>
          
@@ -232,7 +230,7 @@
          <para>
             <literal>EJBServices</literal> is used to resolve local EJBs used to back session beans, and must always be
             provided in an EE environment.  <literal>EJBServices.resolveEjb(EjbDescriptor ejbDescriptor)</literal>
-            returns a wrapper&#8212;<literal>SessionObjectReference</literal>&#8212;around the EJB reference. This
+            returns a wrapper&mdash;<literal>SessionObjectReference</literal>&mdash;around the EJB reference. This
             wrapper allows Weld to request a reference that implements the given business interface, and, in the case of
             SFSBs, both request the removal of the EJB from the container and query whether the EJB has been previously
             removed.
@@ -349,12 +347,12 @@
             integrator is optional.
          </para>
          
-         <tip>
+         <note>
             <para>
                Most Servlet contains use a classloader-per-war, this may provide
                a good way to identify the BDA in use for web requests.
             </para>
-         </tip>
+         </note>
          
          <para>
             When Weld needs to identify the BDA, it will use one of these services, depending on what is servicing the
@@ -528,13 +526,11 @@
                   registered with JSF for this web application. 
                </para>
                
-               <tip>
-                  <para>
-                     There are a number of ways you can obtain the bean manager for the module. You could call
-                     <literal>Bootstrap.getManager()</literal>, passing in the BDA for this module. Alternatively, you
-                     could use the injection into Java EE component classes, or look up the bean manager in JNDI. 
-                  </para>
-               </tip>
+               <para>
+                  There are a number of ways you can obtain the bean manager for the module. You could call
+                  <literal>Bootstrap.getManager()</literal>, passing in the BDA for this module. Alternatively, you
+                  could use the injection into Java EE component classes, or look up the bean manager in JNDI. 
+               </para>
                
                <para>
                   If you are integrating Weld into a JSF environment you must register
@@ -574,13 +570,11 @@
                   registered with JSP for this web application. 
                </para>
                
-               <tip>
-                  <para>
-                     There are a number of ways you can obtain the bean manager for the module. You could call
-                     <literal>Bootstrap.getManager()</literal>, passing in the BDA for this module. Alternatively, you
-                     could use the injection into Java EE component classes, or look up the bean manager in JNDI. 
-                  </para>
-               </tip>
+               <para>
+                  There are a number of ways you can obtain the bean manager for the module. You could call
+                  <literal>Bootstrap.getManager()</literal>, passing in the BDA for this module. Alternatively, you
+                  could use the injection into Java EE component classes, or look up the bean manager in JNDI. 
+               </para>
                
             </listitem>
          </varlistentry>

--- a/docs/reference/src/main/docbook/en-US/scopescontexts.xml
+++ b/docs/reference/src/main/docbook/en-US/scopescontexts.xml
@@ -31,7 +31,7 @@
       session, and automatically destroyed when the session ends.
    </para>
 
-      <tip>
+      <note>
          <para>
             JPA entities aren't a great fit for this model. Entities have their whole own lifecycle and identity model
             which just doesn't map naturally to the model used in CDI. Therefore, we recommend against treating entities
@@ -39,7 +39,7 @@
             the default scope <literal>@Dependent</literal>. The client proxy will get in the way if you try to pass
             an injected instance to the JPA <literal>EntityManager</literal>.
          </para>
-      </tip>
+      </note>
 
    <section>
       <title>Scope types</title>
@@ -105,9 +105,7 @@ public class SecondLevelCache { ... }]]></programlisting>
         </listitem>
       </itemizedlist>
 
-      <note>
-         <para>A CDI extension can implement support for the conversation scope in other web frameworks.</para>
-      </note>
+      <para>A CDI extension can implement support for the conversation scope in other web frameworks.</para>
 
       <para>The request and application scopes are also active:</para>
 
@@ -171,7 +169,7 @@ public class SecondLevelCache { ... }]]></programlisting>
       </itemizedlist>
   
       <para>
-         A conversation represents a task&#8212;a unit of work from the point of view of the user. The conversation context
+         A conversation represents a task&mdash;a unit of work from the point of view of the user. The conversation context
          holds state associated with what the user is currently working on. If the user is doing multiple things at the
          same time, there are multiple conversations.
       </para>
@@ -267,13 +265,11 @@ public class OrderBuilder {
    <f:param name="cid" value="#{javax.enterprise.context.conversation.id}"/>
 </h:link>]]></programlisting>
          
-         <tip>
          <para>
             The conversation context propagates across redirects, making it very easy to implement the common 
             POST-then-redirect pattern, without resort to fragile constructs such as a "flash" object. The container 
             automatically adds the conversation id to the redirect URL as a request parameter.
          </para>
-         </tip>
 
       </section>
   
@@ -283,7 +279,7 @@ public class OrderBuilder {
          <para>
             The container is permitted to destroy a conversation and all state held in its context at any time in order
             to conserve resources. A CDI implementation will normally do this on the basis of some kind of 
-            timeout&#8212;though this is not required by the specification. The timeout is the period of inactivity before
+            timeout&mdash;though this is not required by the specification. The timeout is the period of inactivity before
             the conversation is destroyed (as opposed to the amount of time the conversation is active).
          </para>
     
@@ -306,12 +302,10 @@ public class OrderBuilder {
          is the <emphasis>singleton pseudo-scope</emphasis>, which we specify using the annotation <literal>@Singleton</literal>.
       </para>
       
-      <note>
-         <para>
-            Unlike the other scopes, which belong to the package <literal>javax.enterprise.context</literal>, the 
-            <literal>@Singleton</literal> annotation is defined in the package <literal>javax.inject</literal>.
-         </para>
-      </note>
+      <para>
+         Unlike the other scopes, which belong to the package <literal>javax.enterprise.context</literal>, the 
+         <literal>@Singleton</literal> annotation is defined in the package <literal>javax.inject</literal>.
+      </para>
       
       <para>
          You can guess what "singleton" means here. It means a bean that is instantiated once. Unfortunately, there's 
@@ -380,7 +374,7 @@ public class OrderBuilder {
           every time the expression is evaluated. The instance is not reused during any other expression evaluation.
       </para>
       
-      <tip>
+      <note>
          <para>
             If you need to access a bean directly by EL name in a JSF page, you probably need to give it a scope other
             than <literal>@Dependent</literal>. Otherwise, any value that gets set to the bean by a JSF input will be 
@@ -389,7 +383,7 @@ public class OrderBuilder {
             that really <emphasis>has</emphasis> to have the scope <literal>@Dependent</literal> from a JSF page,
             inject it into a different bean, and expose it to EL via a getter method.
          </para>
-      </tip>
+      </note>
       
       <para>
          Beans with scope <literal>@Dependent</literal> don't need a proxy object. The client holds a direct reference

--- a/docs/reference/src/main/docbook/en-US/weldexamples.xml
+++ b/docs/reference/src/main/docbook/en-US/weldexamples.xml
@@ -374,13 +374,13 @@ public class Game implements Serializable {
             for running Weld in any servlet container (including Jetty), <literal>weld-servlet.jar</literal>.
          </para>
          
-         <tip>
+         <note>
             <para>
                You must also include the jars for JSF, EL, and the common annotations
                (<literal>jsr250-api.jar</literal>), all of which are provided by the Java EE platform (a Java EE
                application server). Are you starting to appreciate why a Java EE platform is worth using?
             </para>
-         </tip>
+         </note>
          
          <para>
             Second, we need to explicitly specify the servlet listener in <literal>web.xml</literal>, again because the
@@ -420,23 +420,21 @@ public class Game implements Serializable {
          <para>
             To use the Weld SE numberguess example in Eclipse, you can
             open the example natively using the
-            <ulink url="http://m2eclipse.sonatype.org/">m2eclipse plugin</ulink>
-            .
+            <ulink url="http://m2eclipse.sonatype.org/">m2eclipse plugin</ulink>.
          </para>
 
          <para>
             If you have m2eclipse installed, you can open any Maven
             project directly. From within Eclipse, select
-            <emphasis>File -> Import... -> Maven Projects</emphasis>
-            . Then, browse to the location of the Weld SE
+            <emphasis>File -> Import... -> Maven Projects</emphasis>. 
+            Then, browse to the location of the Weld SE
             numberguess example. You should see that Eclipse recognizes the existence of a
             Maven project.
          </para>
 
          <para>
             This will create a project in your workspace called
-            <literal>weld-se-numberguess</literal>
-            .
+            <literal>weld-se-numberguess</literal>.
          </para>
 
          <para>
@@ -449,7 +447,7 @@ public class Game implements Serializable {
 
          <para>
             It's time to get the example running!
-            </para>
+         </para>
 
       </section>
 
@@ -963,12 +961,10 @@ public class Game
          the numberguess example.
       </para>
       
-      <note>
-         <para>
-            Java EE 6, which bundles EJB 3.1, allows you to package EJBs in a war, which will make this structure much
-            simpler! Still, there are other advantages of using an ear.
-         </para>
-      </note>
+      <para>
+         Java EE 6, which bundles EJB 3.1, allows you to package EJBs in a war, which will make this structure much
+         simpler! Still, there are other advantages of using an ear.
+      </para>
       
       <para>
          First, let's take a look at the ear aggregator, which is located in the example's <literal>ear</literal> directory. Maven
@@ -994,7 +990,7 @@ public class Game
          url="http://localhost:8080/weld-translator">http://localhost:8080/weld-translator</ulink>.
       </para>
       
-      <tip>
+      <note>
          <para>
             If you weren't using Maven to generate these files, you would need
             <literal>META-INF/application.xml</literal>:
@@ -1020,7 +1016,7 @@ public class Game
     <ejb>weld-translator.jar</ejb>
   </module>
 </application>]]></programlisting>
-      </tip>
+      </note>
       
       <para>
          Next, lets look at the war, which is located in the example's <literal>war</literal> directory. Just as in the


### PR DESCRIPTION
Making the book adhere to the content services style guide so that minimal changes are necessary when the project docs are pulled in.
- changed all &#8212; entities to &mdash;
- changed all tip tags to note
- removed superfluous note tags
- removed superfluous blockquote from itemizedlist
- reformatted several lines longer than 120chars in tables
- added literal tags to filenames that were missing them
