### PR TITLE
WELD-1529 remove the servlet api 3 dependency from permalink example

### DIFF
--- a/examples/jsf/permalink/pom.xml
+++ b/examples/jsf/permalink/pom.xml
@@ -55,13 +55,6 @@
         </dependency>
 
         <dependency>
-            <!-- needed for reference by maven-eclipse-plugin -->
-            <groupId>org.jboss.spec.javax.servlet</groupId>
-            <artifactId>jboss-servlet-api_3.0_spec</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>javax.transaction</groupId>
             <artifactId>jta</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
couldn't find any reason why it shouldn't just be removed. 
