### PR TITLE
WELD-1776 ManagerObjectFactory not working on Windows

### DIFF
--- a/impl/src/main/java/org/jboss/weld/resources/ManagerObjectFactory.java
+++ b/impl/src/main/java/org/jboss/weld/resources/ManagerObjectFactory.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.weld.resources;
 
+import java.io.File;
 import java.util.Hashtable;
 import java.util.Map.Entry;
 
@@ -35,7 +36,10 @@ public class ManagerObjectFactory implements ObjectFactory {
      * The id of a bean deployment archive whose BeanManager should be used as a result of a JNDI "java:comp/env/BeanManager" lookup.
      */
     public static final String FLAT_BEAN_DEPLOYMENT_ID = "flat";
+
     public static final String WEB_INF_CLASSES = "/WEB-INF/classes";
+
+    public static final String WEB_INF_CLASSES_FILE_PATH = File.separatorChar + "WEB-INF" + File.separatorChar + "classes";
 
     private final String contextId;
 
@@ -51,7 +55,7 @@ public class ManagerObjectFactory implements ObjectFactory {
         if (Container.available(contextId)) {
             for (Entry<BeanDeploymentArchive, BeanManagerImpl> entry : Container.instance(contextId).beanDeploymentArchives().entrySet()) {
                 BeanDeploymentArchive bda = entry.getKey();
-                if (bda.getId().equals(FLAT_BEAN_DEPLOYMENT_ID) || bda.getId().contains(WEB_INF_CLASSES)) {
+                if (bda.getId().equals(FLAT_BEAN_DEPLOYMENT_ID) || bda.getId().contains(WEB_INF_CLASSES_FILE_PATH) || bda.getId().contains(WEB_INF_CLASSES)) {
                     return entry.getValue().getCurrent();
                 }
             }


### PR DESCRIPTION
For Weld Servlet BeanDeploymentArchive.getId() contains a file path
provided a WAR archive is extracted to the filesystem, otherwise
"/WEB-INF/classes" is used.
