### PR TITLE
Revert HTMLUnit to 2.4 globally, override to 2.8 in examples

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -101,6 +101,8 @@
         <facelets.version>1.1.15</facelets.version>
         <tomcat.version>6.0.26</tomcat.version>
         <jetty.version>6.1.21</jetty.version>
+        <!-- Override HTMLUnit version -->
+        <htmlunit.version>2.8</htmlunit.version>
 
         <!-- UEL Impl -->
         <uel.version>2.2</uel.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <findbugs-maven-plugin.version>2.3.2</findbugs-maven-plugin.version>
         <glassfish.el.version>2.1.2-b04</glassfish.el.version>
         <google.guava.version>11.0.2</google.guava.version>
-        <htmlunit.version>2.8</htmlunit.version>
+        <htmlunit.version>2.4</htmlunit.version>
         <jacoco.version>0.5.8.201207111220</jacoco.version>
         <javax.activation.version>1.1</javax.activation.version>
         <javax.jms.version>1.1</javax.jms.version>


### PR DESCRIPTION
Same as in 2.0: https://github.com/weld/core/commit/42b97b2c0753257199a5944ae0e0907fc4d2669c
