### PR TITLE
WELD-947, WELD-929: Docs reference & typos fixes

### DIFF
--- a/docs/reference/src/main/docbook/en-US/contexts.xml
+++ b/docs/reference/src/main/docbook/en-US/contexts.xml
@@ -7,11 +7,11 @@
       <title>Managing the built in contexts</title>
 
       <para>
-         Weld allows you to easiy manage the built in contexts by injecting them and calling
+         Weld allows you to easily manage the built in contexts by injecting them and calling
          lifecycle methods. Weld defines two types of context, <emphasis>managed</emphasis>
          and <emphasis>unmanaged</emphasis>. Managed contexts can be activated (allowing bean
          instances to be retrieved from the context), invalidated (scheduling bean instances
-         for destruction) and deactivaed (stopping bean instances from being retrieved, and if
+         for destruction) and deactivated (stopping bean instances from being retrieved, and if
          the context has been invalidated, causing the bean instances to destroyed). Unmanaged
          contexts are always active; some may offer the ability to destroy instances.
       </para>
@@ -22,13 +22,13 @@
          in the context in one thread are not visible in other threads), and is destroyed upon
          invalidation and deactivation. Bound contexts are attached to some external data store
          (such as the Http Session or a manually propagated map) by <emphasis>associating</emphasis>
-         the data store with the context before calling activate, and discociating the data store
+         the data store with the context before calling activate, and dissociating the data store
          after calling activate.
       </para>
       
       <tip>
          <para>
-            Weld automatically controls context lifecycle in many scenarios such as Http Requests,
+            Weld automatically controls context lifecycle in many scenarios such as HTTP requests,
             EJB remote invocations, and MDB invocations. Many of the extensions for CDI offer context
             lifecycle for other environments, it's worth checking to see if there is a suitable extension
             before deciding to manage the context yourself.
@@ -163,7 +163,7 @@
          Unmanaged contexts offer little of interest in a discussion about managing context lifecycles, so from here on in
          we will concentrate on the managed contexts (unmanaged contexts of course play a vital role in the functioning of
          your application and Weld!). As you can see from the table above, the managed contexts offer a number of different
-         implmentations for the same scope; in general, each flavor of context for a scope has the same API. We'll walk through
+         implementations for the same scope; in general, each flavor of context for a scope has the same API. We'll walk through
          a number of common lifecycle management scenarios below; armed with this knowledge, and the Javadoc, you should be able
          to work with any of the context implementations Weld offers.
       </para>
@@ -261,7 +261,7 @@
    
    <para>
       The conversation context also offers a number of properties which control the behavior of conversation expiration
-      (after this period of inactivity the conversation will be ended and destroyed by the containber), and the duration 
+      (after this period of inactivity the conversation will be ended and destroyed by the container), and the duration
       of lock timeouts (the conversation context ensures that a single thread is accessing any bean instances by locking
       access, if a lock can't be obtained after a certain time Weld will error rather than continue to wait for the lock).
       Additionally, you can alter the name of the parameter used to transfer the conversation id (by default, <code>cid</code>).
@@ -269,7 +269,7 @@
    
    <para>
       Weld also introduces the notion of a <code>ManagedConversation</code>, which extends the <code>Conversation</code>
-      interface with the abilty to lock, unlock and touch (update the last used timestamp) a conversation. Finally, all
+      interface with the ability to lock, unlock and touch (update the last used timestamp) a conversation. Finally, all
       non-transient conversations in a session can be obtained from the conversation context, as can the current conversation.
    </para>
    

--- a/docs/reference/src/main/docbook/en-US/environments.xml
+++ b/docs/reference/src/main/docbook/en-US/environments.xml
@@ -318,7 +318,7 @@ public class HelloWorld
 
             <section>
 
-               <title>Programatic Bootstrap API</title>
+               <title>Programmatic Bootstrap API</title>
 
                <para>For added flexibility, CDI SE also comes with a bootstrap API 
                which can be called from within your application in order to initialize
@@ -405,7 +405,7 @@ public class HelloWorld
                <para>It is not necessary to use @ThreadScoped in all
                   multithreaded applications. The thread context is not intended 
                   as a replacement for defining your own application-specific contexts.
-                  It is generally only useful in situtations where you would otherwise
+                  It is generally only useful in situations where you would otherwise
                   have used ThreadLocal directly, which are typically rare.
                </para>
             </note>

--- a/docs/reference/src/main/docbook/en-US/extend.xml
+++ b/docs/reference/src/main/docbook/en-US/extend.xml
@@ -239,7 +239,7 @@ MyBean(MyExtension myExtension) {
          We recommend that frameworks let CDI take over the job of actually instantiating the framework-controlled 
          objects. That way, the framework-controlled objects can take advantage of constructor injection. However, 
          if the framework requires use of a constructor with a special signature, the framework will need to 
-         instatiate the object itself, and so only method and field injection will be supported.
+         insntatiate the object itself, and so only method and field injection will be supported.
       </para>
       </note>
       
@@ -282,7 +282,7 @@ ctx.release();  //clean up dependent objects
       </para>
       
       <para>
-         The <literal>Bean</literal> interface exposes all the interesting things we dicussed in
+         The <literal>Bean</literal> interface exposes all the interesting things we discussed in
          <xref linkend="bean-anatomy"/>.
       </para>
       

--- a/docs/reference/src/main/docbook/en-US/gettingstarted.xml
+++ b/docs/reference/src/main/docbook/en-US/gettingstarted.xml
@@ -10,7 +10,7 @@
       only non-transactional managed beans. This example can be run on a wide range of servers, including JBoss 
       AS, GlassFish, Apache Tomcat, Jetty, Google App Engine, and any compliant Java EE 6 container. 
       Translator is an enterprise (ear) example that contains session beans. This example
-      must be run on JBoss AS 6.0, Glassfish 3.0 or any compliant Java EE 6 container.
+      must be run on JBoss AS 6.0, GlassFish 3.0 or any compliant Java EE 6 container.
    </para>
    
    <para>
@@ -520,7 +520,7 @@ $> mvn war:inplace jetty:run -Pjetty]]></programlisting>
 
       <para>
          You have two options if you want to run the example on Jetty from the IDE. You can either install the
