### PR TITLE
Configuration now logged to target/cdi-tck-configuration.log

### DIFF
--- a/jboss-tck-runner/1.1/src/test/tck12/tck-tests.xml
+++ b/jboss-tck-runner/1.1/src/test/tck12/tck-tests.xml
@@ -3,6 +3,7 @@
 <suite name="Weld / JBoss AS run of CDI TCK" verbose="0" configfailurepolicy="continue">
 
     <listeners>
+	<listener class-name="org.jboss.cdi.tck.impl.testng.ConfigurationLoggingListener"/>  
         <listener class-name="org.jboss.cdi.tck.impl.testng.SingleTestClassMethodInterceptor"/>
         <listener class-name="org.jboss.cdi.tck.impl.testng.ProgressLoggingTestListener"/>
         <!-- The default JUnit XML reporter is disabled -->


### PR DESCRIPTION
Needed to add the listener.
