### PR TITLE
jboss.home commented out - when explicitly specified, it is not possible 

### DIFF
--- a/jboss-as/build.properties
+++ b/jboss-as/build.properties
@@ -1,5 +1,5 @@
 # Container a number of properties associated with installing Weld into JBoss AS and running the TCK in JBoss AS
-jboss.home=/Users/alesj/projects/as7/as/build/target/jboss-as-7.1.0.Alpha1-SNAPSHOT
+#jboss.home=/Users/alesj/projects/as7/as/build/target/jboss-as-7.1.0.Alpha1-SNAPSHOT
 org.jboss.testharness.container.javaOpts=-Xms128m -Xmx512m -XX:MaxPermSize=256m -Dorg.jboss.resolver.warning=true -Dsun.rmi.dgc.client.gcInterval=3600000 -Dsun.rmi.dgc.server.gcInterval=3600000
 
 # time to allow before attempting to restart JBoss AS


### PR DESCRIPTION
jboss.home commented out - when explicitly specified, it is not possible to override the value via environment variable
