### PR TITLE
WELD-1789 Disable injectable reference lookup optimization by default

### DIFF
--- a/impl/src/main/java/org/jboss/weld/SystemPropertiesConfiguration.java
+++ b/impl/src/main/java/org/jboss/weld/SystemPropertiesConfiguration.java
@@ -35,17 +35,22 @@ public final class SystemPropertiesConfiguration {
 
     public static final String CLIENT_PROXY_DUMP_PATH = "org.jboss.weld.proxy.dump";
 
+    public static final String INJECTABLE_REFERENCE_OPTIMIZATION = "org.jboss.weld.injectableReferenceOptimization";
+
     public static final SystemPropertiesConfiguration INSTANCE = new SystemPropertiesConfiguration();
 
-    private boolean xmlValidationDisabled;
+    private final boolean xmlValidationDisabled;
 
-    private boolean nonPortableModeEnabled;
+    private final boolean nonPortableModeEnabled;
 
     private final File proxyDumpPath;
+
+    private final boolean injectableReferenceOptimization;
 
     private SystemPropertiesConfiguration() {
         xmlValidationDisabled = initBooleanSystemProperty(DISABLE_XML_VALIDATION_KEY, false);
         nonPortableModeEnabled = initBooleanSystemProperty(NON_PORTABLE_MODE_KEY, false);
+        injectableReferenceOptimization = initBooleanSystemProperty(INJECTABLE_REFERENCE_OPTIMIZATION, false);
 
         String dumpPathString = AccessController.doPrivileged(new GetSystemPropertyAction(CLIENT_PROXY_DUMP_PATH));
         if (dumpPathString != null && !dumpPathString.isEmpty()) {
@@ -91,6 +96,13 @@ public final class SystemPropertiesConfiguration {
      */
     public boolean isNonPortableModeEnabled() {
         return nonPortableModeEnabled;
+    }
+
+    /**
+     * @return <code>true</code> if the injectable reference lookup optimization is enabled, <code>false</code> otherwise
+     */
+    public boolean isInjectableReferenceOptimizationEnabled() {
+        return injectableReferenceOptimization;
     }
 
     private boolean initBooleanSystemProperty(String key, boolean defaultValue) {

--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -68,6 +68,7 @@ import javax.enterprise.inject.spi.ProducerFactory;
 import javax.enterprise.util.TypeLiteral;
 
 import org.jboss.weld.Container;
+import org.jboss.weld.SystemPropertiesConfiguration;
 import org.jboss.weld.annotated.AnnotatedTypeValidator;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedField;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedMember;
@@ -751,14 +752,14 @@ public class BeanManagerImpl implements WeldManager, Serializable {
                 requestedType = injectionPoint.getType();
             }
 
-            if (injectionPoint != null && injectionPoint.getBean() != null) {
+            if (SystemPropertiesConfiguration.INSTANCE.isInjectableReferenceOptimizationEnabled() && injectionPoint != null && injectionPoint.getBean() != null) {
                 // For certain combinations of scopes, the container is permitted to optimize an injectable reference lookup
                 // This should also partially solve circular @PostConstruct invocation
                 CreationalContextImpl<?> weldCreationalContext = null;
                 Bean<?> bean = injectionPoint.getBean();
 
                 // Do not optimize for self injection
-                if(!bean.equals(resolvedBean)) {
+                if (!bean.equals(resolvedBean)) {
 
                     if (creationalContext instanceof CreationalContextImpl) {
                         weldCreationalContext = (CreationalContextImpl<?>) creationalContext;
@@ -776,10 +777,10 @@ public class BeanManagerImpl implements WeldManager, Serializable {
                             }
                         }
                         Context context = internalGetContext(resolvedBean.getScope());
-                        if(context != null) {
+                        if (context != null) {
                             @java.lang.SuppressWarnings({ "unchecked", "rawtypes" })
-                            final Object existinInstance = context.get(Reflections.<Contextual>cast(resolvedBean));
-                            if(existinInstance != null) {
+                            final Object existinInstance = context.get(Reflections.<Contextual> cast(resolvedBean));
+                            if (existinInstance != null) {
                                 return existinInstance;
                             }
                         }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationApplicationTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationApplicationTest.java
@@ -19,6 +19,7 @@ package org.jboss.weld.tests.proxy.client.optimization;
 import static org.junit.Assert.assertNotNull;
 
 import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,6 +28,8 @@ import org.junit.runner.RunWith;
  * @author Martin Kouba
  * @see WELD-1659
  */
+//We have to ignore this test until we have a solution to set/unset system properties for the JVM of the managed container
+@Ignore("WELD-1789")
 @RunWith(Arquillian.class)
 public class InjectableReferenceOptimizationApplicationTest extends InjectableReferenceOptimizationTestBase {
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationConversationTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationConversationTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,6 +29,8 @@ import org.junit.runner.RunWith;
  * @author Martin Kouba
  * @see WELD-1659
  */
+//We have to ignore this test until we have a solution to set/unset system properties for the JVM of the managed container
+@Ignore("WELD-1789")
 @RunWith(Arquillian.class)
 public class InjectableReferenceOptimizationConversationTest extends InjectableReferenceOptimizationTestBase {
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationDependentTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationDependentTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,6 +29,8 @@ import org.junit.runner.RunWith;
  * @author Martin Kouba
  * @see WELD-1659
  */
+//We have to ignore this test until we have a solution to set/unset system properties for the JVM of the managed container
+@Ignore("WELD-1789")
 @RunWith(Arquillian.class)
 public class InjectableReferenceOptimizationDependentTest extends InjectableReferenceOptimizationTestBase {
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationRequestTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationRequestTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -28,6 +29,8 @@ import org.junit.runner.RunWith;
  * @author Martin Kouba
  * @see WELD-1659
  */
+// We have to ignore this test until we have a solution to set/unset system properties for the JVM of the managed container
+@Ignore("WELD-1789")
 @RunWith(Arquillian.class)
 public class InjectableReferenceOptimizationRequestTest extends InjectableReferenceOptimizationTestBase {
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationSessionTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/client/optimization/InjectableReferenceOptimizationSessionTest.java
@@ -19,6 +19,7 @@ package org.jboss.weld.tests.proxy.client.optimization;
 import static org.junit.Assert.assertNotNull;
 
 import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -27,6 +28,8 @@ import org.junit.runner.RunWith;
  * @author Martin Kouba
  * @see WELD-1659
  */
+//We have to ignore this test until we have a solution to set/unset system properties for the JVM of the managed container
+@Ignore("WELD-1789")
 @RunWith(Arquillian.class)
 public class InjectableReferenceOptimizationSessionTest extends InjectableReferenceOptimizationTestBase {
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/resolution/circular/CircularDependencyTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/resolution/circular/CircularDependencyTest.java
@@ -24,9 +24,12 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+// We have to ignore this test until we have a solution to set/unset system properties for the JVM of the managed container
+@Ignore("WELD-1789")
 @RunWith(Arquillian.class)
 public class CircularDependencyTest {
 


### PR DESCRIPTION
- it's possible to enable the optimization by setting the system property `org.jboss.weld.injectableReferenceOptimization` to true
