### PR TITLE
JDK 1.5 compatibility

### DIFF
--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -83,6 +83,13 @@
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+            <version>1.3.9</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/examples/jsf/pastecode/pom.xml
+++ b/examples/jsf/pastecode/pom.xml
@@ -113,8 +113,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.5</source>
+                    <target>1.5</target>
                     <compilerArgument>-proc:none</compilerArgument>
                 </configuration>
                 <executions>

--- a/impl/src/main/java/org/jboss/weld/util/collections/ArraySetMultimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/ArraySetMultimap.java
@@ -55,7 +55,7 @@ public class ArraySetMultimap<K, V> extends AbstractMap<K, List<V>> {
         List<V> result = super.get(key);
         if (result == null) {
             result = new ArrayList<V>();
-            SimpleEntry<K, List<V>> entry = new SimpleEntry<K, List<V>>(key, result);
+            Map.Entry<K, List<V>> entry = new MapEntry<K, List<V>>(key, result);
             entrySet.add(entry);
         }
         result.add(value);
@@ -71,5 +71,51 @@ public class ArraySetMultimap<K, V> extends AbstractMap<K, List<V>> {
     @Override
     public Set<java.util.Map.Entry<K, List<V>>> entrySet() {
         return entrySet;
+    }
+
+    static class MapEntry<K, V> implements Map.Entry<K, V> {
+        private K key;
+        private V value;
+
+        MapEntry(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        public K getKey() {
+            return key;
+        }
+
+        public V getValue() {
+            return value;
+        }
+
+        public V setValue(V value) {
+            V previous = this.value;
+            this.value = value;
+            return previous;
+        }
+
+        @Override
+        public int hashCode() {
+            return (key == null ? 0 : key.hashCode()) ^ (value == null ? 0 : value.hashCode());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof Map.Entry == false) {
+                return false;
+            }
+
+            Map.Entry e = (Map.Entry) o;
+
+            return (key == null ? e.getKey() == null : key.equals(e.getKey()))
+                    && (value == null ? e.getValue() == null : value.equals(e.getValue()));
+        }
+
+        @Override
+        public String toString() {
+            return key + "=" + value;
+        }
     }
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -133,6 +133,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>findbugs</artifactId>
+            <version>1.3.9</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
Building with JDK 1.5 has problems on modules that include dependencies on artifacts built with JDK 6 (class version 50).

Some JDK 1.5 compatible modules:

bom
build-config
impl
environment/se/build
environment/se/core
examples/se/hello-world
examples/se/numberguess

This should suffice for SE support.
