### PR TITLE
WELD-807

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -57,6 +57,7 @@ import org.jboss.weld.Container;
 import org.jboss.weld.exceptions.DefinitionException;
 import org.jboss.weld.exceptions.WeldException;
 import org.jboss.weld.serialization.spi.ContextualStore;
+import org.jboss.weld.serialization.spi.ProxyServices;
 import org.jboss.weld.util.Proxies.TypeInfo;
 import org.jboss.weld.util.bytecode.Boxing;
 import org.jboss.weld.util.bytecode.BytecodeUtils;
@@ -975,14 +976,14 @@ public class ProxyFactory<T>
       Class<?> superClass = typeInfo.getSuperClass();
       if (superClass.getName().startsWith("java"))
       {
-         ClassLoader cl = bean.getBeanClass().getClassLoader();
+         ClassLoader cl = Container.instance().services().get(ProxyServices.class).getClassLoader(bean.getBeanClass());
          if (cl == null)
          {
             cl = Thread.currentThread().getContextClassLoader();
          }
          return cl;
       }
-      return superClass.getClassLoader();
+      return Container.instance().services().get(ProxyServices.class).getClassLoader(superClass);
    }
 
    public static ClassLoader resolveClassLoaderForBeanProxy(Bean<?> bean)

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/util/SimpleProxyServices.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/util/SimpleProxyServices.java
@@ -39,33 +39,7 @@ public class SimpleProxyServices implements ProxyServices
 
    public ClassLoader getClassLoader(final Class<?> proxiedBeanType)
    {
-      SecurityManager sm = System.getSecurityManager();
-      if (sm != null)
-      {
-         return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>()
-         {
-            public ClassLoader run()
-            {
-               return _getClassLoader(proxiedBeanType);
-            }
-         });
-      }
-      else
-      {
-         return _getClassLoader(proxiedBeanType);
-      }      
-   }
-
-   private ClassLoader _getClassLoader(Class<?> proxiedBeanType)
-   {
-      if (proxiedBeanType.getName().startsWith("java"))
-      {
-         return this.getClass().getClassLoader();
-      }
-      else
-      {
-         return proxiedBeanType.getClassLoader();
-      }
+      return proxiedBeanType.getClassLoader();
    }
 
    public void cleanup()
@@ -74,6 +48,7 @@ public class SimpleProxyServices implements ProxyServices
 
    }
 
+   @Deprecated
    public Class<?> loadBeanClass(final String className)
    {
       try


### PR DESCRIPTION
Fix for Glassfish - tried by Siva and works. We're using a modified version of ProxyServices to allow Glassfish to provide their own classloader strategy. SimpleProxyServices is modified to delegate to class.getClassLoader(), thus not changing the behaviour in the default case.
