### PR TITLE
Using Collection.addAll instead of add manually

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/AnnotatedTypes.java
+++ b/impl/src/main/java/org/jboss/weld/util/AnnotatedTypes.java
@@ -273,9 +273,7 @@ public class AnnotatedTypes {
             builder.append('(');
             Method[] declaredMethods = AccessController.doPrivileged(new GetDeclaredMethodsAction(a.annotationType()));
             List<Method> methods = new ArrayList<Method>(declaredMethods.length);
-            for (Method m : declaredMethods) {
-                methods.add(m);
-            }
+            Collections.addAll(methods, declaredMethods);
             Collections.sort(methods, MethodComparator.INSTANCE);
 
             for (int i = 0; i < methods.size(); ++i) {

--- a/impl/src/main/java/org/jboss/weld/util/collections/Arrays2.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/Arrays2.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Array;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -46,9 +47,7 @@ public class Arrays2 {
 
     public static <T> Set<T> asSet(T... array) {
         Set<T> result = new HashSet<T>(array.length);
-        for (T a : array) {
-            result.add(a);
-        }
+        Collections.addAll(result, array);
         return result;
     }
 

--- a/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/AbstractImmutableListTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/AbstractImmutableListTest.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.tests.unit.util.collections;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -41,9 +42,7 @@ public abstract class AbstractImmutableListTest extends AbstractImmutableCollect
     @Override
     protected List<String> getDefaultCollection() {
         List<String> result = new ArrayList<>();
-        for (String item : getData()) {
-            result.add(item);
-        }
+        Collections.addAll(result, getData());
         return result;
     }
 

--- a/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/AbstractImmutableSetTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/AbstractImmutableSetTest.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.weld.tests.unit.util.collections;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -38,9 +39,7 @@ public abstract class AbstractImmutableSetTest extends AbstractImmutableCollecti
     @Override
     protected Set<String> getDefaultCollection() {
         Set<String> result = new LinkedHashSet<>();
-        for (String item : getData()) {
-            result.add(item);
-        }
+        Collections.addAll(result, getData());
         return result;
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processSyntheticAnnotatedType/AnnotatedTypeWrapper.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processSyntheticAnnotatedType/AnnotatedTypeWrapper.java
@@ -34,9 +34,7 @@ public class AnnotatedTypeWrapper<T> extends ForwardingAnnotatedType<T> {
     public AnnotatedTypeWrapper(AnnotatedType<T> delegate, Annotation... annotations) {
         this.delegate = delegate;
         this.annotations = new HashSet<Annotation>(delegate.getAnnotations());
-        for (Annotation annotation : annotations) {
-            this.annotations.add(annotation);
-        }
+        Collections.addAll(this.annotations, annotations);
     }
 
     @Override

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/extension/bean/OrangeBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/specialization/extension/bean/OrangeBean.java
@@ -44,9 +44,7 @@ public class OrangeBean implements Bean<Orange> {
     @SuppressWarnings("unchecked")
     private <T> Set<T> immutableSet(T... items) {
         Set<T> set = new HashSet<T>();
-        for (T item : items) {
-            set.add(item);
-        }
+        Collections.addAll(set, items);
         return Collections.unmodifiableSet(set);
     }
 

--- a/tests-common/src/main/java/org/jboss/weld/test/util/annotated/TestTypeClosureBuilder.java
+++ b/tests-common/src/main/java/org/jboss/weld/test/util/annotated/TestTypeClosureBuilder.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.test.util.annotated;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -36,16 +37,12 @@ class TestTypeClosureBuilder {
             c = c.getSuperclass();
         }
         while (c != null);
-        for (Class<?> i : beanType.getInterfaces()) {
-            types.add(i);
-        }
+        Collections.addAll(types, beanType.getInterfaces());
         return this;
     }
 
     public TestTypeClosureBuilder addInterfaces(Class<?> beanType) {
-        for (Class<?> i : beanType.getInterfaces()) {
-            types.add(i);
-        }
+        Collections.addAll(types, beanType.getInterfaces());
         return this;
     }
 


### PR DESCRIPTION
Using Collection.addAll instead of add manually. This way is cleaner and some documentations say it is faster than manual copy.
