### PR TITLE
WELD-880 Do not abort deployment if class loading causes a LinkageError

### DIFF
--- a/impl/src/main/java/org/jboss/weld/resources/ClassTransformer.java
+++ b/impl/src/main/java/org/jboss/weld/resources/ClassTransformer.java
@@ -184,7 +184,7 @@ public class ClassTransformer implements Service
       }
       catch (ComputationException e)
       {
-         if (e.getCause() instanceof NoClassDefFoundError || e.getCause() instanceof TypeNotPresentException || e.getCause() instanceof ResourceLoadingException)
+         if (e.getCause() instanceof NoClassDefFoundError || e.getCause() instanceof TypeNotPresentException || e.getCause() instanceof ResourceLoadingException || e.getCause() instanceof LinkageError)
          {
             throw new ResourceLoadingException("Error loading class " + clazz.getName(), e.getCause());
          }


### PR DESCRIPTION
AS7 sometimes throws LinageError rather than NoClassDefFoundError when loading fails 
