### PR TITLE
Fix AroundConstructTest - incorrect use of static members

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/aroundConstruct/basic/AbstractInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/aroundConstruct/basic/AbstractInterceptor.java
@@ -25,21 +25,12 @@ import java.lang.reflect.Constructor;
 import javax.interceptor.InvocationContext;
 
 import org.jboss.weld.interceptor.proxy.InterceptorInvocationContext;
+import org.jboss.weld.test.util.ActionSequence;
 
 public abstract class AbstractInterceptor {
 
-    private static boolean invoked;
-
-    public static boolean isInvoked() {
-        return invoked;
-    }
-
-    public static void reset() {
-        invoked = false;
-    }
-
-    public static void invoked() {
-        invoked = true;
+    protected void invoked() {
+        ActionSequence.addAction(getClass().getSimpleName());
     }
 
     protected void checkConstructor(InvocationContext ctx, Class<?> expectedDeclaringClass) {


### PR DESCRIPTION
org.jboss.weld.tests.interceptors.aroundConstruct.basic.AroundConstructTest#testExceptions method did not make much sense
