### PR TITLE
optimization for composing strings

### DIFF
--- a/impl/src/main/java/org/jboss/weld/injection/producer/AbstractMemberProducer.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/AbstractMemberProducer.java
@@ -191,7 +191,7 @@ public abstract class AbstractMemberProducer<X, T> extends AbstractProducer<T> {
         } else {
                 result.append(getBean());
             }
-            result.append(" declared on " + getDeclaringBean());
+            result.append(" declared on ").append(getDeclaringBean());
         }
         return result.toString();
     }

--- a/impl/src/main/java/org/jboss/weld/resolution/NameBasedResolver.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/NameBasedResolver.java
@@ -96,7 +96,7 @@ public class NameBasedResolver {
     public String toString() {
         StringBuilder buffer = new StringBuilder();
         buffer.append("Resolver\n");
-        buffer.append("Resolved names points: " + resolvedNames.size() + "\n");
+        buffer.append("Resolved names points: ").append(resolvedNames.size()).append('\n');
         return buffer.toString();
     }
 

--- a/impl/src/main/java/org/jboss/weld/resolution/TypeSafeResolver.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/TypeSafeResolver.java
@@ -157,9 +157,9 @@ public abstract class TypeSafeResolver<R extends Resolvable, T, C extends Collec
      */
     @Override
     public String toString() {
-        StringBuilder buffer = new StringBuilder();
-        buffer.append("Resolver\n");
-        buffer.append("Resolved injection points: " + resolved.size() + "\n");
-        return buffer.toString();
+        StringBuilder sb = new StringBuilder();
+        sb.append("Resolver\n");
+        sb.append("Resolved injection points: ").append(resolved.size()).append('\n');
+        return sb.toString();
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/conversation/event/Servlet.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/conversation/event/Servlet.java
@@ -48,11 +48,11 @@ public class Servlet extends HttpServlet {
         } else if (uri.contains("/end")) {
             conversation.end();
         }
-        resp.getWriter().append("Initialized conversations:" + observer.getInitializedConversationCount().get());
-        resp.getWriter().append("\n");
-        resp.getWriter().append("Destroyed conversations:" + observer.getDestroyedConversationCount().get());
-        resp.getWriter().append("\n");
-        resp.getWriter().append("cid:" + conversation.getId());
+        resp.getWriter().append("Initialized conversations:").append(Integer.toString(observer.getInitializedConversationCount().get()));
+        resp.getWriter().append('\n');
+        resp.getWriter().append("Destroyed conversations:").append(Integer.toString(observer.getDestroyedConversationCount().get()));
+        resp.getWriter().append('\n');
+        resp.getWriter().append("cid:").append(conversation.getId());
         resp.setContentType("text/plain");
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/conversation/servlet/Servlet.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/conversation/servlet/Servlet.java
@@ -88,18 +88,18 @@ public class Servlet extends HttpServlet {
     }
 
     private void printInfo(PrintWriter writer) {
-        writer.append("message: " + message.getValue());
-        writer.append("\n");
-        writer.append("cid: [" + conversation.getId());
-        writer.append("]");
-        writer.append("\n");
-        writer.append("transient: " + conversation.isTransient());
-        writer.append("\n");
+        writer.append("message: ").append(message.getValue());
+        writer.append('\n');
+        writer.append("cid: [").append(conversation.getId());
+        writer.append(']');
+        writer.append('\n');
+        writer.append("transient: ").append(Boolean.toString(conversation.isTransient()));
+        writer.append('\n');
     }
 
     private void printSessionIds(PrintWriter writer, Set<String> ids) {
         for (String id : ids) {
-            writer.append("<" + id + ">");
+            writer.append('<').append(id).append('>');
         }
     }
     

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/request/event/Servlet.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/request/event/Servlet.java
@@ -34,9 +34,9 @@ public class Servlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        resp.getWriter().append("Initialized requests:" + observer.getInitializedRequestCount().get());
-        resp.getWriter().append("\n");
-        resp.getWriter().append("Destroyed requests:" + observer.getDestroyedRequestCount().get());
+        resp.getWriter().append("Initialized requests:").append(Integer.toString(observer.getInitializedRequestCount().get()));
+        resp.getWriter().append('\n');
+        resp.getWriter().append("Destroyed requests:").append(Integer.toString(observer.getDestroyedRequestCount().get()));
         resp.setContentType("text/plain");
     }
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/event/Servlet.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/event/Servlet.java
@@ -45,9 +45,9 @@ public class Servlet extends HttpServlet {
                 throw new RuntimeException("@Destroyed(SessionScoped.class) called before the session context was actually destroyed");
             }
         }
-        resp.getWriter().append("Initialized sessions:" + observer.getInitializedSessionCount().get());
-        resp.getWriter().append("\n");
-        resp.getWriter().append("Destroyed sessions:" + observer.getDestroyedSessionCount().get());
+        resp.getWriter().append("Initialized sessions:").append(Integer.toString(observer.getInitializedSessionCount().get()));
+        resp.getWriter().append('\n');
+        resp.getWriter().append("Destroyed sessions:").append(Integer.toString(observer.getDestroyedSessionCount().get()));
         resp.setContentType("text/plain");
     }
 }


### PR DESCRIPTION
Based in discussion on OpenJDK:
https://bugs.openjdk.java.net/browse/JDK-8055723

To avoid an extra StringBuilder created
for the purpose of concatenating. So it will save memory and will faster
than concat String.

And talking with compiler team, it's will not to compiler optimization, so we need to do manually.
