### PR TITLE
Implementation and test of WELD-731

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/BeanManagerResourceBindingListener.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/BeanManagerResourceBindingListener.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat Middleware LLC, and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.servlet;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NameClassPair;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Emulates the behavior of the naming resource binding that is typically done
+ * using configuration files in Tomcat and Jetty. This listener provides the ability
+ * to bind the BeanManager to JNDI without the need for configuration.
+ *
+ * @author Dan Allen
+ * @author Christian Sadilek <csadilek@redhat.com>
+ */
+public class BeanManagerResourceBindingListener implements ServletContextListener {
+    private static final Logger log = LoggerFactory.getLogger(BeanManagerResourceBindingListener.class);
+
+    private static final String RESOURCES_CONTEXT = "java:comp/env";
+    private static final String BEAN_MANAGER_JNDI_NAME = "BeanManager";
+    private static final String QUALIFIED_BEAN_MANAGER_JNDI_NAME = RESOURCES_CONTEXT + "/" + BEAN_MANAGER_JNDI_NAME;
+    private static final String BEAN_MANAGER_OBJECT_FACTORY = "org.jboss.weld.resources.ManagerObjectFactory";
+
+    private boolean bound = false;
+
+    public void contextInitialized(ServletContextEvent sce) {
+        try {
+            InitialContext ctx = new InitialContext();
+            boolean present = false;
+            try {
+                NamingEnumeration<NameClassPair> entries = ctx.list(RESOURCES_CONTEXT);
+                while (entries.hasMoreElements()) {
+                    try {
+                        NameClassPair e = entries.next();
+                        if (e.getName().equals(BEAN_MANAGER_JNDI_NAME) && e.getClassName().equals(BeanManager.class)) {
+                            present = true;
+                            break;
+                        }
+                    } catch (Exception e) {
+                        log.info("Problem when interating through " + RESOURCES_CONTEXT, e);
+                    }
+                }
+            } catch (NamingException e) {
+                log.info("Could not read context " + RESOURCES_CONTEXT + ": Trying to create it!");
+                try {
+                    Context compCtx = (Context) ctx.lookup("java:comp");
+                    compCtx.createSubcontext("env");
+                } catch (Exception ex) {
+                    log.error("Could not create context:" + RESOURCES_CONTEXT);
+                }
+            }
+
+            if (!present) {
+                try {
+                    // we rebind just in case it really is there and we just couldn't read it
+                    ctx.rebind(QUALIFIED_BEAN_MANAGER_JNDI_NAME,
+                            new Reference(BeanManager.class.getName(), BEAN_MANAGER_OBJECT_FACTORY, null));
+                    bound = true;
+                    log.info("BeanManager reference bound to " + QUALIFIED_BEAN_MANAGER_JNDI_NAME);
+                } catch (NamingException e) {
+                    throw new RuntimeException("Could not bind BeanManager reference to JNDI: " + e.getExplanation()
+                            + " \n"
+                            + "If the naming context is read-only, you may need to use a configuration to"
+                            + "bind the BeanManager instead, such as Tomcat's context.xml or Jetty's jetty-web.xml.");
+                }
+            }
+        } catch (NamingException e) {
+            throw new RuntimeException("Could not create InitialContext to bind BeanManager reference in JNDI: "
+                    + e.getExplanation());
+        }
+    }
+
+    public void contextDestroyed(ServletContextEvent sce) {
+        if (bound) {
+            try {
+                InitialContext ctx = new InitialContext();
+                ctx.unbind(QUALIFIED_BEAN_MANAGER_JNDI_NAME);
+                log.info("Successfully unbound BeanManager reference.");
+            } catch (NamingException e) {
+                log.warn("Failed to unbind BeanManager reference!");
+            }
+        }
+    }
+}

--- a/environments/servlet/tests/jetty7/src/test/java/org/jboss/weld/environment/servlet/test/config/ConfigWithoutJettyEnvTest.java
+++ b/environments/servlet/tests/jetty7/src/test/java/org/jboss/weld/environment/servlet/test/config/ConfigWithoutJettyEnvTest.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.weld.environment.servlet.test.config;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.weld.environment.servlet.test.util.BeansXml;
+import org.jboss.weld.environment.servlet.test.util.Deployments;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="mailto:csadilek@redhat.com">Christian Sadilek</a>
+ */
+@RunWith(Arquillian.class)
+public class ConfigWithoutJettyEnvTest extends ConfigTestBase {
+
+    public static final String DEFAULT_WEB_XML_START = "<web-app>";
+    public static final String DEFAULT_WEB_XML_BODY = 
+        Deployments.toListener("org.jboss.weld.environment.servlet.Listener") + 
+        Deployments.toListener("org.jboss.weld.environment.servlet.BeanManagerResourceBindingListener");
+    
+    public static final String DEFAULT_WEB_XML_PREFIX = DEFAULT_WEB_XML_START + DEFAULT_WEB_XML_BODY;
+    public static final String DEFAULT_WEB_XML_SUFFIX = "</web-app>";
+
+    public static final Asset WEB_XML = 
+        new ByteArrayAsset((DEFAULT_WEB_XML_PREFIX + DEFAULT_WEB_XML_SUFFIX).getBytes());
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        return ShrinkWrap.create(WebArchive.class)
+            .addAsWebInfResource(new BeansXml(), "beans.xml")
+            .setWebXML(WEB_XML)
+            .addClass(GoodBean.class);
+    }
+}


### PR DESCRIPTION
As discussed with Ales today, this is a servlet listener that will bind the BeanManager to JNDI. 

This is useful for:
- containers that don't support defining naming resources in a context xml file
- to avoid having to use context.xml or jetty-env.xml all together (simpler deployment)
