### PR TITLE
WELD-1638 EE7-related doc and example updates

### DIFF
--- a/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.xml
+++ b/docs/reference/src/main/docbook/en-US/Weld_-_JSR-299_Reference_Implementation.xml
@@ -8,6 +8,12 @@
    <preface>
       <title>A note about naming and nomenclature</title>
       <para>
+         Throughout this document, mentions of JSR-299 and JSR-346 appear. JSR is a document of a proposed specification
+         used in the Java Community Process (JCP). JSRs are somewhat analogous to RFCs used by IETF. JSR-299 and JSR-346 
+         are the JCP specification names for the 1.0 and 1.1 versions of CDI, respectively.
+      </para>
+      
+      <para>
          Shortly before the final draft of JSR-299 was submitted, the specification changed its name from "Web Beans" to
          "Java Contexts and Dependency Injection for the Java EE platform", abbreviated CDI. For a brief period after
          the renaming, the reference implementation adopted the name "Web Beans". However, this ended up causing more

--- a/docs/reference/src/main/docbook/en-US/beans.xml
+++ b/docs/reference/src/main/docbook/en-US/beans.xml
@@ -374,7 +374,7 @@ class MockPaymentProcessor extends PaymentProcessorImpl { ... }]]></programlisti
          <title>Interceptor binding types</title>
 
          <para>
-            You might be familiar with the use of interceptors in EJB 3.0. In Java EE 6, this functionality has
+            You might be familiar with the use of interceptors in EJB 3. Since Java EE 6, this functionality has
             been generalized to work with other managed beans. That's right, you no longer have to make your bean 
             an EJB just to intercept its methods. Holler. So what does CDI have to offer above and beyond that? Well, 
             quite a lot actually. Let's cover some background.
@@ -587,7 +587,7 @@ class ShoppingCart implements Serializable { ... }]]></programlisting>
        
          <para>
             Many beans (including any <literal>@SessionScoped</literal> or <literal>@ApplicationScoped</literal> 
-            beans) are available for concurrent access. Therefore, the concurrency management provided by EJB 3.1 
+            beans) are available for concurrent access. Therefore, the concurrency management provided by EJB 3.2 
             is especially useful. Most session and application scoped beans should be EJBs.
          </para>
        
@@ -604,7 +604,7 @@ class ShoppingCart implements Serializable { ... }]]></programlisting>
 
          <para>
             The point we're trying to make is: use a session bean when you need the services it provides, not just 
-            because you want to use dependency injection, lifecycle management, or interceptors. Java EE 6 provides
+            because you want to use dependency injection, lifecycle management, or interceptors. Java EE 7 provides
             a graduated programming model. It's usually easy to start with an ordinary managed bean, and later turn 
             it into an EJB just by adding one of the following annotations: <literal>@Stateless</literal>, 
             <literal>@Stateful</literal> or <literal>@Singleton</literal>.
