### PR TITLE
WELD-510 Support for Portlet 2.0

### DIFF
--- a/environments/servlet/core/pom.xml
+++ b/environments/servlet/core/pom.xml
@@ -35,6 +35,13 @@
         </dependency>
 
         <dependency>
+            <groupId>javax.portlet</groupId>
+            <artifactId>portlet-api</artifactId>
+            <version>2.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>catalina</artifactId>
             <version>6.0.18</version>


### PR DESCRIPTION
Weld-servlet fix so it works within JSF+PortletBridge environment, where ServletContext is not accessible directly but only delegated to via PortletContext.

Portlet API runtime dependency is limited to a situation where JSF ExternalContext returns a non-ServletContext instance.
