### PR TITLE
JAVASERVERFACES-3240 is fixed in Mojarra 2.2.7

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/AfterBeanDiscoveryImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/AfterBeanDiscoveryImpl.java
@@ -145,10 +145,9 @@ public class AfterBeanDiscoveryImpl extends AbstractBeanDiscoveryEvent implement
         if (scope == null) {
             throw ContextLogger.LOG.contextHasNullScope(context);
         }
-        // TODO: re-enable this once Mojarra is fixed - https://java.net/jira/browse/JAVASERVERFACES-3240
-        //  if (!getBeanManager().isScope(scope)) {
-        //      throw MetadataLogger.LOG.contextGetScopeIsNotAScope(scope, context);
-        //  }
+        if (!getBeanManager().isScope(scope)) {
+            throw MetadataLogger.LOG.contextGetScopeIsNotAScope(scope, context);
+        }
         getBeanManager().addContext(context);
     }
 


### PR DESCRIPTION
Note that WildFly `8.x` branch is currently using 2.2.8-jbossorg-1, `master` branch the 2.2.8-jbossorg-2.
