### PR TITLE
WELD-1129: @Veto classes that conflict in an uber-jar

### DIFF
--- a/impl/src/main/java/org/jboss/weld/injection/package-info.java
+++ b/impl/src/main/java/org/jboss/weld/injection/package-info.java
@@ -1,0 +1,2 @@
+@javax.enterprise.inject.Veto
+package org.jboss.weld.injection;

--- a/impl/src/main/java/org/jboss/weld/literal/package-info.java
+++ b/impl/src/main/java/org/jboss/weld/literal/package-info.java
@@ -1,0 +1,2 @@
+@javax.enterprise.inject.Veto
+package org.jboss.weld.literal;

--- a/impl/src/main/java/org/jboss/weld/manager/package-info.java
+++ b/impl/src/main/java/org/jboss/weld/manager/package-info.java
@@ -1,0 +1,2 @@
+@javax.enterprise.inject.Veto
+package org.jboss.weld.manager;

--- a/impl/src/main/java/org/jboss/weld/package-info.java
+++ b/impl/src/main/java/org/jboss/weld/package-info.java
@@ -1,0 +1,6 @@
+/** FIXME this package (and it's children) can be removed as soon as WELD-1129 is fixed.
+ * 
+ *  This project builds an Uber-Jar containing Weld, which was not designed to contain an beans.xml itself.
+ */
+@javax.enterprise.inject.Veto
+package org.jboss.weld;

--- a/impl/src/main/java/org/jboss/weld/servlet/package-info.java
+++ b/impl/src/main/java/org/jboss/weld/servlet/package-info.java
@@ -1,0 +1,2 @@
+@javax.enterprise.inject.Veto
+package org.jboss.weld.servlet;


### PR DESCRIPTION
I'm doing this the first time, so maybe I forgot something or do too much.

Here's a possible patch for https://issues.jboss.org/browse/WELD-1129