-         m2eclispe[link] plugin and run the goals as described above. Your other option is to start the Jetty container
+         m2eclipse[link] plugin and run the goals as described above. Your other option is to start the Jetty container
          from a Java application.
       </para>
 

--- a/docs/reference/src/main/docbook/en-US/injection.xml
+++ b/docs/reference/src/main/docbook/en-US/injection.xml
@@ -256,7 +256,7 @@ PaymentProcessor getPaymentProcessor(@Synchronous PaymentProcessor syncPaymentPr
          Now, you may be thinking, <emphasis>"What's the different between using a qualifier and just specifying the
          exact implementation class you want?"</emphasis> It's important to understand that a qualifier is like an
          extension of the interface. It does not create a direct dependency to any particular implementation. There 
-         may be multiple alterative implementations of <literal>@Asynchronous PaymentProcessor</literal>!
+         may be multiple alternative implementations of <literal>@Asynchronous PaymentProcessor</literal>!
       </para>
 
    </section>
@@ -265,7 +265,7 @@ PaymentProcessor getPaymentProcessor(@Synchronous PaymentProcessor syncPaymentPr
       <title>The built-in qualifiers <literal>@Default</literal> and <literal>@Any</literal></title>
       
       <para>Whenever a bean or injection point does not explicitly declare a qualifier, the container assumes the
-      qualifier <literal>@Default</literal>. From time to time, you'll need to decare an injection point without
+      qualifier <literal>@Default</literal>. From time to time, you'll need to declare an injection point without
       specifying a qualifier. There's a qualifier for that too. All beans have the qualifier <literal>@Any</literal>.
       Therefore, by explicitly specifying <literal>@Any</literal> at an injection point, you suppress the default
       qualifier, without otherwise restricting the beans that are eligible for injection.</para>
@@ -297,7 +297,7 @@ public @interface PayBy {
 }]]></programlisting> 
    
          <para>
-            Then we select one of the possible member values when appling the qualifier:
+            Then we select one of the possible member values when applying the qualifier:
          </para>
 
          <programlisting role="JAVA"><![CDATA[private @Inject @PayBy(CHECK) PaymentProcessor checkPayment;]]></programlisting> 
@@ -444,7 +444,7 @@ public class MockPaymentProcessor implements PaymentProcessor {
       <para>
          See <ulink
          url="http://sfwk.org/Documentation/HowDoAResolveAnAmbiguousResolutionExceptionBetweenAProducerMethodAndARawType">this
-         FAQ</ulink> for step-by-step instructions for how to resolve an ambigous resolution exception between a raw
+         FAQ</ulink> for step-by-step instructions for how to resolve an ambiguous resolution exception between a raw
          bean type and a producer method that returns the same bean type.
       </para>
       
@@ -639,7 +639,7 @@ public class MockPaymentProcessor implements PaymentProcessor {
       <programlisting role="JAVA"><![CDATA[@Inject @Any Instance<PaymentProcessor> paymentProcessorSource;]]></programlisting>
       
       <para>
-         Next, we need to obtain an instance of our qualifier type. Since annotatons are interfaces, we can't just write
+         Next, we need to obtain an instance of our qualifier type. Since annotations are interfaces, we can't just write
          <literal>new Asynchronous()</literal>. It's also quite tedious to create a concrete implementation of an annotation 
          type from scratch. Instead, CDI lets us obtain a qualifier instance by subclassing the helper class 
          <literal>AnnotationLiteral</literal>. 
@@ -743,7 +743,7 @@ public @interface HttpParam {
 }]]></programlisting>
 
   <para>Note that acquiring of the request in this example is JSF-centric. For a more generic solution
