### PR TITLE
Make jboss-as7-updater more resilient

### DIFF
--- a/jboss-as/jboss-as-7/pom.xml
+++ b/jboss-as/jboss-as-7/pom.xml
@@ -5,13 +5,6 @@
     <packaging>pom</packaging>
     <version>1.1.23-SNAPSHOT</version>
 
-    <parent>
-        <groupId>org.jboss.weld</groupId>
-        <artifactId>weld-core-parent</artifactId>
-        <version>1.1.23-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
     <name>JBoss AS7 Updater</name>
 
     <!-- Minimal metadata -->
@@ -28,13 +21,14 @@
 
 
     <properties>
+        <weld.update.version>${project.version}</weld.update.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-core</artifactId>
-            <version>${project.version}</version>
+            <version>${weld.update.version}</version>
         </dependency>
     </dependencies>
     <profiles>


### PR DESCRIPTION
- Added weld.update.version property
- Removed parent, to make the updater completely independent
- maven-deploy-plugin now doesn't have a fix version, but it only defines the skip property, so it shouldn't matter
