### PR TITLE
WELD-934 Weld servlet should not crash when booting in GWT dev hosted mode

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/gwtdev/GwtDevHostedModeContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/gwtdev/GwtDevHostedModeContainer.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.weld.environment.gwtdev;
+
+import org.jboss.weld.environment.Container;
+import org.jboss.weld.environment.jetty.Jetty6Container;
+
+/**
+ *
+ */
+public class GwtDevHostedModeContainer extends Jetty6Container
+{
+   public static Container INSTANCE = new GwtDevHostedModeContainer();
+
+   // The gwt-dev jar is never in the project classpath (only in the maven/eclipse/intellij plugin classpath)
+   // except when GWT is being run in hosted mode.
+   private static final String GWT_DEV_HOSTED_MODE_REQUIRED_CLASS_NAME = "com.google.gwt.dev.HostedMode";
+
+   protected String classToCheck()
+   {
+      return GWT_DEV_HOSTED_MODE_REQUIRED_CLASS_NAME;
+   }
+
+}

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/Listener.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/Listener.java
@@ -22,6 +22,7 @@ import org.jboss.weld.bootstrap.api.Bootstrap;
 import org.jboss.weld.bootstrap.api.Environments;
 import org.jboss.weld.environment.Container;
 import org.jboss.weld.environment.ContainerContext;
+import org.jboss.weld.environment.gwtdev.GwtDevHostedModeContainer;
 import org.jboss.weld.environment.jetty.Jetty6Container;
 import org.jboss.weld.environment.jetty.Jetty7Container;
 import org.jboss.weld.environment.jetty.JettyPost72Container;
@@ -225,6 +226,8 @@ public class Listener extends ForwardingServletListener
       Container container = checkContainers(cc, dump, extContainers);
       if (container == null)
          container = checkContainers(cc, dump, Arrays.asList(
+               // Needs to be first: gwt-dev jar has tomcat classes but uses jetty
+               GwtDevHostedModeContainer.INSTANCE,
                Tomcat7Container.INSTANCE,
                Tomcat6Container.INSTANCE,
                Jetty6Container.INSTANCE,


### PR DESCRIPTION
When running in GWT dev hosted mode, there are some tomcat classes on the classpath, which confuse weld into using the wrong container.
In fact, GWT dev hosted modes is in fact a separate container (a customized variant of the Jetty 6 container).

This pull request fixes that.
