### PR TITLE
AnnotatedTypeObserversTest

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/AnnotatedTypeObserversTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/AnnotatedTypeObserversTest.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.annotatedType.observers;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class AnnotatedTypeObserversTest
+{
+   @Deployment
+   public static Archive<?> deploy()
+   {
+      return ShrinkWrap.create(BeanArchive.class).addPackage(RoomsExtension.class.getPackage())
+            .addAsServiceProvider(Extension.class, RoomsExtension.class);
+   }
+
+   @Inject
+   private BeanManager beanManager;
+
+   @Inject
+   @RoomId("hall")
+   Room hall;
+
+   @Inject
+   @RoomId("pit")
+   Room pit;
+
+   @Test
+   public void testRoomObservers()
+   {
+      beanManager.fireEvent(new CleanEvent());
+
+      Assert.assertTrue(hall.isClean());
+      Assert.assertTrue(pit.isClean());
+   }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/CleanEvent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/CleanEvent.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.annotatedType.observers;
+
+public class CleanEvent
+{
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/Room.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/Room.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.annotatedType.observers;
+
+import javax.enterprise.event.Observes;
+
+public class Room
+{
+   private boolean clean = false;
+
+   public void clean(@Observes CleanEvent event)
+   {
+      setClean(true);
+   }
+
+   public boolean isClean()
+   {
+      return clean;
+   }
+
+   public void setClean(boolean entered)
+   {
+      this.clean = entered;
+   }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/RoomId.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/RoomId.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.annotatedType.observers;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Target(
+{TYPE, METHOD, PARAMETER, FIELD})
+@Retention(RUNTIME)
+@Documented
+public @interface RoomId {
+   String value();
+
+   public static class RoomIdLiteral extends AnnotationLiteral<RoomId> implements RoomId
+   {
+      @Override
+      public int hashCode()
+      {
+         final int prime = 31;
+         int result = super.hashCode();
+         result = prime * result + ((value == null) ? 0 : value.hashCode());
+         return result;
+      }
+
+      @Override
+      public boolean equals(Object obj)
+      {
+         if (this == obj)
+            return true;
+         if (!super.equals(obj))
+            return false;
+         if (getClass() != obj.getClass())
+            return false;
+         RoomIdLiteral other = (RoomIdLiteral) obj;
+         if (value == null)
+         {
+            if (other.value != null)
+               return false;
+         }
+         else if (!value.equals(other.value))
+            return false;
+         return true;
+      }
+
+      private static final long serialVersionUID = 3237202887991048175L;
+
+      private String value;
+
+      public RoomIdLiteral(String value)
+      {
+         this.value = value;
+      }
+
+      @Override
+      public String value()
+      {
+         return value;
+      }
+   }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/RoomsExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/annotatedType/observers/RoomsExtension.java
@@ -1,0 +1,133 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.annotatedType.observers;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedConstructor;
+import javax.enterprise.inject.spi.AnnotatedField;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+import javax.enterprise.util.AnnotationLiteral;
+
+public class RoomsExtension implements Extension
+{
+   private static class ApplicationScopedLiteral extends AnnotationLiteral<ApplicationScoped> implements ApplicationScoped {} 
+
+   private void removeRoomBean(@Observes ProcessAnnotatedType<Room> pat) {
+      if(!pat.getAnnotatedType().isAnnotationPresent(RoomId.class)) {
+         pat.veto();
+      }
+   }
+   
+   private void addRoomAnnotatedTypes(@Observes BeforeBeanDiscovery bbd, BeanManager bm) {
+      
+      AnnotatedType<Room> wrapped = bm.createAnnotatedType(Room.class);
+      
+      bbd.addAnnotatedType(new RoomAnnotatedTypeWrapper(wrapped, "hall"));
+      bbd.addAnnotatedType(new RoomAnnotatedTypeWrapper(wrapped, "pit"));
+   }
+   
+   private static class RoomAnnotatedTypeWrapper implements AnnotatedType<Room> {
+
+      private AnnotatedType<Room> wrapped;
+      private String id;
+      
+      private RoomAnnotatedTypeWrapper(AnnotatedType<Room> wrapped, String id) {
+         this.wrapped = wrapped;
+         this.id = id;
+      }
+      
+      @Override
+      public Type getBaseType()
+      {
+         return wrapped.getBaseType();
+      }
+
+      @Override
+      public Set<Type> getTypeClosure()
+      {
+         return wrapped.getTypeClosure();
+      }
+
+      @Override
+      public <T extends Annotation> T getAnnotation(Class<T> annotationType)
+      {
+         if (ApplicationScoped.class.isAssignableFrom(annotationType)) {
+            return (T) new ApplicationScopedLiteral();
+         }
+         if (RoomId.class.isAssignableFrom(annotationType)) {
+            return (T) new RoomId.RoomIdLiteral(id);
+         }
+         return wrapped.getAnnotation(annotationType);
+      }
+
+      @Override
+      public Set<Annotation> getAnnotations()
+      {
+         Set<Annotation> ret = new HashSet<Annotation> ();
+         
+         ret.add(getAnnotation(ApplicationScoped.class));
+         ret.add(getAnnotation(RoomId.class));
+         
+         return ret;
+      }
+
+      @Override
+      public boolean isAnnotationPresent(Class<? extends Annotation> annotationType)
+      {
+         if (ApplicationScoped.class.isAssignableFrom(annotationType) || RoomId.class.isAssignableFrom(annotationType)) {
+            return true; 
+         }
+         
+         return wrapped.isAnnotationPresent(annotationType);
+      }
+
+      @Override
+      public Class<Room> getJavaClass()
+      {
+         return wrapped.getJavaClass();
+      }
+
+      @Override
+      public Set<AnnotatedConstructor<Room>> getConstructors()
+      {
+         return wrapped.getConstructors();
+      }
+
+      @Override
+      public Set<AnnotatedMethod<? super Room>> getMethods()
+      {
+         return wrapped.getMethods();
+      }
+
+      @Override
+      public Set<AnnotatedField<? super Room>> getFields()
+      {
+         return wrapped.getFields();
+      }
+   }
+}


### PR DESCRIPTION
Adding a test for creating two beans with wrapping an AnnotatedType on a shared class and testing an observer declared in the shared class is observed by both beans.

This test currently fails in 2.0
