### PR TITLE
Remove unnecessary dependency in TCK runner.

### DIFF
--- a/jboss-as/jboss-as-7/pom.xml
+++ b/jboss-as/jboss-as-7/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.jboss.weld</groupId>
     <artifactId>weld-core-jboss-as7-updater</artifactId>
     <packaging>pom</packaging>
-    <version>1.1.24-SNAPSHOT</version>
+    <version>1.1.25-SNAPSHOT</version>
 
     <name>JBoss AS7 Updater</name>
 

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -38,13 +38,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
-            <classifier>jdk15</classifier>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-spi</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
This breaks "write-artifacts-to-disk" maven profile execution.
