### PR TITLE
Arquillian test for VerifyError raised when loading generated proxy

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/InterceptedBeanWithFinalEqualsTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/InterceptedBeanWithFinalEqualsTest.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.interceptors.finalEquals;
+
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static junit.framework.Assert.assertEquals;
+
+
+/**
+ * @author Sebastian Graca, ISPiK S.A.
+ */
+@RunWith(Arquillian.class)
+public class InterceptedBeanWithFinalEqualsTest {
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class).intercept(QuotingInterceptor.class).addPackage(InterceptedBeanWithFinalEqualsTest.class.getPackage());
+    }
+
+    @Test
+    public void interceptionWorksOnClassWithFinalEquals(Quoter quoter) {
+        assertEquals("\"unquoted\"", quoter.returnUnquoted("unquoted"));
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/Quoted.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/Quoted.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.interceptors.finalEquals;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+
+/**
+ * @author Sebastian Graca, ISPiK S.A.
+ */
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+public @interface Quoted {
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/Quoter.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/Quoter.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.interceptors.finalEquals;
+
+
+/**
+ * @author Sebastian Graca, ISPiK S.A.
+ */
+public class Quoter {
+    @Quoted
+    public String returnUnquoted(String value) {
+        return value;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/QuotingInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/finalEquals/QuotingInterceptor.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.interceptors.finalEquals;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+
+/**
+ * @author Sebastian Graca, ISPiK S.A.
+ */
+@Quoted
+@Interceptor
+public class QuotingInterceptor {
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        return "\"" + context.proceed() + "\"";
+    }
+}


### PR DESCRIPTION
a test demonstrating that VerifyError is raised when binding and interceptor to a method in a class with final equals method
