### PR TITLE
WELD-1710 Servlet container support - fix detection in Jetty 9.2

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/Container.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/Container.java
@@ -17,6 +17,7 @@
 
 package org.jboss.weld.environment;
 
+
 /**
  * Abstract the web container setup notion.
  * e.g. Tomcat, Jetty, GAE, ...
@@ -24,6 +25,9 @@ package org.jboss.weld.environment;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public interface Container {
+
+    String CONTEXT_PARAM_CONTAINER_CLASS = Container.class.getPackage().getName() + ".container.class";
+
     /**
      * Touch if this container can be used.
      * We should throw an exception if it cannot be used.

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/AbstractJettyContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/AbstractJettyContainer.java
@@ -26,6 +26,7 @@ import org.jboss.weld.environment.ContainerContext;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public abstract class AbstractJettyContainer extends AbstractContainer {
+
     public static final String INJECTOR_ATTRIBUTE_NAME = "org.jboss.weld.environment.jetty.JettyWeldInjector";
 
     public void destroy(ContainerContext context) {

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
@@ -36,13 +36,16 @@ public class JettyContainer extends AbstractJettyContainer {
 
     public static Container INSTANCE = new JettyContainer();
 
+    private static final String JETTY_SERVERNAME = "jetty";
+
     private static final String JETTY_REQUIRED_CLASS_NAME = "org.eclipse.jetty.servlet.ServletHandler";
 
     private static final int MAJOR_VERSION = 7;
     private static final int MINOR_VERSION = 2;
 
     protected String classToCheck() {
-        // This is not used anyway - ServletContext.getServerInfo() is parsed instead
+        // This is not used anyway - server implementation classes are hidden from the web application in Jetty by default
+        // Instead ServletContext.getServerInfo() is parsed
         return JETTY_REQUIRED_CLASS_NAME;
     }
 
@@ -50,6 +53,9 @@ public class JettyContainer extends AbstractJettyContainer {
         ServletContext sc = context.getServletContext();
         String si = sc.getServerInfo();
         log.debugv("Parsing server info: {0}", si);
+        if(!si.contains(JETTY_SERVERNAME)) {
+            return false;
+        }
         int p = si.indexOf("/");
         if (p < 0) {
             return false;

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/tomcat/TomcatContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/tomcat/TomcatContainer.java
@@ -28,10 +28,13 @@ import org.jboss.weld.environment.servlet.EnhancedListener;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public class TomcatContainer extends AbstractContainer {
+
     public static Container INSTANCE = new TomcatContainer();
 
+    private static final String TOMCAT_REQUIRED_CLASS_NAME = "org.apache.catalina.connector.Request";
+
     protected String classToCheck() {
-        return "org.apache.tomcat.InstanceManager";
+        return TOMCAT_REQUIRED_CLASS_NAME;
     }
 
     public void initialize(ContainerContext context) {

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -27,10 +27,10 @@
     <properties>
         <jsf.version>2.1</jsf.version>
         <jsf-impl.version>2.1.22</jsf-impl.version>
-        <tomcat.version>7.0.52</tomcat.version>
-        <tomcat8.version>8.0.3</tomcat8.version>
+        <tomcat.version>7.0.55</tomcat.version>
+        <tomcat8.version>8.0.9</tomcat8.version>
         <jetty.version>8.1.14.v20131031</jetty.version>
-        <jetty9.version>9.1.0.v20131115</jetty9.version>
+        <jetty9.version>9.1.4.v20140401</jetty9.version>
         <!-- Jetty 6 API is used for GWT support only -->
         <jetty6.version>6.1.26</jetty6.version>
         <uel.glassfish.version>2.2</uel.glassfish.version>


### PR DESCRIPTION
- TomcatContainer - change the name of the  required class
- JettyContainer - add "servername" check
- allow to skip Container detection and define the Container class via
  context-param
- update Tomcat and Jetty versions
