### PR TITLE
Suggestion: uses the @SafeVarags

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/collections/Arrays2.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/Arrays2.java
@@ -45,6 +45,7 @@ public class Arrays2 {
         return containsAll(array, values) && array.length == values.length;
     }
 
+    @SafeVarargs
     public static <T> Set<T> asSet(T... array) {
         Set<T> result = new HashSet<T>(array.length);
         Collections.addAll(result, array);

--- a/impl/src/main/java/org/jboss/weld/util/collections/Sets.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/Sets.java
@@ -39,6 +39,7 @@ public final class Sets {
      * @param elements
      * @return
      */
+    @SafeVarargs
     public static <E> HashSet<E> newHashSet(E... elements) {
         HashSet<E> set = new HashSet<>(elements.length);
         Collections.addAll(set, elements);

--- a/tests-common/src/main/java/org/jboss/weld/test/util/Utils.java
+++ b/tests-common/src/main/java/org/jboss/weld/test/util/Utils.java
@@ -58,6 +58,7 @@ public class Utils {
      * @param annotationTypes The annotations to match
      * @return True if match, false otherwise
      */
+    @SafeVarargs
     public static boolean annotationSetMatches(Set<? extends Annotation> annotations, Class<? extends Annotation>... annotationTypes) {
         List<Class<? extends Annotation>> annotationTypeList = new ArrayList<Class<? extends Annotation>>();
         annotationTypeList.addAll(Arrays.asList(annotationTypes));


### PR DESCRIPTION
 @SafeVarargs annotation suppresses unchecked warnings about parameterized array creation at call sites, that was born in Java 7.
