### PR TITLE
fix pom versions in jboss-as/ modules so we update the actual weld versions

### DIFF
--- a/jboss-as/jboss-as-6/pom.xml
+++ b/jboss-as/jboss-as-6/pom.xml
@@ -4,12 +4,12 @@
     <groupId>org.jboss.weld</groupId>
     <artifactId>weld-core-jboss-as6-updater</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/jboss-as/jboss-as-7/pom.xml
+++ b/jboss-as/jboss-as-7/pom.xml
@@ -4,12 +4,12 @@
     <groupId>org.jboss.weld</groupId>
     <artifactId>weld-core-jboss-as7-updater</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.6-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
 
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-core-parent</artifactId>
-        <version>1.1.6-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Would be nice if updating this would be part of the release process somehow (cannot be done by automatically by the maven release plugin due to cyclic dep, AFAIK)
