### PR TITLE
Old style naming for documentation for compatibility with existing links on  http://weld.cdi-spec.org

### DIFF
--- a/docs/reference/src/main/asciidoc/beans.asciidoc
+++ b/docs/reference/src/main/asciidoc/beans.asciidoc
@@ -1,3 +1,4 @@
+[[beanscdi]]
 == More about beans
 
 A bean is usually an application class that contains business logic. It

--- a/docs/reference/src/main/asciidoc/configure.asciidoc
+++ b/docs/reference/src/main/asciidoc/configure.asciidoc
@@ -1,3 +1,4 @@
+[[configure]]
 == Configuration
 
 === Excluding classes from scanning and deployment

--- a/docs/reference/src/main/asciidoc/contexts.asciidoc
+++ b/docs/reference/src/main/asciidoc/contexts.asciidoc
@@ -1,3 +1,4 @@
+[[contexts]]
 == Context Management
 
 === Managing the built in contexts

--- a/docs/reference/src/main/asciidoc/decorators.asciidoc
+++ b/docs/reference/src/main/asciidoc/decorators.asciidoc
@@ -1,3 +1,4 @@
+[[decorators]]
 == Decorators
 
 Interceptors are a powerful way to capture and separate concerns which

--- a/docs/reference/src/main/asciidoc/ee.asciidoc
+++ b/docs/reference/src/main/asciidoc/ee.asciidoc
@@ -1,3 +1,4 @@
+[[ee]]
 == Java EE integration
 
 CDI is fully integrated into the Java EE environment. Beans have access

--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -1,3 +1,4 @@
+[[environments]]
 == Application servers and environments supported by Weld
 
 === Using Weld with WildFly

--- a/docs/reference/src/main/asciidoc/events.asciidoc
+++ b/docs/reference/src/main/asciidoc/events.asciidoc
@@ -1,3 +1,4 @@
+[[events]]
 == Events
 
 Dependency injection enables loose-coupling by allowing the

--- a/docs/reference/src/main/asciidoc/example.asciidoc
+++ b/docs/reference/src/main/asciidoc/example.asciidoc
@@ -1,3 +1,4 @@
+[[example]]
 == JSF web application example
 
 Let's illustrate these ideas with a full example. We're going to

--- a/docs/reference/src/main/asciidoc/extend.asciidoc
+++ b/docs/reference/src/main/asciidoc/extend.asciidoc
@@ -1,3 +1,4 @@
+[[extend]]
 == Portable extensions
 
 CDI is intended to be a foundation for frameworks, extensions and

--- a/docs/reference/src/main/asciidoc/gettingstarted.asciidoc
+++ b/docs/reference/src/main/asciidoc/gettingstarted.asciidoc
@@ -1,3 +1,4 @@
+[[gettingstarted]]
 == Getting started with Weld
 
 Weld comes with a number of examples. We recommend you start with

--- a/docs/reference/src/main/asciidoc/injection.asciidoc
+++ b/docs/reference/src/main/asciidoc/injection.asciidoc
@@ -1,3 +1,4 @@
+[[injection]]
 == Dependency injection and programmatic lookup
 
 One of the most significant features of CDI—certainly the most

--- a/docs/reference/src/main/asciidoc/interceptors.asciidoc
+++ b/docs/reference/src/main/asciidoc/interceptors.asciidoc
@@ -1,3 +1,4 @@
+[[interceptors]]
 == Interceptors
 
 Interceptor functionality is defined in the Java Interceptors

--- a/docs/reference/src/main/asciidoc/intro.asciidoc
+++ b/docs/reference/src/main/asciidoc/intro.asciidoc
@@ -1,3 +1,4 @@
+[[intro]]
 == Introduction
 
 So you're keen to get started writing your first bean? Or perhaps you're

--- a/docs/reference/src/main/asciidoc/next.asciidoc
+++ b/docs/reference/src/main/asciidoc/next.asciidoc
@@ -1,3 +1,4 @@
+[[next]]
 == Next steps
 
 A lot of additional information on CDI can be found online. Regardless,

--- a/docs/reference/src/main/asciidoc/part1.asciidoc
+++ b/docs/reference/src/main/asciidoc/part1.asciidoc
@@ -1,3 +1,4 @@
+[[part-1]]
 = Beans
 
 [partintro]

--- a/docs/reference/src/main/asciidoc/part2.asciidoc
+++ b/docs/reference/src/main/asciidoc/part2.asciidoc
@@ -1,3 +1,4 @@
+[[part-2]]
 = Getting Start with Weld, the CDI Reference Implementation
 
 [partintro]

--- a/docs/reference/src/main/asciidoc/part3.asciidoc
+++ b/docs/reference/src/main/asciidoc/part3.asciidoc
@@ -1,3 +1,4 @@
+[[part-3]]
 = Loose coupling with strong typing
 
 [partintro]

--- a/docs/reference/src/main/asciidoc/part4.asciidoc
+++ b/docs/reference/src/main/asciidoc/part4.asciidoc
@@ -1,3 +1,4 @@
+[[part-4]]
 = CDI and the Java EE ecosystem
 
 [partintro]

--- a/docs/reference/src/main/asciidoc/part5.asciidoc
+++ b/docs/reference/src/main/asciidoc/part5.asciidoc
@@ -1,3 +1,4 @@
+[[part-5]]
 = Weld Reference Guide
 
 [partintro]

--- a/docs/reference/src/main/asciidoc/resources.asciidoc
+++ b/docs/reference/src/main/asciidoc/resources.asciidoc
@@ -1,3 +1,4 @@
+[[resources]]
 == Java EE component environment resources
 
 Java EE 5 already introduced some limited support for dependency

--- a/docs/reference/src/main/asciidoc/ri-spi.asciidoc
+++ b/docs/reference/src/main/asciidoc/ri-spi.asciidoc
@@ -1,3 +1,4 @@
+[[ri-spi]]
 [appendix]
 == Integrating Weld into other environments
 

--- a/docs/reference/src/main/asciidoc/scopescontexts.asciidoc
+++ b/docs/reference/src/main/asciidoc/scopescontexts.asciidoc
@@ -1,3 +1,4 @@
+[[scopescontexts]]
 == Scopes and contexts
 
 So far, we've seen a few examples of _scope type annotations_. The scope

--- a/docs/reference/src/main/asciidoc/specialization.asciidoc
+++ b/docs/reference/src/main/asciidoc/specialization.asciidoc
@@ -1,3 +1,4 @@
+[[specialization]]
 == Specialization, inheritance and alternatives
 
 When you first start developing with CDI, you'll likely be dealing only

--- a/docs/reference/src/main/asciidoc/stereotypes.asciidoc
+++ b/docs/reference/src/main/asciidoc/stereotypes.asciidoc
@@ -1,3 +1,4 @@
+[[stereotypes]]
 == Stereotypes
 
 The CDI specification defines a stereotype as follows:

--- a/docs/reference/src/main/asciidoc/weldexamples.asciidoc
+++ b/docs/reference/src/main/asciidoc/weldexamples.asciidoc
@@ -1,3 +1,4 @@
+[[weldexamples]]
 == Diving into the Weld examples
 
 It's time to pull the covers back and dive into the internals of Weld


### PR DESCRIPTION
Fixing for broken links on weld website. (Try link  "reference documentation" on main page).
