### PR TITLE
WELD-1527 Log warning when PAT observer uses unbounded wildcard type without @WithAnnotations

### DIFF
--- a/impl/src/main/java/org/jboss/weld/event/ExtensionObserverMethodImpl.java
+++ b/impl/src/main/java/org/jboss/weld/event/ExtensionObserverMethodImpl.java
@@ -79,7 +79,7 @@ public class ExtensionObserverMethodImpl<T, X> extends ObserverMethodImpl<T, X> 
         }
         if (isProcessAnnotatedType && requiredTypeAnnotations.isEmpty()) {
             Type[] typeArguments = eventParameter.getActualTypeArguments();
-            if (typeArguments.length == 0 || Reflections.isUnboundedWildcard(typeArguments[0])) {
+            if (typeArguments.length == 0 || Reflections.isUnboundedWildcard(typeArguments[0]) || Reflections.isUnboundedTypeVariable(typeArguments[0])) {
                 EventLogger.LOG.unrestrictedProcessAnnotatedTypes(this);
             }
         }

--- a/impl/src/main/java/org/jboss/weld/logging/EventLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/EventLogger.java
@@ -77,7 +77,7 @@ public interface EventLogger extends WeldLogger {
     DefinitionException invalidWithAnnotations(Object param1);
 
     @LogMessage(level=Level.WARN)
-    @Message(id = 411, value = "Observer method {0} receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type parameter that is not an unbounded wildcard.", format = Format.MESSAGE_FORMAT)
+    @Message(id = 411, value = "Observer method {0} receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.", format = Format.MESSAGE_FORMAT)
     void unrestrictedProcessAnnotatedTypes(Object param1);
 
 }

--- a/impl/src/main/java/org/jboss/weld/util/reflection/Reflections.java
+++ b/impl/src/main/java/org/jboss/weld/util/reflection/Reflections.java
@@ -369,6 +369,14 @@ public class Reflections {
         return false;
     }
 
+    public static boolean isUnboundedTypeVariable(Type type) {
+        if (type instanceof TypeVariable<?>) {
+            TypeVariable<?> typeVariable = (TypeVariable<?>) type;
+            return isEmptyBoundArray(typeVariable.getBounds());
+        }
+        return false;
+    }
+
     private static boolean isEmptyBoundArray(Type[] bounds) {
         return bounds == null || bounds.length == 0 || (bounds.length == 1 && Object.class.equals(bounds[0]));
     }


### PR DESCRIPTION
Logic added to `ExtensionObserverMethodImpl.checkRequiredTypeAnnotations` to log warning
