### PR TITLE
Remove two tests from TCK exclude-list

### DIFF
--- a/jboss-tck-runner/1.1/src/test/tck12/tck-tests.xml
+++ b/jboss-tck-runner/1.1/src/test/tck12/tck-tests.xml
@@ -28,19 +28,6 @@
             <!-- Issues in Weld (the RI) -->
 
             <!-- Issues in WildFly -->
-            <!-- WFLY-2654 -->
-            <class name="org.jboss.cdi.tck.interceptors.tests.contract.aroundTimeout.AroundTimeoutInterceptorTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
-
-            <!-- TODO add corresponding issue -->
-            <class name="org.jboss.cdi.tck.tests.lookup.injection.non.contextual.WebServiceInjectionIntoNonContextualComponentTest">
-                <methods>
-                    <exclude name=".*"/>
-                </methods>
-            </class>
 
         </classes>
     </test>


### PR DESCRIPTION
WFLY-2654 is resolved
WebServiceInjectionIntoNonContextualComponentTest is excluded in the TCK
