### PR TITLE
Don't execute checkstyle on every incremental build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -556,7 +556,7 @@
                                         </goals>
                                     </pluginExecutionFilter>
                                     <action>
-                                        <execute />
+                                        <ignore />
                                     </action>
                                 </pluginExecution>
                             </pluginExecutions>


### PR DESCRIPTION
as it causes build loops with m2e and JBoss Tools (see https://issues.jboss.org/browse/JBIDE-11485).

Running mvn checkstyle:checkstyle on every file save is just nuts :-)

In Eclipse, checkstyle should either be run manually or via the checkstyle integration plugin (see https://bugs.eclipse.org/bugs/show_bug.cgi?id=347556). 
