### PR TITLE
WELD-1561 Update Jetty integration

### DIFF
--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -31,7 +31,7 @@
         <tomcat.version>6.0.36</tomcat.version>
         <tomcat7.version>7.0.47</tomcat7.version>
         <jetty6.version>6.1.26</jetty6.version>
-        <jetty.version>8.1.11.v20130520</jetty.version>
+        <jetty.version>8.1.14.v20131031</jetty.version>
         <uel.glassfish.version>2.2</uel.glassfish.version>
         <!-- Testing deps -->
         <apache.httpclient.version>3.1</apache.httpclient.version>

--- a/environments/servlet/tests/jetty/src/test/java/org/jboss/weld/environment/servlet/test/util/JettyDeployments.java
+++ b/environments/servlet/tests/jetty/src/test/java/org/jboss/weld/environment/servlet/test/util/JettyDeployments.java
@@ -24,5 +24,5 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
  * @author Ales Justin
  */
 public class JettyDeployments {
-    public static final Asset JETTY_ENV = new StringAsset("<Configure id=\"webAppCtx\" class=\"org.eclipse.jetty.webapp.WebAppContext\"><New class=\"org.eclipse.jetty.plus.jndi.EnvEntry\"><Arg><Ref id=\"webAppCtx\"/></Arg><Arg>BeanManager</Arg><Arg><New class=\"javax.naming.Reference\"><Arg>javax.enterprise.inject.spi.BeanManager</Arg><Arg>org.jboss.weld.resources.ManagerObjectFactory</Arg><Arg/></New></Arg><Arg type=\"boolean\">true</Arg></New></Configure>");
+    public static final Asset JETTY_ENV = new StringAsset("<Configure id=\"webAppCtx\" class=\"org.eclipse.jetty.webapp.WebAppContext\"><Set class=\"org.eclipse.jetty.util.resource.Resource\" name=\"defaultUseCaches\">false</Set><New class=\"org.eclipse.jetty.plus.jndi.EnvEntry\"><Arg><Ref id=\"webAppCtx\"/></Arg><Arg>BeanManager</Arg><Arg><New class=\"javax.naming.Reference\"><Arg>javax.enterprise.inject.spi.BeanManager</Arg><Arg>org.jboss.weld.resources.ManagerObjectFactory</Arg><Arg/></New></Arg><Arg type=\"boolean\">true</Arg></New></Configure>");
 }


### PR DESCRIPTION
- modify WeldDecorator to support Jetty 9.1 API
- instruct Jetty to disable JVM built-in URL caching in the test suite
- upgrade the default Jetty version to 8.1.14.v20131031
