### PR TITLE
Fixing bug WELD-1448 also on branch 1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <arquillian.glassfish.version>1.0.0.CR1</arquillian.glassfish.version>
         <arquillian.jboss6.version>1.0.0.CR2</arquillian.jboss6.version>
         <atinject.tck.version>1.0.0-PFD-3</atinject.tck.version>
-        <cal10n.version>0.7.4</cal10n.version>
+        <cal10n.version>0.7.7</cal10n.version>
         <cargo.maven2.plugin.version>1.0</cargo.maven2.plugin.version>
         <cdi.api.version>1.0-SP4</cdi.api.version>
         <cdi.tck.version>1.0.5.Final</cdi.tck.version>
@@ -531,7 +531,7 @@
                     </executions>
                 </plugin>
 
-                <!-- So m2e doesn't throw errors for features it doesn't support in the 
+                <!-- So m2e doesn't throw errors for features it doesn't support in the
                     POM -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>


### PR DESCRIPTION
I was experiencing the WELD-1448 bug with the weld-osgi-bundle.jar Version 1.1.16.Final on glassfish 3.1.2.2 after i have replaced the original weld of version 1.1.8. After examining the fix for branch 1.2 and 2.0 I have fixed this at 1.1 branch as well. Please consider this for the next 1.1.17 release.

Cheers, Sven
