### PR TITLE
Bug in manual: Just like web-env.xml, jetty-web.xml needs to be in WEB-INF, not META-INF

### DIFF
--- a/docs/reference/src/main/docbook/en-US/environments.xml
+++ b/docs/reference/src/main/docbook/en-US/environments.xml
@@ -175,7 +175,7 @@
 
          <para>
             Weld also supports Servlet injection in Jetty 6. To enable this, add the file
-            <literal>META-INF/jetty-web.xml</literal> with the following content to your war:
+            <literal>WEB-INF/jetty-web.xml</literal> with the following content to your war:
          </para>
 
          <programlisting role="XML"><![CDATA[<!DOCTYPE Configure PUBLIC "-//Mort Bay Consulting//DTD Configure//EN"


### PR DESCRIPTION
Only this commit matters:
  https://github.com/ge0ffrey/weld-core/commit/d7c66d25e357c571b399d01927910a8eb39c84e9

```
          <para>
             Weld also supports Servlet injection in Jetty 6. To enable this, add the file
-            <literal>META-INF/jetty-web.xml</literal> with the following content to your war:
+            <literal>WEB-INF/jetty-web.xml</literal> with the following content to your war:
         </para>
```

Not sure why the other commits are being added too. One of them is already merged before and the other 2 are just fallout of "git merge upstream/master". Is there a way to avoid that?
