### PR TITLE
remove unnecessary extends Object

### DIFF
--- a/impl/src/main/java/org/jboss/weld/interceptor/proxy/SimpleInvocationContext.java
+++ b/impl/src/main/java/org/jboss/weld/interceptor/proxy/SimpleInvocationContext.java
@@ -136,7 +136,7 @@ public class SimpleInvocationContext implements InvocationContext {
                     Class<?> methodParameterClass = parameterTypes[i];
                     if (params[i] != null) {
                         // identity ok
-                        Class<? extends Object> newArgumentClass = params[i].getClass();
+                        Class<?> newArgumentClass = params[i].getClass();
                         if (newArgumentClass.equals(methodParameterClass)) {
                             break;
                         }
@@ -184,7 +184,7 @@ public class SimpleInvocationContext implements InvocationContext {
         }
     }
 
-    private void throwIAE(int i, Class<?> methodParameterClass, Class<? extends Object> newArgumentClass) {
+    private void throwIAE(int i, Class<?> methodParameterClass, Class<?> newArgumentClass) {
         throw new IllegalArgumentException("Incompatible parameter type on position: " + i + " :" + newArgumentClass + " (expected type was "
                 + methodParameterClass.getName() + ")");
     }

--- a/tests/src/test/java/org/jboss/weld/tests/unit/bootstrap/InjectionServicesTest.java
+++ b/tests/src/test/java/org/jboss/weld/tests/unit/bootstrap/InjectionServicesTest.java
@@ -39,7 +39,7 @@ public class InjectionServicesTest {
 
         BeanManager manager = getBeanManager(container);
 
-        Bean<? extends Object> bean = manager.resolve(manager.getBeans(Foo.class));
+        Bean<?> bean = manager.resolve(manager.getBeans(Foo.class));
         ijs.reset();
         Foo foo = (Foo) manager.getReference(bean, Foo.class, manager.createCreationalContext(bean));
 

--- a/tests/src/test/java/org/jboss/weld/tests/unit/threadlocal/ThreadLocalTestCase.java
+++ b/tests/src/test/java/org/jboss/weld/tests/unit/threadlocal/ThreadLocalTestCase.java
@@ -34,7 +34,7 @@ public class ThreadLocalTestCase {
         container.startContainer();
         BeanManager manager = getBeanManager(container);
 
-        Bean<? extends Object> testBean = manager.resolve(manager.getBeans(ThreadLocalTestCase.class));
+        Bean<?> testBean = manager.resolve(manager.getBeans(ThreadLocalTestCase.class));
 
         try {
             manager.getReference(


### PR DESCRIPTION
remove unnecessary extends Object, because all classes already extends Object.
