### PR TITLE
Improve Weld SE Startup Performance: Use available jandex.idx files and more

### DIFF
--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
@@ -17,7 +17,6 @@
 package org.jboss.weld.environment.se;
 
 import java.lang.annotation.Annotation;
-import java.net.URL;
 import java.security.AccessController;
 import java.util.Arrays;
 import java.util.Collection;
@@ -51,6 +50,7 @@ import org.jboss.weld.environment.se.events.ContainerInitialized;
 import org.jboss.weld.environment.se.logging.WeldSELogger;
 import org.jboss.weld.environment.se.util.SEReflections;
 import org.jboss.weld.literal.InitializedLiteral;
+import org.jboss.weld.metadata.BeansXmlMergeUtil;
 import org.jboss.weld.metadata.MetadataImpl;
 import org.jboss.weld.resources.spi.ClassFileServices;
 import org.jboss.weld.resources.spi.ResourceLoader;
@@ -250,14 +250,12 @@ public class Weld {
      */
     private WeldSEBeanDeploymentArchive mergeToOne(CDI11Bootstrap bootstrap, Collection<WeldSEBeanDeploymentArchive> discoveredArchives) {
         Set<String> beanClasses = new HashSet<String>();
-        Set<URL> urls = new HashSet<URL>();
+        Set<BeansXml> beansXMLs = new HashSet<BeansXml>();
         for (BeanDeploymentArchive archive : discoveredArchives) {
             beanClasses.addAll(archive.getBeanClasses());
-            if (archive.getBeansXml() != BeansXml.EMPTY_BEANS_XML) {
-                urls.add(archive.getBeansXml().getUrl());
-            }
+            beansXMLs.add(archive.getBeansXml());
         }
-        BeansXml beansXml = bootstrap.parse(urls, true);
+        BeansXml beansXml = new BeansXmlMergeUtil().merge(beansXMLs);
         WeldSEBeanDeploymentArchive archive = new WeldSEBeanDeploymentArchive("main", beanClasses, beansXml);
         return archive;
     }

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/AbstractWeldSEDeployment.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/AbstractWeldSEDeployment.java
@@ -26,11 +26,9 @@ import org.jboss.weld.bootstrap.spi.Deployment;
 import org.jboss.weld.bootstrap.spi.Metadata;
 
 /**
- * Implements the basic requirements of a {@link Deployment}. Provides a service
- * registry.
+ * Implements the basic requirements of a {@link Deployment}. Provides a service registry.
  * <p/>
- * Suitable for extension by those who need to build custom {@link Deployment}
- * implementations.
+ * Suitable for extension by those who need to build custom {@link Deployment} implementations.
  *
  * @author Pete Muir
  * @author Ales Justin
@@ -38,7 +36,9 @@ import org.jboss.weld.bootstrap.spi.Metadata;
 public abstract class AbstractWeldSEDeployment implements CDI11Deployment {
 
     public static final String BEANS_XML = "META-INF/beans.xml";
-    public static final String[] RESOURCES = {BEANS_XML};
+    public static final String JANDEX_INDEX_NAME = "META-INF/jandex.idx";
+
+    public static final String[] RESOURCES = { BEANS_XML };
 
     private final ServiceRegistry serviceRegistry;
     private final Iterable<Metadata<Extension>> extensions;
@@ -55,6 +55,4 @@ public abstract class AbstractWeldSEDeployment implements CDI11Deployment {
     public Iterable<Metadata<Extension>> getExtensions() {
         return extensions;
     }
-
-
 }

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/BeanArchiveBuilder.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/BeanArchiveBuilder.java
@@ -16,11 +16,9 @@
  */
 package org.jboss.weld.environment.se.discovery.url;
 
-import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 
-import org.jboss.weld.bootstrap.api.Bootstrap;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.environment.se.discovery.WeldSEBeanDeploymentArchive;
 
@@ -34,30 +32,18 @@ class BeanArchiveBuilder {
 
     private Object index;
     private List<String> classes;
-    private URL beansXmlUrl;
-    private BeansXml beansXml = null;
-    private Bootstrap bootstrap;
+    private final BeansXml beansXml;
     private String id;
 
-    public BeanArchiveBuilder(String id, Object index, List<String> classes, URL beansXmlUrl, Bootstrap bootstrap) {
+    public BeanArchiveBuilder(String id, Object index, List<String> classes, BeansXml beansXml) {
         this.id = id;
         this.index = index;
         this.classes = classes;
-        this.beansXmlUrl = beansXmlUrl;
-        this.bootstrap = bootstrap;
-    }
-
-    public BeansXml parseBeansXml() {
-        beansXml = bootstrap.parse(beansXmlUrl);
-        return beansXml;
+        this.beansXml = beansXml;
     }
 
     public BeansXml getParsedBeansXml() {
-        if (beansXml == null) {
-            return parseBeansXml();
-        } else {
-            return beansXml;
-        }
+        return beansXml;
     }
 
     public WeldSEBeanDeploymentArchive build() {
@@ -90,10 +76,6 @@ class BeanArchiveBuilder {
 
     public List<String> getClasses() {
         return classes;
-    }
-
-    public URL getBeansXmlUrl() {
-        return beansXmlUrl;
     }
 
     public Iterator<String> getClassIterator() {

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/DiscoveryStrategy.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/DiscoveryStrategy.java
@@ -52,7 +52,7 @@ public abstract class DiscoveryStrategy {
         builders = new URLScanner(resourceLoader, bootstrap, AbstractWeldSEDeployment.RESOURCES).scan();
         initialize();
         for (BeanArchiveBuilder builder : builders) {
-            BeansXml beansXml = builder.parseBeansXml();
+            BeansXml beansXml = builder.getParsedBeansXml();
             switch (beansXml.getBeanDiscoveryMode()) {
                 case ALL:
                     addToArchives(processAllDiscovery(builder));

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/JandexEnabledFileSystemURLHandler.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/JandexEnabledFileSystemURLHandler.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.Indexer;
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.environment.se.logging.WeldSELogger;
 
 /**
@@ -34,8 +35,8 @@ public class JandexEnabledFileSystemURLHandler extends FileSystemURLHandler {
 
     private final Indexer indexer = new Indexer();
 
-    public JandexEnabledFileSystemURLHandler(Bootstrap bootstrap) {
-        super(bootstrap);
+    public JandexEnabledFileSystemURLHandler(Bootstrap bootstrap, BeansXml beansXml) {
+        super(bootstrap, beansXml);
     }
 
     private void addToIndex(URL url) {
@@ -66,7 +67,7 @@ public class JandexEnabledFileSystemURLHandler extends FileSystemURLHandler {
 
     @Override
     protected BeanArchiveBuilder createBeanArchiveBuilder() {
-        return new BeanArchiveBuilder(null, buildJandexIndex(), getDiscoveredClasses(), getDiscoveredBeansXmlUrl(), getBootstrap());
+        return new BeanArchiveBuilder(null, buildJandexIndex(), getDiscoveredClasses(), getDiscoveredBeansXml());
     }
 
     public Index buildJandexIndex() {

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/JandexIndexURLHandler.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/JandexIndexURLHandler.java
@@ -1,0 +1,143 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2009, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.se.discovery.url;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.UnsupportedVersion;
+import org.jboss.logging.Logger;
+import org.jboss.weld.bootstrap.spi.BeansXml;
+import org.jboss.weld.environment.se.discovery.AbstractWeldSEDeployment;
+import org.jboss.weld.environment.se.logging.WeldSELogger;
+
+/**
+ * This class uses a Jandex-Index ("META-INF/jandex.idx") to scan the the archive. If no index is available the {@link JandexIndexURLHandler#handle(String)}
+ * method will return null. To prevent this, use {@link JandexIndexURLHandler#canHandle(String)} to check if an index is available and supported.
+ *
+ * @author Stefan Großmann
+ */
+public class JandexIndexURLHandler implements URLHandler {
+    private static final Logger log = Logger.getLogger(JandexIndexURLHandler.class);
+
+    private static final String JAR_URL_PREFIX = "jar:";
+    private static final String FILE_URL_PREFIX = "file:";
+    private static final String SEPARATOR = "!/";
+
+    private final List<String> discoveredClasses = new ArrayList<String>();
+    private final BeansXml beansXml;
+
+    private Index indexCache = null;
+    private String indexCacheUrlPath = null;
+
+    public JandexIndexURLHandler(BeansXml beansXml) {
+        this.beansXml = beansXml;
+    }
+
+    @Override
+    public boolean canHandle(String urlPath) {
+        return getIndex(urlPath) != null;
+    }
+
+    @Override
+    public BeanArchiveBuilder handle(String urlPath) {
+        Index index = getIndex(urlPath);
+        handleArchiveByIndex(index);
+        return createBeanArchiveBuilder(index);
+    }
+
+    private Index getIndex(final String urlPath) {
+        if (urlPath == null) {
+            throw new IllegalArgumentException("");
+        }
+
+        if (indexCacheUrlPath == null || !indexCacheUrlPath.equals(urlPath)) {
+            Index newIndex = loadJandexIndex(urlPath);
+            indexCache = newIndex;
+            indexCacheUrlPath = urlPath;
+
+        }
+
+        return indexCache;
+    }
+
+    private Index loadJandexIndex(final String urlPath) {
+        URL indexURL = null;
+        Index index = null;
+
+        final String indexUrlString = getJandexIndexURLString(urlPath);
+        try {
+            indexURL = new URL(indexUrlString);
+        } catch (MalformedURLException e) {
+            return null;
+        }
+
+        InputStream indexFileStream = null;
+        try {
+            indexFileStream = indexURL.openStream();
+            final IndexReader indexFileReader = new IndexReader(indexFileStream);
+            index = indexFileReader.read();
+        } catch (IllegalArgumentException e) {
+            log.debugv("Jandex index at {} is not valid", indexUrlString);
+        } catch (UnsupportedVersion e) {
+            log.debugv("Version of Jandex index at {} is not supported", indexUrlString);
+        } catch (FileNotFoundException ignore) {
+            // There is no index available.
+            log.tracev("No Jandex index found at {}", indexUrlString);
+        } catch (IOException ioe) {
+            log.debugv("Cannot load Jandex index at {}", indexUrlString);
+            log.trace("", ioe);
+        } finally {
+            if (indexFileStream != null) {
+                try {
+                    indexFileStream.close();
+                } catch (IOException ioe) {
+                    WeldSELogger.LOG.couldNotCloseStreamOfJandexIndex(urlPath, ioe);
+                }
+            }
+        }
+
+        return index;
+    }
+
+    private String getJandexIndexURLString(final String urlPath) {
+        String indexUrlString = FILE_URL_PREFIX + urlPath + SEPARATOR + AbstractWeldSEDeployment.JANDEX_INDEX_NAME;
+        if (urlPath.toLowerCase().endsWith(".jar")) {
+            indexUrlString = JAR_URL_PREFIX + indexUrlString;
+        }
+
+        return indexUrlString;
+    }
+
+    private void handleArchiveByIndex(Index index) {
+        for (ClassInfo classInfo : index.getKnownClasses()) {
+            discoveredClasses.add(classInfo.name().toString());
+        }
+    }
+
+    private BeanArchiveBuilder createBeanArchiveBuilder(Index index) {
+        return new BeanArchiveBuilder(null, index, discoveredClasses, beansXml);
+    }
+}

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/URLHandler.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/URLHandler.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.weld.environment.se.discovery.url;
 
-
 /**
  * Represents a handler for handling the url path to the directory of classes or to the jar files.
  *
@@ -31,4 +30,9 @@ interface URLHandler {
      *         enabled.
      */
     BeanArchiveBuilder handle(String urlPath);
+
+    /**
+     * @return true if the specific URLHandler implementation is able to hande the archrive with the given urlPath.
+     */
+    boolean canHandle(String urlPath);
 }

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/URLScanner.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/discovery/url/URLScanner.java
@@ -17,14 +17,21 @@
 package org.jboss.weld.environment.se.discovery.url;
 
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.zip.ZipFile;
 
 import org.jboss.logging.Logger;
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.discovery.AbstractWeldSEDeployment;
 import org.jboss.weld.environment.se.logging.WeldSELogger;
 import org.jboss.weld.environment.se.util.SEReflections;
 import org.jboss.weld.resources.spi.ResourceLoader;
@@ -39,10 +46,13 @@ import org.jboss.weld.util.reflection.Reflections;
  * @author Pete Muir
  * @author Peter Royle
  * @author Marko Luksa
+ * @author Stefan Großmann
  */
 public class URLScanner {
 
     private static final String JANDEX_ENABLED_FS_URL_HANDLER_CLASS_STRING = "org.jboss.weld.environment.se.discovery.url.JandexEnabledFileSystemURLHandler";
+    private static final String JANDEX_INDEX_ENABLED_HANDLER_CLASS_STRING = "org.jboss.weld.environment.se.discovery.url.JandexIndexURLHandler";
+
     private static final Logger log = Logger.getLogger(URLScanner.class);
     private static final String FILE = "file";
     // according to JarURLConnection api doc, the separator is "!/"
@@ -65,26 +75,65 @@ public class URLScanner {
      * @return Collection<BeanArchiveBuilder> collection of the {@link BeanArchiveBuilder}-s that were created.
      */
     public Collection<BeanArchiveBuilder> scan() {
-        URLHandler handler = null;
         for (String resourceName : resources) {
             // grab all the URLs for this resource
             for (URL url : resourceLoader.getResources(resourceName)) {
+                log.debugv("Scanning bean archive for {0}.", url);
                 String urlPath;
+                BeansXml beansXml = null;
                 try {
                     urlPath = getUrlPath(resourceName, url);
+                    beansXml = getBeansXML(url);
+                    if (!mustScan(beansXml)) {
+                        continue;
+                    }
                 } catch (URISyntaxException e) {
                     WeldSELogger.LOG.couldNotReadResource(resourceName, e);
                     continue;
                 }
-                if (Reflections.isClassLoadable(Weld.JANDEX_INDEX_CLASS_NAME, resourceLoader)) {
-                    handler = SEReflections.newInstance(resourceLoader, JANDEX_ENABLED_FS_URL_HANDLER_CLASS_STRING, bootstrap);
-                } else {
-                    handler = new FileSystemURLHandler(bootstrap);
-                }
+
+                final URLHandler handler = constructHandler(urlPath, beansXml);
                 builders.add(handler.handle(urlPath).setId(getId(urlPath)));
             }
         }
         return builders;
+    }
+
+    private boolean mustScan(final BeansXml beansXml) {
+        boolean mustScan = true;
+        if (beansXml != null) {
+            final BeanDiscoveryMode discoveryMode = beansXml.getBeanDiscoveryMode();
+            if (discoveryMode == BeanDiscoveryMode.NONE) {
+                mustScan = false;
+            }
+        }
+        return mustScan;
+    }
+
+    private URLHandler constructHandler(String urlPath, final BeansXml beansXml) {
+        final boolean jandexInClassPath = Reflections.isClassLoadable(Weld.JANDEX_INDEX_CLASS_NAME, resourceLoader);
+        URLHandler handler;
+        if (jandexInClassPath) {
+            handler = SEReflections.newInstance(resourceLoader, JANDEX_INDEX_ENABLED_HANDLER_CLASS_STRING, beansXml);
+            if (!handler.canHandle(urlPath)) {
+                log.debugv("Not able to load JANDEX index for {}. Fallback to JandexEnabledFileSystemURLHandler.", beansXml);
+                handler = SEReflections.newInstance(resourceLoader, JANDEX_ENABLED_FS_URL_HANDLER_CLASS_STRING, bootstrap, beansXml);
+            }
+        } else {
+            handler = new FileSystemURLHandler(bootstrap, beansXml);
+        }
+        return handler;
+    }
+
+    private BeansXml getBeansXML(URL url) throws URISyntaxException {
+        final String resourceUrlPath = url.toURI().getSchemeSpecificPart();
+        BeansXml beansXml = null;
+        // hack for /META-INF/beans.xml
+        if (resourceUrlPath.endsWith(AbstractWeldSEDeployment.BEANS_XML)) {
+            beansXml = bootstrap.parse(url);
+        }
+
+        return beansXml;
     }
 
     private String getUrlPath(String resourceName, URL url) throws URISyntaxException {
@@ -114,6 +163,36 @@ public class URLScanner {
             }
         }
 
+        if (urlPath.startsWith("http:") || urlPath.startsWith("https:")) {
+            urlPath = convertWebstartToLocalPath(urlPath);
+        }
+
+        return urlPath;
+    }
+
+    /**
+     * WebStart support: get path to local cached copy of remote JAR file
+     */
+    private String convertWebstartToLocalPath(String urlPath) {
+        // Class loader should be an instance of com.sun.jnlp.JNLPClassLoader
+        ClassLoader jnlpClassLoader = WeldSEResourceLoader.getClassLoader();
+        try {
+            // Try to call com.sun.jnlp.JNLPClassLoader#getJarFile(URL) from JDK 6
+            Method m = jnlpClassLoader.getClass().getMethod("getJarFile", URL.class);
+            // returns a reference to the local cached copy of the JAR
+            ZipFile jarFile = (ZipFile) m.invoke(jnlpClassLoader, new URL(urlPath));
+            urlPath = jarFile.getName();
+        } catch (MalformedURLException mue) {
+            WeldSELogger.LOG.couldNotReadEntries(urlPath, mue);
+        } catch (NoSuchMethodException nsme) {
+            WeldSELogger.LOG.unexpectedClassLoader(nsme);
+        } catch (IllegalArgumentException iarge) {
+            WeldSELogger.LOG.unexpectedClassLoader(iarge);
+        } catch (InvocationTargetException ite) {
+            WeldSELogger.LOG.jnlpClassLoaderInternalException(ite);
+        } catch (Exception iacce) {
+            WeldSELogger.LOG.jnlpClassLoaderInvocationException(iacce);
+        }
         return urlPath;
     }
 
@@ -123,7 +202,6 @@ public class URLScanner {
     private String getId(String urlPath) {
         return urlPath;
     }
-
 
     /**
      * Determine resource type (eg: jar, file, bundle)

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/logging/WeldSELogger.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/logging/WeldSELogger.java
@@ -63,8 +63,9 @@ public interface WeldSELogger extends BasicLogger {
     @Message(id = 8, value = "Error loading file {0}", format = Format.MESSAGE_FORMAT)
     void errorLoadingFile(Object param1);
 
-    @Message(id = 9, value = "There is more than one beans.xml in the archive", format = Format.MESSAGE_FORMAT)
-    IllegalArgumentException tooManyBeansXml();
+    @LogMessage(level = Level.WARN)
+    @Message(id = 9, value = "Could not close the stream for of the jandex index file for {0}.", format = Format.MESSAGE_FORMAT)
+    void couldNotCloseStreamOfJandexIndex(Object param1, @Cause Throwable cause);
 
     @LogMessage(level = Level.WARN)
     @Message(id = 10, value = "Could not open the stream on the url {0} when adding to the jandex index.", format = Format.MESSAGE_FORMAT)
@@ -97,5 +98,4 @@ public interface WeldSELogger extends BasicLogger {
 
     @Message(id = 19, value = "Jandex index is null in the constructor of class: {0}", format = Format.MESSAGE_FORMAT)
     IllegalStateException jandexIndexNotCreated(Object param1);
-
 }

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/arquillian/WeldSEDeployableContainer.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/arquillian/WeldSEDeployableContainer.java
@@ -40,7 +40,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptor;
-import org.jboss.weld.bootstrap.api.Bootstrap;
 import org.jboss.weld.bootstrap.api.CDI11Bootstrap;
 import org.jboss.weld.bootstrap.spi.Deployment;
 import org.jboss.weld.environment.se.Weld;

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/Apartment.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/Apartment.java
@@ -1,0 +1,5 @@
+package org.jboss.weld.environment.se.test.beandiscovery;
+
+public class Apartment {
+
+}

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/BeanDiscoveryWithJandexIndexTest.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/BeanDiscoveryWithJandexIndexTest.java
@@ -1,0 +1,100 @@
+package org.jboss.weld.environment.se.test.beandiscovery;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.JarIndexer;
+import org.jboss.jandex.Result;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.weld.environment.se.test.arquillian.WeldSEClassPath;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class BeanDiscoveryWithJandexIndexTest {
+    @Deployment
+    public static Archive<?> getDeployment() {
+        WeldSEClassPath archives = ShrinkWrap.create(WeldSEClassPath.class);
+        JavaArchive archive01 = ShrinkWrap.create(BeanArchive.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(EmptyAsset.INSTANCE, "jandex.idx") // simulate broken index
+                .addClasses(Dog.class, Cat.class, Cow.class);
+        archives.add(archive01);
+        
+        JavaArchive archive02 = ShrinkWrap.create(BeanArchive.class)
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ANNOTATED), "beans.xml")
+                .addClasses(Plant.class, Tree.class, Stone.class);
+        archive02.addAsManifestResource(createJandexIndexAsset(archive02), "jandex.idx");
+        archives.add(archive02);
+        
+        JavaArchive archive03 = ShrinkWrap.create(BeanArchive.class)
+                .addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL), "beans.xml")
+                .addClasses(Flat.class, House.class, Apartment.class);
+        archive03.addAsManifestResource(createJandexIndexAsset(archive03), "jandex.idx");
+        archives.add(archive03);        
+        return archives;
+    }
+
+    /**
+     * Exports the JavaArchive to a temporary file and uses {@link JarIndexer} to write an 
+     * jandex.idx file.  
+     */
+    private static Asset createJandexIndexAsset(JavaArchive archiveToIndex) {
+        Asset jandexIndexAsset = EmptyAsset.INSTANCE;
+        try {
+            final File tempJarFile = File.createTempFile("BeanDiscoveryWithJandexIndexTest", ".jar");
+            tempJarFile.deleteOnExit();
+            
+            archiveToIndex.as(ZipExporter.class).exportTo(tempJarFile, true);
+            
+            final Indexer indexer = new Indexer();
+            final Result result = JarIndexer.createJarIndex(tempJarFile, indexer, false, false, false);
+            
+            final File indexFile = result.getOutputFile();
+            indexFile.deleteOnExit();
+            
+            jandexIndexAsset = new FileAsset(indexFile);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        
+        return jandexIndexAsset;
+    }
+
+    @Test
+    public void testIndexedAllBeanDiscoveryForBrokenIndex(BeanManager manager) {
+        assertEquals(1, manager.getBeans(Dog.class).size());
+        assertEquals(1, manager.getBeans(Cat.class).size());
+        assertEquals(1, manager.getBeans(Cow.class).size());
+    }
+    
+    @Test
+    public void testIndexedAnnotatedBeanDiscovery(BeanManager manager) {
+        assertEquals(1, manager.getBeans(Plant.class).size());
+        assertEquals(1, manager.getBeans(Tree.class).size());
+        assertEquals(0, manager.getBeans(Stone.class).size()); // not annotated!
+    }
+    
+    @Test
+    public void testIndexedAllBeanDiscovery(BeanManager manager) {
+        assertEquals(1, manager.getBeans(Flat.class).size());
+        assertEquals(1, manager.getBeans(House.class).size());
+        assertEquals(1, manager.getBeans(Apartment.class).size());
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/metadata/BeansXmlMergeUtil.java
+++ b/impl/src/main/java/org/jboss/weld/metadata/BeansXmlMergeUtil.java
@@ -1,0 +1,71 @@
+package org.jboss.weld.metadata;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.bootstrap.spi.BeansXml;
+import org.jboss.weld.bootstrap.spi.Filter;
+import org.jboss.weld.bootstrap.spi.Metadata;
+
+/**
+ * Utility class to merge beans.xml files.
+ * @author Stefan Großmann
+ */
+public class BeansXmlMergeUtil {
+    public BeansXml merge(final Iterable<BeansXml> beansXmls) {
+        return merge(beansXmls, false);
+    }
+
+    public BeansXml merge(final Iterable<BeansXml> beansXmls, final boolean removeDuplicates) {
+        final List<Metadata<String>> alternatives = new ArrayList<Metadata<String>>();
+        final List<Metadata<String>> alternativeStereotypes = new ArrayList<Metadata<String>>();
+        final List<Metadata<String>> decorators = new ArrayList<Metadata<String>>();
+        final List<Metadata<String>> interceptors = new ArrayList<Metadata<String>>();
+        final List<Metadata<Filter>> includes = new ArrayList<Metadata<Filter>>();
+        final List<Metadata<Filter>> excludes = new ArrayList<Metadata<Filter>>();
+
+        URL beansXmlUrl = null;
+        for (BeansXml beansXml : beansXmls) {
+            addTo(alternatives, beansXml.getEnabledAlternativeClasses(), removeDuplicates);
+            addTo(alternativeStereotypes, beansXml.getEnabledAlternativeStereotypes(), removeDuplicates);
+            addTo(decorators, beansXml.getEnabledDecorators(), removeDuplicates);
+            addTo(interceptors, beansXml.getEnabledInterceptors(), removeDuplicates);
+            includes.addAll(beansXml.getScanning().getIncludes());
+            excludes.addAll(beansXml.getScanning().getExcludes());
+
+            if (beansXml.getUrl() != null) {
+                /**
+                 * provided we are merging the content of multiple XML files, getBeansXml() returns an InputStream representing the last one
+                 */
+                beansXmlUrl = beansXml.getUrl();
+            }
+        }
+
+        return new BeansXmlImpl(alternatives, alternativeStereotypes, decorators, interceptors, new ScanningImpl(includes, excludes), beansXmlUrl,
+                BeanDiscoveryMode.ALL, null);
+    }
+
+    private void addTo(List<Metadata<String>> list, List<Metadata<String>> listToAdd, final boolean removeDuplicates) {
+        if (removeDuplicates) {
+            List<Metadata<String>> filteredListToAdd = new ArrayList<Metadata<String>>(listToAdd.size());
+            for (Metadata<String> metadata : listToAdd) {
+                if (!alreadyAdded(metadata, list)) {
+                    filteredListToAdd.add(metadata);
+                }
+            }
+            listToAdd = filteredListToAdd;
+        }
+        list.addAll(listToAdd);
+    }
+
+    private boolean alreadyAdded(Metadata<String> metadata, List<Metadata<String>> list) {
+        for (Metadata<String> existing : list) {
+            if (existing.getValue().equals(metadata.getValue())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/impl/src/test/java/org/jboss/weld/tests/unit/metadata/BeansXmlMergeUtilTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/metadata/BeansXmlMergeUtilTest.java
@@ -1,0 +1,127 @@
+package org.jboss.weld.tests.unit.metadata;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.bootstrap.spi.BeansXml;
+import org.jboss.weld.bootstrap.spi.ClassAvailableActivation;
+import org.jboss.weld.bootstrap.spi.Filter;
+import org.jboss.weld.bootstrap.spi.Metadata;
+import org.jboss.weld.bootstrap.spi.SystemPropertyActivation;
+import org.jboss.weld.metadata.BeansXmlImpl;
+import org.jboss.weld.metadata.BeansXmlMergeUtil;
+import org.jboss.weld.metadata.MetadataImpl;
+import org.jboss.weld.metadata.ScanningImpl;
+import org.junit.Test;
+
+public class BeansXmlMergeUtilTest {
+    private class FilterStub implements Filter {
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public Collection<Metadata<SystemPropertyActivation>> getSystemPropertyActivations() {
+            return null;
+        }
+
+        @Override
+        public Collection<Metadata<ClassAvailableActivation>> getClassAvailableActivations() {
+            return null;
+        }
+    }
+
+    @Test
+    public void testMergeEmptyBeansXML() {
+        final List<BeansXml> beansXMLFiles = Arrays.asList(BeansXml.EMPTY_BEANS_XML, BeansXml.EMPTY_BEANS_XML);
+        final BeansXml mergedBeansXml = new BeansXmlMergeUtil().merge(beansXMLFiles);
+        assertNotNull(mergedBeansXml);
+        assertNotNull(mergedBeansXml.getEnabledAlternativeClasses());
+        assertNotNull(mergedBeansXml.getEnabledAlternativeStereotypes());
+        assertNotNull(mergedBeansXml.getEnabledDecorators());
+        assertNotNull(mergedBeansXml.getEnabledInterceptors());
+        assertNotNull(mergedBeansXml.getScanning());
+        assertNotNull(mergedBeansXml.getScanning().getExcludes());
+        assertNotNull(mergedBeansXml.getScanning().getIncludes());
+    }
+
+    @Test
+    public void testMergeAll() {
+        final BeansXml beansXml1 = createBeansXmlTestInstance();
+        final BeansXml beansXml2 = createBeansXmlTestInstance();
+
+        final List<BeansXml> beansXMLFiles = Arrays.asList(beansXml1, beansXml2, BeansXml.EMPTY_BEANS_XML);
+        final BeansXml mergedBeansXml = new BeansXmlMergeUtil().merge(beansXMLFiles);
+
+        assertNotNull(mergedBeansXml);
+        assertNotNull(mergedBeansXml.getEnabledAlternativeClasses());
+        assertNotNull(mergedBeansXml.getEnabledAlternativeStereotypes());
+        assertNotNull(mergedBeansXml.getEnabledDecorators());
+        assertNotNull(mergedBeansXml.getEnabledInterceptors());
+        assertNotNull(mergedBeansXml.getScanning());
+        assertNotNull(mergedBeansXml.getScanning().getExcludes());
+        assertNotNull(mergedBeansXml.getScanning().getIncludes());
+
+        assertEquals(2, mergedBeansXml.getEnabledAlternativeClasses().size());
+        assertEquals(2, mergedBeansXml.getEnabledAlternativeStereotypes().size());
+        assertEquals(2, mergedBeansXml.getEnabledDecorators().size());
+        assertEquals(2, mergedBeansXml.getEnabledInterceptors().size());
+        assertEquals(2, mergedBeansXml.getScanning().getExcludes().size());
+        assertEquals(2, mergedBeansXml.getScanning().getIncludes().size());
+    }
+
+    @Test
+    public void testMergeWithoutDuplicates() {
+        final BeansXml beansXml1 = createBeansXmlTestInstance();
+        final BeansXml beansXml2 = createBeansXmlTestInstance();
+
+        final List<BeansXml> beansXMLFiles = Arrays.asList(beansXml1, beansXml2, BeansXml.EMPTY_BEANS_XML);
+        final BeansXml mergedBeansXml = new BeansXmlMergeUtil().merge(beansXMLFiles, true);
+
+        assertNotNull(mergedBeansXml);
+        assertNotNull(mergedBeansXml.getEnabledAlternativeClasses());
+        assertNotNull(mergedBeansXml.getEnabledAlternativeStereotypes());
+        assertNotNull(mergedBeansXml.getEnabledDecorators());
+        assertNotNull(mergedBeansXml.getEnabledInterceptors());
+        assertNotNull(mergedBeansXml.getScanning());
+        assertNotNull(mergedBeansXml.getScanning().getExcludes());
+        assertNotNull(mergedBeansXml.getScanning().getIncludes());
+
+        assertEquals(1, mergedBeansXml.getEnabledAlternativeClasses().size());
+        assertEquals(1, mergedBeansXml.getEnabledAlternativeStereotypes().size());
+        assertEquals(1, mergedBeansXml.getEnabledDecorators().size());
+        assertEquals(1, mergedBeansXml.getEnabledInterceptors().size());
+    }
+
+    public BeansXml createBeansXmlTestInstance() {
+        final MetadataImpl<String> alternative = new MetadataImpl<String>("some.package.SomeAlternative", "C:\temp");
+        final MetadataImpl<String> stereoType = new MetadataImpl<String>("some.package.SomeStereotype", "C:\temp");
+        final MetadataImpl<String> decorator = new MetadataImpl<String>("some.package.SomeDecorator", "C:\temp");
+        final MetadataImpl<String> interceptor = new MetadataImpl<String>("some.package.SomeInterceptor", "C:\temp");
+        final Metadata<Filter> include = new MetadataImpl<Filter>(new FilterStub(), "C:\temp");
+        final Metadata<Filter> exclude = new MetadataImpl<Filter>(new FilterStub(), "C:\temp");
+
+        final List<Metadata<String>> alternativesClasses = new ArrayList<Metadata<String>>();
+        final List<Metadata<String>> alternativeStereotypes = new ArrayList<Metadata<String>>();
+        final List<Metadata<String>> decorators = new ArrayList<Metadata<String>>();
+        final List<Metadata<String>> interceptors = new ArrayList<Metadata<String>>();
+        final List<Metadata<Filter>> includes = new ArrayList<Metadata<Filter>>();
+        final List<Metadata<Filter>> excludes = new ArrayList<Metadata<Filter>>();
+
+        alternativesClasses.add(alternative);
+        alternativeStereotypes.add(stereoType);
+        decorators.add(decorator);
+        interceptors.add(interceptor);
+        includes.add(include);
+        excludes.add(exclude);
+
+        return new BeansXmlImpl(alternativesClasses, alternativeStereotypes, decorators, interceptors, new ScanningImpl(includes, excludes), null,
+                BeanDiscoveryMode.ALL, "1.1");
+    }
+}


### PR DESCRIPTION
The proposed code change with this pull request helps to improve the memory consumption of Weld SE during and after the start-up phase.

In our application we currently have (just) 22 JAR files with a beans.xml file. In future, this number should grow. If we start-up Weld SE in this environment, our application consumes additional 30 MB memory (which is an increase of 50 percent).

During the start-up, Weld SE scans all jars with a beans.xml file completely, using java.util.zip.ZipFile. With a memory profiler we can see that during the initialization, the memory consumption raises up to 300 MB, before it decreases again.

The following pull request contains a proposal to improve the start-up behaviour of Weld SE. It contains the following enhancements:
- If an archive contained a beans.xml with bean-discovery-mode=none is was completely scanned by URLScanner.scan(). The scan-result was returned in a Collection. After the scanning, this result was never used. In this pull request, URLScanner is adapted, so that an archive with bean-discovery-mode=none is not scanned anymore.
- The Weld SE Startup is now able to use jandex.idx files at the meta-inf directory of an archive (if Jandex is in the classpath). The implementation first checks if an index is available and usable. If yes, Weld SE just need to load the index instead or reading the complete archive.
- The beans.xml files are not re-parsed during a merge operation any-more. The new class BeansXMLMergeUtil is able to do the merge without re-parsing. 

Especially in bigger Java SE applications, the memory consumption and start-up performance of the CDI Container can become a show stopper.  The proposed changes can help to solve this problem.
