### PR TITLE
WELD-1517 Servlet support - first fire @Destroyed(ApplicationScoped.clas...

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/EnhancedListener.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/EnhancedListener.java
@@ -76,8 +76,8 @@ public class EnhancedListener extends ForwardingServletListener implements Servl
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
-        lifecycle.destroy(sce.getServletContext());
         super.contextDestroyed(sce);
+        lifecycle.destroy(sce.getServletContext());
     }
 
     @Override

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/Listener.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/Listener.java
@@ -69,8 +69,8 @@ public class Listener extends ForwardingServletListener {
         if (isEnhancedListenerUsed) {
             return;
         }
-        lifecycle.destroy(sce.getServletContext());
         super.contextDestroyed(sce);
+        lifecycle.destroy(sce.getServletContext());
     }
 
     @Override


### PR DESCRIPTION
...s) and then destroy application context

This is not entirely per the spec. However, we believe it's more useful
than original implementation where @Destroyed(ApplicationScoped.class)
observers weren't notified.
