### PR TITLE
WELD-1746 Don't destroy ended conversations outside of synchronized block

### DIFF
--- a/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
+++ b/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
@@ -277,7 +277,8 @@ public abstract class AbstractConversationContext<R, S> extends AbstractBoundCon
             }
 
             try {
-                if (getCurrentConversation().isTransient()) {
+                if (getCurrentConversation().isTransient() && getRequestAttribute(getRequest(), ConversationNamingScheme.PARAMETER_NAME) != null) {
+                    // WELD-1746 Don't destroy ended conversations - these must be destroyed in a synchronized block - see also cleanUpConversationMap()
                     destroy();
                 } else {
                     // Update the conversation timestamp


### PR DESCRIPTION
This fix should be applied to 2.2 branch as well.
