### PR TITLE
Remove tck10 dependency from dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -435,12 +435,6 @@
 
             <dependency>
                 <groupId>org.jboss.weld</groupId>
-                <artifactId>weld-porting-package-tck10</artifactId>
-                <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-porting-package-tck11</artifactId>
                 <version>${project.version}</version>
             </dependency>


### PR DESCRIPTION
This changeset here will remove the TCK10 dependency from the core pom.xml. It fixes the maven site reporting "Dependency Report" because there is no weld-porting-package-tck10 2.0.3.Final etc.
