### PR TITLE
WELD-1490 - Infinite loop in SyntheticClassBean.toString()

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/SyntheticClassBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/SyntheticClassBean.java
@@ -64,6 +64,7 @@ public class SyntheticClassBean<T> extends AbstractSyntheticBean<T> {
 
     @Override
     public String toString() {
-        return "SyntheticClassBean [attributes=" + attributes() + ", injectionTarget=" + producer + ", beanClass=" + getBeanClass() + "]";
+        return "SyntheticClassBean [attributes=" + attributes() + ", injectionTarget=" + producer.getClass() + ", beanClass="
+                + getBeanClass() + "]";
     }
 }


### PR DESCRIPTION
Added info of at least what implementation of InjectionTarget is used.
In my opinion including information about 'InjectionTarget producer' in the SyntheticClassBean.toString() is redundant as the producer is created directly for this instance. (And that's kind of all useful information we can get from the InjectionTarget.)

Discussion welcomed
