### PR TITLE
WELD-851

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -253,7 +253,7 @@
                <plugin>
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>findbugs-maven-plugin</artifactId>
-                  <version>2.3.1</version>
+                  <version>2.3.2</version>
                   <dependencies>
                      <dependency>
                         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Bump findbugs-maven-plugin version so that it works again with Maven 3.
