### PR TITLE
WELD-974 failing testcase proves @Alternative @Specializes does not work

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/NamedFoo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/NamedFoo.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.specialization;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Named;
+
+@ApplicationScoped
+@Named("namedFoo")
+public class NamedFoo
+{
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/SpecializationTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/SpecializationTest.java
@@ -50,4 +50,10 @@ public class SpecializationTest
       Assert.assertEquals(User2.class, beanManager.resolve(beanManager.getBeans(User.class)).getBeanClass());
    }
 
+   @Test
+   public void testSpecializationWithAlternative()
+   {
+      Assert.assertEquals(NamedFoo.class, beanManager.resolve(beanManager.getBeans(NamedFoo.class)).getBeanClass());
+   }
+
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/SpecializesNamedFoo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/SpecializesNamedFoo.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.specialization;
+
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Specializes;
+
+@Alternative @Specializes
+public class SpecializesNamedFoo extends NamedFoo
+{
+
+}


### PR DESCRIPTION
WELD-974 failing testcase to prove that @Alternative @Specializes doesn't work

https://issues.jboss.org/browse/WELD-974
