### PR TITLE
WELD-1607 Clean up conversation context properly

### DIFF
--- a/impl/src/main/java/org/jboss/weld/context/AbstractContext.java
+++ b/impl/src/main/java/org/jboss/weld/context/AbstractContext.java
@@ -169,7 +169,12 @@ public abstract class AbstractContext implements AlterableContext {
 
     public void cleanup() {
         if (getBeanStore() != null) {
-            getBeanStore().clear();
+            try {
+                getBeanStore().clear();
+            } catch (Exception e) {
+                ContextLogger.LOG.unableToClearBeanStore(getBeanStore());
+                ContextLogger.LOG.catchingDebug(e);
+            }
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
+++ b/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
@@ -163,9 +163,9 @@ public abstract class AbstractConversationContext<R, S> extends AbstractBoundCon
         if (isAssociated()) {
             try {
                 copyConversationIdGeneratorAndConversationsToSession();
-                this.associated.set(null);
                 return true;
             } finally {
+                this.associated.set(null);
                 cleanup();
             }
         } else {

--- a/impl/src/main/java/org/jboss/weld/logging/ContextLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/ContextLogger.java
@@ -153,4 +153,8 @@ public interface ContextLogger extends WeldLogger {
     @Message(id = 223, value = "Context.getScope() returned null for {0}", format = Format.MESSAGE_FORMAT)
     DefinitionException contextHasNullScope(Object param1);
 
+    @LogMessage(level = Level.WARN)
+    @Message(id = 224, value = "Unable to clear bean store {0}.", format = Format.MESSAGE_FORMAT)
+    void unableToClearBeanStore(Object beanStore);
+
 }


### PR DESCRIPTION
Always unset AbstractConversationContext.associated threadlocal during
dissociate.

An exception thrown within BeanStore.clear() should not abort context
cleanup.
