### PR TITLE
Fix deployment name in ArchiveIsolationOverrideTestBase-dependent tests

### DIFF
--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/decorators/BeanDiscoveryDecorator02Test.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/decorators/BeanDiscoveryDecorator02Test.java
@@ -30,7 +30,7 @@ public class BeanDiscoveryDecorator02Test extends ArchiveIsolationOverrideTestBa
         return true;
     }
     
-    @Deployment(managed = false, name = "main")
+    @Deployment(managed = false)
     public static Archive<?> getDeployment() {
         WeldSEClassPath archives = ShrinkWrap.create(WeldSEClassPath.class);
         JavaArchive archive01 = ShrinkWrap

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/interceptors/BeanDiscoveryInterceptor02Test.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/interceptors/BeanDiscoveryInterceptor02Test.java
@@ -30,7 +30,7 @@ public class BeanDiscoveryInterceptor02Test extends ArchiveIsolationOverrideTest
         return true;
     }
     
-    @Deployment(managed = false, name = "main")
+    @Deployment(managed = false)
     public static Archive<?> getDeployment() {
         WeldSEClassPath archives = ShrinkWrap.create(WeldSEClassPath.class);
         JavaArchive archive01 = ShrinkWrap.create(BeanArchive.class)


### PR DESCRIPTION
The tests shouldn't even work before this commit, as the deployments have different name than what the deployer expects.