@@ -899,11 +899,11 @@ public class Shop {
          </para>
 
          <programlisting role="XML"><![CDATA[<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://java.sun.com/xml/ns/javaee"
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee 
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee 
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_0.xsd">
 </beans>]]></programlisting> 
 
          <para>

--- a/docs/reference/src/main/docbook/en-US/configure.xml
+++ b/docs/reference/src/main/docbook/en-US/configure.xml
@@ -218,9 +218,9 @@
       </para>
       <example>
         <title>context mapping configuration in web.xml</title>
-      <programlisting role="XML"><![CDATA[<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+      <programlisting role="XML"><![CDATA[<web-app version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee/"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
     <context-param>
         <param-name>org.jboss.weld.context.mapping</param-name>

--- a/docs/reference/src/main/docbook/en-US/decorators.xml
+++ b/docs/reference/src/main/docbook/en-US/decorators.xml
@@ -158,11 +158,11 @@ public abstract class LargeTransactionDecorator
       </para>
 
       <programlisting role="XML"><![CDATA[<beans
-   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
    <decorators>
          <class>org.mycompany.myapp.LargeTransactionDecorator</class>
    </decorators>

--- a/docs/reference/src/main/docbook/en-US/environments.xml
+++ b/docs/reference/src/main/docbook/en-US/environments.xml
@@ -10,15 +10,6 @@
             If you are using WildFly 8.0 or better, no additional configuration is required to use Weld (or CDI for that matter).
         </para>
 
-        <note>
-            <para>
-                Additionally, Weld Servlet supports JBoss EAP 5.1, to do this use the
-                <literal>jboss5</literal>
-                variant
-                of Weld Servlet.
-            </para>
-        </note>
-
     </section>
 
     <section>
@@ -79,7 +70,7 @@
 ]]></programlisting>
 
         <para>
-            Actually you don't have to register this listener in Servlet 3.0 compliant containers which support <literal>javax.servlet.ServletContainerInitializer</literal> service properly (e.g. Tomcat 7.0.50).
+            Actually you don't have to register this listener in Servlet 3.x compliant containers which support <literal>javax.servlet.ServletContainerInitializer</literal> service properly (e.g. Tomcat 7.0.50).
             In this case <literal>org.jboss.weld.environment.servlet.EnhancedListener</literal> will do all the necessary work automatically, and what is more important -
             injection into Listeners will work on some containers as well (see <xref linkend="tomcat-container"/> and <xref linkend="jetty-container"/> for more info).
         </para>

--- a/docs/reference/src/main/docbook/en-US/gettingstarted.xml
+++ b/docs/reference/src/main/docbook/en-US/gettingstarted.xml
@@ -14,7 +14,7 @@
    </para>
 
    <para>
-      Both examples use JSF 2.0 as the web framework and, as such, can be found in the <literal>examples/jsf</literal>
+      Both examples use JSF 2.2 as the web framework and, as such, can be found in the <literal>examples/jsf</literal>
       directory of the Weld distribution.
    </para>
 
@@ -165,7 +165,7 @@ $> mvn jboss-as:run]]></programlisting>
 
       <note>
          <para>
-            The translator uses session beans, which are packaged in an EJB module within an ear. Java EE 6 will allow
+            The translator uses session beans, which are packaged in an EJB module within an ear. Java EE 7 allows
             session beans to be deployed in war modules, but that's a topic for a later chapter.
          </para>
       </note>

--- a/docs/reference/src/main/docbook/en-US/injection.xml
+++ b/docs/reference/src/main/docbook/en-US/injection.xml
@@ -414,11 +414,11 @@ public class MockPaymentProcessor implements PaymentProcessor {
         </para>
 
         <programlisting role="XML"><![CDATA[<beans
-   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
    <alternatives>
          <class>org.mycompany.mock.MockPaymentProcessor</class>
    </alternatives>

--- a/docs/reference/src/main/docbook/en-US/interceptors.xml
+++ b/docs/reference/src/main/docbook/en-US/interceptors.xml
@@ -134,11 +134,11 @@ public class TransactionInterceptor {
       </para>
 
 <programlisting role="XML"><![CDATA[<beans
-   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
    <interceptors>
       <class>org.mycompany.myapp.TransactionInterceptor</class>
    </interceptors>
@@ -168,11 +168,11 @@ public class TransactionInterceptor {
       </para>
 
       <programlisting role="XML"><![CDATA[<beans
-   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
    <interceptors>
       <class>org.mycompany.myapp.SecurityInterceptor</class>
       <class>org.mycompany.myapp.TransactionInterceptor</class>

--- a/docs/reference/src/main/docbook/en-US/intro.xml
+++ b/docs/reference/src/main/docbook/en-US/intro.xml
@@ -25,7 +25,7 @@
       </para>
 
       <para>
-         Java EE 6 finally lays down that common definition in the Managed Beans specification. Managed Beans are
+         Java EE 6 finally laid down that common definition in the Managed Beans specification. Managed Beans are
          defined as container-managed objects with minimal programming restrictions, otherwise known by the acronym 
          POJO (Plain Old Java Object). They support a small set of basic services, such as resource injection, lifecycle 
          callbacks and interceptors. Companion specifications, such as EJB and CDI, build on this basic model. But, 

--- a/docs/reference/src/main/docbook/en-US/next.xml
+++ b/docs/reference/src/main/docbook/en-US/next.xml
@@ -10,7 +10,7 @@
    </para>
   
    <para>
-      The CDI reference implementation, Weld, is being developed by the <ulink url="http://seamframework.org/Weld/Home#H-MaintainersAndContributors">Weld
+      The CDI reference implementation, Weld, is being developed by the <ulink url="https://github.com/weld/core/graphs/contributors">Weld
       team</ulink>. The team and the CDI spec lead blog at <ulink
       url="http://in.relation.to">in.relation.to</ulink>. This guide was originally based on a series of blog entries
       published there while the specification was being developed. It's probably the best source of information about
@@ -19,7 +19,7 @@
 
    <para>
       We encourage you to follow the <ulink url="https://lists.jboss.org/mailman/listinfo/weld-dev">weld-dev</ulink>
-      mailing list and to get involved in <ulink url="http://seamframework.org/Weld/Development">development</ulink>. If
+      mailing list and to get involved in <ulink url="http://weld.cdi-spec.org/community/">development</ulink>. If
       you are reading this guide, you likely have something to offer.
    </para>
 

--- a/docs/reference/src/main/docbook/en-US/part1.xml
+++ b/docs/reference/src/main/docbook/en-US/part1.xml
@@ -12,7 +12,7 @@ tainer, for example, alternative web presentation technologies.
 
    <!-- NOTE synchronize this intro with the intro on http://seamframework.org/Weld -->
    <para>
-      The <ulink url="http://jcp.org/en/jsr/detail?id=299">CDI</ulink> specification defines a set of 
+      The <ulink url="http://jcp.org/en/jsr/detail?id=346">CDI</ulink> specification defines a set of 
       complementary services that help improve the structure of application code. CDI layers an enhanced lifecycle 
       and interaction model over existing Java component types, including managed beans and Enterprise Java Beans. 
       The CDI services provide:
@@ -53,7 +53,7 @@ tainer, for example, alternative web presentation technologies.
       and the Java EE component architecture. But the specification does not limit the use of CDI to the Java EE 
       environment. In the Java SE environment, the services might be provided by a standalone CDI implementation 
       like Weld (see <xref linkend="weld-se"/>), or even by a container that also implements the subset of EJB 
-      defined for embedded usage by the EJB 3.1 specification. CDI is especially useful in the context of web 
+      defined for embedded usage by the EJB 3.2 specification. CDI is especially useful in the context of web 
       application development, but the problems it solves are general development concerns and it is therefore 
       applicable to a wide variety of application.
    </para>
@@ -193,13 +193,13 @@ tainer, for example, alternative web presentation technologies.
       CDI was influenced by a number of existing Java frameworks, including Seam, Guice and Spring. However, CDI has 
       its own, very distinct, character: more typesafe than Seam, more stateful and less XML-centric than Spring, more 
       web and enterprise-application capable than Guice. But it couldn't have been any of these without inspiration from 
-      the frameworks mentioned and <emphasis>lots</emphasis> of collaboration and hard work by the JSR-299 Expert Group
-      (EG).
+      the frameworks mentioned and <emphasis>lots</emphasis> of collaboration and hard work by the JSR-299 and JSR-346 
+      Expert Groups (EG).
    </para>
   
    <para>
-      Finally, CDI is a <ulink url="http://jcp.org">Java Community Process</ulink> (JCP) standard. Java EE 6 requires 
-      that all compliant application servers provide support for JSR-299 (even in the web profile).
+      Finally, CDI is a <ulink url="http://jcp.org">Java Community Process</ulink> (JCP) standard. Java EE 7 requires 
+      that all compliant application servers provide support for JSR-346 (even in the web profile).
    </para>
   
 <!--

--- a/docs/reference/src/main/docbook/en-US/part5.xml
+++ b/docs/reference/src/main/docbook/en-US/part5.xml
@@ -10,7 +10,7 @@
    </para>
 
    <para>
-      You might also want to check out <ulink url="http://incubator.apache.org/deltaspike/">DeltaSpike</ulink> project which provides portable extensions to CDI.
+      You might also want to check out <ulink url="http://deltaspike.apache.org/">DeltaSpike</ulink> project which provides portable extensions to CDI.
    </para>
    
    <para>

--- a/docs/reference/src/main/docbook/en-US/ri-spi.xml
+++ b/docs/reference/src/main/docbook/en-US/ri-spi.xml
@@ -824,7 +824,7 @@ public interface ResourceLoader extends Service {
             </para> 
 
             <para>
-                If you are running in a EJB 3.1 environment, you should register this as an around-timeout
+                If you are running in a EJB 3.2 environment, you should register this as an around-timeout
                 interceptor as well.
             </para>
 

--- a/docs/reference/src/main/docbook/en-US/specialization.xml
+++ b/docs/reference/src/main/docbook/en-US/specialization.xml
@@ -113,11 +113,11 @@ public class StagingPaymentProcessor
       </para>
 
       <programlisting role="XML"><![CDATA[<beans
-   xmlns="http://java.sun.com/xml/ns/javaee"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
    <alternatives>
          <stereotype>org.mycompany.myapp.Staging</stereotype>
    </alternatives>

--- a/docs/reference/src/main/docbook/en-US/weldexamples.xml
+++ b/docs/reference/src/main/docbook/en-US/weldexamples.xml
@@ -24,18 +24,18 @@
       
       <para>
           All the configuration files for this example are located in <literal>WEB-INF/</literal>, which can be found in
-          the <literal>src/main/webapp</literal> directory of the example. First, we have the JSF 2.0 version of
+          the <literal>src/main/webapp</literal> directory of the example. First, we have the JSF 2.2 version of
           <literal>faces-config.xml</literal>. A standardized version of Facelets is the default view handler in JSF
-          2.0, so there's really nothing that we have to configure. Thus, the configuration consists of only the root
+          2.2, so there's really nothing that we have to configure. Thus, the configuration consists of only the root
           element.
       </para>
       
-      <programlisting role="XML"><![CDATA[<faces-config version="2.0"
-   xmlns="http://java.sun.com/xml/ns/javaee"
+      <programlisting role="XML"><![CDATA[<faces-config version="2.2"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
       
       <name>numberguess</name>
       
@@ -943,7 +943,7 @@ public class NumberGuessFrame extends javax.swing.JFrame {
       
       <note>
          <para>
-            Java EE 6, which bundles EJB 3.1, allows you to package EJBs in a WAR, which will make this structure much
+            Java EE 7, which bundles EJB 3.2, allows you to package EJBs in a WAR, which will make this structure much
             simpler! Still, there are other advantages of using an EAR.
          </para>
       </note>
@@ -978,12 +978,12 @@ public class NumberGuessFrame extends javax.swing.JFrame {
             <literal>META-INF/application.xml</literal>:
          </para>
          
-         <programlisting role="XML"><![CDATA[<application version="6"
-   xmlns="http://java.sun.com/xml/ns/javaee" 
+         <programlisting role="XML"><![CDATA[<application version="7"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/application_6.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd">
 
   <display-name>weld-jsf-translator-ear</display-name>
   <description>The Weld JSF translator example (ear)</description>
@@ -1002,7 +1002,7 @@ public class NumberGuessFrame extends javax.swing.JFrame {
       
       <para>
          Next, let's look at the WAR, which is located in the example's <literal>war</literal> directory. Just as in the
-         numberguess example, we have a <literal>faces-config.xml</literal> for JSF 2.0 and a <literal>web.xml</literal>
+         numberguess example, we have a <literal>faces-config.xml</literal> for JSF 2.2 and a <literal>web.xml</literal>
          (to activate JSF) under WEB-INF, both sourced from <literal>src/main/webapp/WEB-INF</literal>.
       </para>
       

--- a/examples/jsf/login/src/main/resources/META-INF/persistence.xml
+++ b/examples/jsf/login/src/main/resources/META-INF/persistence.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence xmlns="http://java.sun.com/xml/ns/persistence" 
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence" 
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd" 
-             version="1.0">
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd" 
+             version="2.1">
    <persistence-unit name="loginDatabase">
       <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
       <properties>

--- a/examples/jsf/login/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/jsf/login/src/main/webapp/WEB-INF/beans.xml
@@ -1,9 +1,9 @@
 <!-- Marker file indicating CDI should be enabled -->
-<beans xmlns="http://java.sun.com/xml/ns/javaee"
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee 
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee 
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
 <!--       <alternatives> -->
 <!--          <class>org.jboss.weld.examples.login.EJBUserManager</class> -->
 <!--       </alternatives> -->

--- a/examples/jsf/login/src/main/webapp/WEB-INF/faces-config.xml
+++ b/examples/jsf/login/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<faces-config version="2.0"
-              xmlns="http://java.sun.com/xml/ns/javaee"
+<faces-config version="2.2"
+              xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
 
 </faces-config>

--- a/examples/jsf/login/src/main/webapp/WEB-INF/web.xml
+++ b/examples/jsf/login/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<web-app version="2.5"
-    xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
    
    <display-name>Web Beans Login example</display-name>
 

--- a/examples/jsf/login/src/main/webapp/home.xhtml
+++ b/examples/jsf/login/src/main/webapp/home.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
 
   <ui:composition template="template.xhtml">
     <ui:define name="content">

--- a/examples/jsf/login/src/main/webapp/template.xhtml
+++ b/examples/jsf/login/src/main/webapp/template.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/examples/jsf/login/src/main/webapp/users.xhtml
+++ b/examples/jsf/login/src/main/webapp/users.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:ui="http://java.sun.com/jsf/facelets"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core">
+	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core">
 
 <ui:composition template="template.xhtml">
 	<ui:define name="content">

--- a/examples/jsf/numberguess/src/main/webapp-wildfly-cluster/WEB-INF/web.xml
+++ b/examples/jsf/numberguess/src/main/webapp-wildfly-cluster/WEB-INF/web.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5"
-   xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="3.1"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
    
    <distributable/>
   

--- a/examples/jsf/numberguess/src/main/webapp-wildfly/WEB-INF/web.xml
+++ b/examples/jsf/numberguess/src/main/webapp-wildfly/WEB-INF/web.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app version="2.5"
-   xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="3.1"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
    
    <display-name>Weld Numberguess example</display-name>
    

--- a/examples/jsf/numberguess/src/main/webapp/WEB-INF/faces-config.xml
+++ b/examples/jsf/numberguess/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<faces-config version="2.0"
-   xmlns="http://java.sun.com/xml/ns/javaee"
+<faces-config version="2.2"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
       
       <name>numberguess</name>
       

--- a/examples/jsf/numberguess/src/main/webapp/home.xhtml
+++ b/examples/jsf/numberguess/src/main/webapp/home.xhtml
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-   xmlns:ui="http://java.sun.com/jsf/facelets"
-   xmlns:h="http://java.sun.com/jsf/html"
-   xmlns:f="http://java.sun.com/jsf/core">
+   xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+   xmlns:h="http://xmlns.jcp.org/jsf/html"
+   xmlns:f="http://xmlns.jcp.org/jsf/core">
 
    <ui:composition template="/template.xhtml">
       <ui:define name="content">

--- a/examples/jsf/numberguess/src/main/webapp/template.xhtml
+++ b/examples/jsf/numberguess/src/main/webapp/template.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/examples/jsf/pastecode/src/main/resources/META-INF/persistence.xml
+++ b/examples/jsf/pastecode/src/main/resources/META-INF/persistence.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence xmlns="http://java.sun.com/xml/ns/persistence" 
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence" 
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd" 
-             version="2.0">
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd" 
+             version="2.1">
    <persistence-unit name="pastecodeDatabase">
       <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
       <properties>

--- a/examples/jsf/pastecode/src/main/webapp/WEB-INF/beans.xml
+++ b/examples/jsf/pastecode/src/main/webapp/WEB-INF/beans.xml
@@ -3,11 +3,11 @@
    The contents of this file is permitted to be empty.
    The schema definition is provided for your convenience.
 -->
-<beans xmlns="http://java.sun.com/xml/ns/javaee"
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee 
-      http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee 
+      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd">
       
       <decorators>
       	<class>org.jboss.weld.examples.pastecode.session.FloodingDecorator</class>

--- a/examples/jsf/pastecode/src/main/webapp/WEB-INF/faces-config.xml
+++ b/examples/jsf/pastecode/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<faces-config version="2.0" xmlns="http://java.sun.com/xml/ns/javaee"
+<faces-config version="2.2" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+   xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
    
    <name>weldpastecode</name>
 

--- a/examples/jsf/pastecode/src/main/webapp/WEB-INF/web.xml
+++ b/examples/jsf/pastecode/src/main/webapp/WEB-INF/web.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://java.sun.com/xml/ns/javaee" xmlns:web="http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xsi:schemaLocation="
+            http://xmlns.jcp.org/xml/ns/javaee 
+            http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
   <display-name>Weld PasteCode example</display-name>
   <context-param>
     <param-name>javax.faces.DEFAULT_SUFFIX</param-name>

--- a/examples/jsf/pastecode/src/main/webapp/display.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/display.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
   
   <ui:composition template="template.xhtml">
      <ui:define name="viewMetadata">

--- a/examples/jsf/pastecode/src/main/webapp/help.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/help.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
   
   <ui:composition template="template.xhtml">
    	

--- a/examples/jsf/pastecode/src/main/webapp/history.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/history.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-	xmlns:ui="http://java.sun.com/jsf/facelets"
-	xmlns:h="http://java.sun.com/jsf/html"
-	xmlns:f="http://java.sun.com/jsf/core">
+	xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:f="http://xmlns.jcp.org/jsf/core">
 
 <ui:composition template="template.xhtml">
 	<ui:define name="viewMetadata">

--- a/examples/jsf/pastecode/src/main/webapp/home.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/home.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
   
    <ui:composition template="template.xhtml">
    	

--- a/examples/jsf/pastecode/src/main/webapp/jsScripts.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/jsScripts.xhtml
@@ -1,9 +1,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:h="http://java.sun.com/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:mj="http://mojarra.dev.java.net/mojarra_ext"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
       
 	<ui:composition>
 	

--- a/examples/jsf/pastecode/src/main/webapp/pagination.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/pagination.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
 	<ui:composition>
 	

--- a/examples/jsf/pastecode/src/main/webapp/rightMenuDefault.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/rightMenuDefault.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:h="http://java.sun.com/jsf/html"
-      xmlns:f="http://java.sun.com/jsf/core"
-      xmlns:ui="http://java.sun.com/jsf/facelets">
+      xmlns:h="http://xmlns.jcp.org/jsf/html"
+      xmlns:f="http://xmlns.jcp.org/jsf/core"
+      xmlns:ui="http://xmlns.jcp.org/jsf/facelets">
 
 	<ui:composition>
 			

--- a/examples/jsf/pastecode/src/main/webapp/template.xhtml
+++ b/examples/jsf/pastecode/src/main/webapp/template.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
     
 <f:view>
     <ui:insert name="viewMetadata"/>    

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/faces-config.xml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/faces-config.xml
@@ -20,12 +20,12 @@
  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
-<faces-config version="2.0"
-   xmlns="http://java.sun.com/xml/ns/javaee"
+<faces-config version="2.2"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
 
    <navigation-rule>
       <from-view-id>*</from-view-id>

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/categories.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/categories.xhtml
@@ -21,9 +21,9 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:f="http://java.sun.com/jsf/core"
-    xmlns:h="http://java.sun.com/jsf/html">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
 
                     <h2>Categories</h2>
                     <ul>

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/comments.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/comments.xhtml
@@ -21,9 +21,9 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:f="http://java.sun.com/jsf/core"
-    xmlns:h="http://java.sun.com/jsf/html">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
 
                         <ul id="comments" class="post-comments clear">
                             <h3>#{_entry.numComments} Comment#{_entry.numComments != 1 ? 's' : ''}</h3>

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/commonViewParams.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/commonViewParams.xhtml
@@ -21,8 +21,8 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
 
     <f:viewParam name="page" value="#{blog.page}"/>
     <f:viewParam name="q" value="#{blog.searchString}"/>

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/entryContent.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/entryContent.xhtml
@@ -21,10 +21,10 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:c="http://java.sun.com/jsp/jstl/core"
-    xmlns:f="http://java.sun.com/jsf/core"
-    xmlns:h="http://java.sun.com/jsf/html">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
+    xmlns:f="http://xmlns.jcp.org/jsf/core"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
 
                 <div class="post">
                     <div class="post-title">

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/entryList.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/entryList.xhtml
@@ -21,11 +21,11 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:c="http://java.sun.com/jsp/jstl/core"
-    xmlns:fn="http://java.sun.com/jsp/jstl/functions"
-    xmlns:f="http://java.sun.com/jsf/core"
-    xmlns:h="http://java.sun.com/jsf/html">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:c="http://xmlns.jcp.org/jsp/jstl/core"
+    xmlns:fn="http://xmlns.jcp.org/jsp/jstl/functions"
+    xmlns:f="http://xmlns.jcp.org/jsf/core"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
 
                 <c:if test="#{view.viewId == '/category.xhtml'}">
                 <div class="category">

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/otherCategories.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/otherCategories.xhtml
@@ -21,9 +21,9 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:f="http://java.sun.com/jsf/core"
-    xmlns:h="http://java.sun.com/jsf/html">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
 
                     <h2>Other Categories</h2>
                     <ul>

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/singleEntry.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/fragments/singleEntry.xhtml
@@ -21,9 +21,9 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:f="http://java.sun.com/jsf/core"
-    xmlns:h="http://java.sun.com/jsf/html">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:f="http://xmlns.jcp.org/jsf/core"
+    xmlns:h="http://xmlns.jcp.org/jsf/html">
 
                 <ui:remove><!-- The check for phase prevents a "ghost" form submit --></ui:remove>
                 <h:panelGroup rendered="#{facesContext.currentPhaseId.ordinal == 6 and empty blog.entry}">

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/layout/template.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/layout/template.xhtml
@@ -23,9 +23,9 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <html xmlns="http://www.w3.org/1999/xhtml"
-   xmlns:ui="http://java.sun.com/jsf/facelets"
-   xmlns:f="http://java.sun.com/jsf/core"
-   xmlns:h="http://java.sun.com/jsf/html">
+   xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+   xmlns:f="http://xmlns.jcp.org/jsf/core"
+   xmlns:h="http://xmlns.jcp.org/jsf/html">
    <f:view>
       <ui:insert name="viewMetadata"/>
    <head>

--- a/examples/jsf/permalink/src/main/webapp/WEB-INF/web.xml
+++ b/examples/jsf/permalink/src/main/webapp/WEB-INF/web.xml
@@ -20,12 +20,12 @@
  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
-<web-app version="2.5"
-   xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="3.1"
+   xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="
-      http://java.sun.com/xml/ns/javaee
-      http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+      http://xmlns.jcp.org/xml/ns/javaee
+      http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
 
    <display-name>Weld Permalink Example (Servlet Environment)</display-name>
    

--- a/examples/jsf/permalink/src/main/webapp/category.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/category.xhtml
@@ -21,8 +21,8 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-   xmlns:ui="http://java.sun.com/jsf/facelets"
-   xmlns:f="http://java.sun.com/jsf/core"
+   xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+   xmlns:f="http://xmlns.jcp.org/jsf/core"
    template="/WEB-INF/layout/template.xhtml">
    <ui:define name="viewMetadata">
       <f:metadata>

--- a/examples/jsf/permalink/src/main/webapp/entry.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/entry.xhtml
@@ -21,8 +21,8 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-   xmlns:ui="http://java.sun.com/jsf/facelets"
-   xmlns:f="http://java.sun.com/jsf/core"
+   xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+   xmlns:f="http://xmlns.jcp.org/jsf/core"
    template="/WEB-INF/layout/template.xhtml">
    <ui:define name="viewMetadata">
       <f:metadata>

--- a/examples/jsf/permalink/src/main/webapp/home.xhtml
+++ b/examples/jsf/permalink/src/main/webapp/home.xhtml
@@ -21,8 +21,8 @@
  02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <ui:composition xmlns="http://www.w3.org/1999/xhtml"
-   xmlns:ui="http://java.sun.com/jsf/facelets"
-   xmlns:f="http://java.sun.com/jsf/core"
+   xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+   xmlns:f="http://xmlns.jcp.org/jsf/core"
    template="/WEB-INF/layout/template.xhtml">
    <ui:define name="viewMetadata">
       <f:metadata>

--- a/examples/jsf/translator/ear/pom.xml
+++ b/examples/jsf/translator/ear/pom.xml
@@ -52,6 +52,7 @@
                             <contextRoot>/weld-translator</contextRoot>
                         </webModule>
                     </modules>
+                    <version>7</version>
                 </configuration>
             </plugin>
         </plugins>

--- a/examples/jsf/translator/war/src/main/webapp/WEB-INF/faces-config.xml
+++ b/examples/jsf/translator/war/src/main/webapp/WEB-INF/faces-config.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<faces-config version="2.0"
-              xmlns="http://java.sun.com/xml/ns/javaee"
+<faces-config version="2.2"
+              xmlns="http://xmlns.jcp.org/xml/ns/javaee"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facesconfig_2_0.xsd">
+              xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd">
 
 </faces-config>

--- a/examples/jsf/translator/war/src/main/webapp/WEB-INF/web.xml
+++ b/examples/jsf/translator/war/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<web-app version="2.5"
-    xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
    
    <display-name>Web Beans Numbergues example</display-name>
 

--- a/examples/jsf/translator/war/src/main/webapp/home.xhtml
+++ b/examples/jsf/translator/war/src/main/webapp/home.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
 
   <ui:composition template="template.xhtml">
     <ui:define name="content">

--- a/examples/jsf/translator/war/src/main/webapp/template.xhtml
+++ b/examples/jsf/translator/war/src/main/webapp/template.xhtml
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
-    xmlns:ui="http://java.sun.com/jsf/facelets"
-    xmlns:h="http://java.sun.com/jsf/html"
-    xmlns:f="http://java.sun.com/jsf/core">
+    xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
+    xmlns:h="http://xmlns.jcp.org/jsf/html"
+    xmlns:f="http://xmlns.jcp.org/jsf/core">
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -270,8 +270,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-ejb-plugin</artifactId>
                     <configuration>
-                        <ejbVersion>3.0</ejbVersion>
+                        <ejbVersion>3.2</ejbVersion>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-ear-plugin</artifactId>
+                    <version>2.9</version>
                 </plugin>
                 <!-- Work around issues encountered with http://jira.codehaus.org/browse/MWAR-187
                     during release -->


### PR DESCRIPTION
- updated old namespace http://java.sun.com to http://xmlns.jcp.org in doc and examples
- DOC:
  - added a short explanation of "JSR-299" and "JSR-346"
  - replaced EE6-spec mentions with EE7 ones (where it made sense)
  - updated a couple of outdated links (Seam, and DS "incubator")
- EXAMPLES:
  - updated maven-ear-plugin to 2.9 to allow <version>7</version>
  - updated <ejbVersion> to 3.2
