### PR TITLE
Fix MessageSenderTest (SLSB JAX-RS Resource decoration)

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageDecorator.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageDecorator.java
@@ -6,7 +6,6 @@ import javax.decorator.Decorator;
 import javax.decorator.Delegate;
 import javax.inject.Inject;
 
-
 @Decorator
 public abstract class MessageDecorator implements MessageSender, Serializable {
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageSender.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageSender.java
@@ -1,10 +1,5 @@
 package org.jboss.weld.tests.decorators.weld1110;
 
-import javax.ejb.Local;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-
 public interface MessageSender {
 
     String send(String message);

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageSenderImpl.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageSenderImpl.java
@@ -1,11 +1,11 @@
 package org.jboss.weld.tests.decorators.weld1110;
 
-import javax.ejb.Stateful;
+import javax.ejb.Stateless;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
-@Stateful
+@Stateless
 @Path("message/{message}")
 public class MessageSenderImpl implements MessageSender {
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageSenderTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/MessageSenderTest.java
@@ -45,17 +45,17 @@ public class MessageSenderTest {
 
     @Test
     public void testImpl() throws Exception {
-        String response = getWebServiceResponse("rest/message/Hello");
+        String response = getHttpGETResponse("rest/message/Hello");
         Assert.assertEquals("Decorated Hello", response);
     }
 
     @Test
     public void testFacade() throws Exception {
-        String response = getWebServiceResponse("rest/facade/Hello");
+        String response = getHttpGETResponse("rest/facade/Hello");
         Assert.assertEquals("Decorated Hello", response);
     }
 
-    private String getWebServiceResponse(String urlPath) throws IOException {
+    private String getHttpGETResponse(String urlPath) throws IOException {
         URL url = new URL(base, urlPath);
         BufferedReader in = new BufferedReader(new InputStreamReader(url.openStream()));
         try {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/RestFacade.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/weld1110/RestFacade.java
@@ -5,9 +5,6 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 
-/**
- *
- */
 @Path("facade/{message}")
 public class RestFacade {
 


### PR DESCRIPTION
- Per 10.2.4 of JAX-RS 2.0 spec, only Stateless and Singleton EJBs are supported as root resources, not Stateful
