### PR TITLE
Test for WELD-912: Specializing beans in different bean archives.

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/AS7SpecializationTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/AS7SpecializationTest.java
@@ -1,0 +1,39 @@
+package org.jboss.weld.tests.specialization;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+@RunWith(Arquillian.class)
+public class AS7SpecializationTest {
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addAsLibrary(ShrinkWrap.create(BeanArchive.class, "test.jar")
+                        .addClass(User.class))
+                .addClass(User2.class);
+    }
+
+    @Inject
+    private BeanManager beanManager;
+
+    /**
+     * WELD-321, WELD-912
+     */
+    @Test
+    public void testSpecialization() {
+        Assert.assertEquals(User2.class, beanManager.resolve(beanManager.getBeans(User.class)).getBeanClass());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/SpecializationTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/SpecializationTest.java
@@ -33,7 +33,8 @@ public class SpecializationTest {
     @Deployment
     public static Archive<?> deploy() {
         return ShrinkWrap.create(BeanArchive.class)
-                .addPackage(SpecializationTest.class.getPackage());
+                .addClass(User.class)
+                .addClass(User2.class);
     }
 
     @Inject


### PR DESCRIPTION
This is a test for WELD-912, as suggested in Nicklas' first comment.

AS7SpecializationTest (the new test) fails with incontainer-remote maven profile (while SpecializationTest passes). Both tests pass with the default profile. I haven't tested with other profiles.