-  you could write your own prodcuer for the request and have it injected as a method parameter.</para>
+  you could write your own producer for the request and have it injected as a method parameter.</para>
 
   <para>Note also that the <literal>value()</literal> member of the <literal>HttpParam</literal>
   annotation is ignored by the container since it is annotated <literal>@Nonbinding.</literal></para>

--- a/docs/reference/src/main/docbook/en-US/part5.xml
+++ b/docs/reference/src/main/docbook/en-US/part5.xml
@@ -3,7 +3,7 @@
 <partintro>
 
    <para>
-      Weld is the reference implementation of JSR-299, and is used by JBoss AS and Glassfish to provide CDI services for
+      Weld is the reference implementation of JSR-299, and is used by JBoss AS and GlassFish to provide CDI services for
       Java Enterprise Edition (Java EE) applications. Weld also goes beyond the environments and APIs defined by the
       JSR-299 specification by providing support for a number of other environments (such as a servlet container such as
       Tomcat, or Java SE).

--- a/docs/reference/src/main/docbook/en-US/resources.xml
+++ b/docs/reference/src/main/docbook/en-US/resources.xml
@@ -14,7 +14,7 @@
             Naturally, there is now a slight mismatch with the new style of dependency injection in CDI. Most notably,
             component environment injection relies on string-based names to qualify ambiguous types, and there is no 
             real consistency as to the nature of the names (sometimes a JNDI name, sometimes a persistence unit name, 
-            sometimes an EJB link, sometimes a nonportable "mapped name"). Producer fields turned out to be an elegant 
+            sometimes an EJB link, sometimes a non-portable "mapped name"). Producer fields turned out to be an elegant
             adaptor to reduce all this complexity to a common model and get component environment resources to 
             participate in the CDI system just like any other kind of bean.
          </para>

--- a/docs/reference/src/main/docbook/en-US/ri-spi.xml
+++ b/docs/reference/src/main/docbook/en-US/ri-spi.xml
@@ -306,7 +306,7 @@
          
          <para>
             <literal>InjectionServices</literal> provides a very simple contract, the
-            <literal>InjectionServices.aroundInject(InjectionContext ic);</literal> intercepter will be called for every
+            <literal>InjectionServices.aroundInject(InjectionContext ic);</literal> interceptor will be called for every
             instance that CDI injects, whether it is a contextual instance, or a non-contextual instance injected by
             <literal>InjectionTarget.inject()</literal>.
          </para>
@@ -407,7 +407,7 @@
          <para>
             The bootstrap is split into phases, container initialization, bean deployment, bean validation and shutdown.
             Initialization will create a manager, and add the built-in contexts, and examine the deployment structure.
-            Bean deployment will deploy any beans (defined using annotations, programtically, or built in). Bean
+            Bean deployment will deploy any beans (defined using annotations, programmatically, or built in). Bean
             validation will validate all beans.
          </para>
          
@@ -473,7 +473,7 @@
             <listitem>
                <para>
                   If you are integrating Weld into an environment that supports deployment of multiple applications, you
-                  must enable, automatically, or through user configuation, classloader isolation for each CDI
+                  must enable, automatically, or through user configuration, classloader isolation for each CDI
                   application.
                </para>
             </listitem>
@@ -489,7 +489,7 @@
                   automatically, or through user configuration, for each CDI application which uses Servlet.
                </para>
                <para>
-                  You must ensure that that <literal>WeldListener.contextInitialized()</literal> is called
+                  You must ensure that <literal>WeldListener.contextInitialized()</literal> is called
                   after beans are deployed is complete (<literal>Bootstrap.deployBeans()</literal> has been called). 
                </para>
             </listitem>

--- a/docs/reference/src/main/docbook/en-US/scopescontexts.xml
+++ b/docs/reference/src/main/docbook/en-US/scopescontexts.xml
@@ -436,7 +436,8 @@ public class Calculator { ... }]]></programlisting>
          </para>
 
          <para>
-            This feature is particularly useful with producer methods, as we'll see in the next chapter.
+            This feature is particularly useful with producer methods, as we'll see in
+            <xref linkend="producermethods"/>.
          </para>
 
       </section>

--- a/docs/reference/src/main/docbook/en-US/weldexamples.xml
+++ b/docs/reference/src/main/docbook/en-US/weldexamples.xml
@@ -1028,7 +1028,7 @@ public class Game
       
       <para>
          More interesting is the JSF view used to translate text. Just as in the numberguess example we have a template,
-         which surrounds the form (ommitted here for brevity):
+         which surrounds the form (omitted here for brevity):
       </para>
       
       <programlisting role="XML"><![CDATA[<h:form id="translator">


### PR DESCRIPTION
Fixed the docs as per the following issues:

https://issues.jboss.org/browse/WELD-947
https://issues.jboss.org/browse/WELD-929
