### PR TITLE
WELD-1709 @WithAnnotations applies only to public annotated constructors

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/RequiredAnnotationDiscovery.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/RequiredAnnotationDiscovery.java
@@ -84,7 +84,7 @@ public class RequiredAnnotationDiscovery implements Service {
                 }
             }
             // constructors
-            for (Constructor<?> constructor : clazz.getConstructors()) {
+            for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
                 if (containsAnnotations(cache.getAnnotations(constructor), requiredAnnotation)) {
                     return true;
                 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/annotatedType/withAnnotations/Group.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/annotatedType/withAnnotations/Group.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.extensions.annotatedType.withAnnotations;
+
+
+import java.beans.ConstructorProperties;
+
+public class Group {
+
+    private final String name;
+
+    @ConstructorProperties({"name"})
+    Group(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/annotatedType/withAnnotations/VerifyingExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/annotatedType/withAnnotations/VerifyingExtension.java
@@ -24,17 +24,30 @@ import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.WithAnnotations;
 import javax.validation.Constraint;
+import java.beans.ConstructorProperties;
 
 public class VerifyingExtension implements Extension {
 
-    private AnnotatedType<Person> type;
+    private AnnotatedType<Person> personType;
+
+    private AnnotatedType<Group> groupType;
 
     void processPerson(@Observes @WithAnnotations(Constraint.class) ProcessAnnotatedType<Person> event) {
-        assertNull(type);
-        this.type = event.getAnnotatedType();
+        assertNull(personType);
+        this.personType = event.getAnnotatedType();
     }
 
-    public AnnotatedType<Person> getType() {
-        return type;
+    void processGroup(@Observes @WithAnnotations(ConstructorProperties.class) ProcessAnnotatedType<Group> event) {
+        assertNull(groupType);
+        this.groupType = event.getAnnotatedType();
+    }
+
+    public AnnotatedType<Person> getPersonType() {
+        return personType;
+
+    }
+
+    public AnnotatedType<Group> getGroupType() {
+        return groupType;
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/annotatedType/withAnnotations/WithAnnotationsTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/annotatedType/withAnnotations/WithAnnotationsTest.java
@@ -50,7 +50,10 @@ public class WithAnnotationsTest {
 
     @Test
     public void test() {
-        assertNotNull(extension.getType());
-        assertEquals(Person.class, extension.getType().getJavaClass());
+        assertNotNull(extension.getPersonType());
+        assertEquals(Person.class, extension.getPersonType().getJavaClass());
+
+        assertNotNull(extension.getGroupType());
+        assertEquals(Group.class, extension.getGroupType().getJavaClass());
     }
 }


### PR DESCRIPTION
As stated in the CDI specification, the `@WtihAnnotations` annotation can appear on any member of the annotated type. However, Weld is only delivering the `ProcessAnnotatedType` events for types whose annotated constructors are `public`.
