### PR TITLE
WELD-1774 Fix conversation context activation/association

### DIFF
--- a/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
+++ b/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
@@ -120,14 +120,11 @@ public abstract class AbstractConversationContext<R, S> extends AbstractBoundCon
 
     @Override
     public boolean associate(R request) {
-        if (this.associated.get() == null) {
             this.associated.set(request);
             /*
             * We need to delay attaching the bean store until activate() is called
             * so that we can attach the correct conversation id
-            */
-
-            /*
+            *
             * We may need access to the conversation id generator and
             * conversations. If the session already exists, we can load it from
             * there, otherwise we can create a new conversation id generator and
@@ -152,11 +149,7 @@ public abstract class AbstractConversationContext<R, S> extends AbstractBoundCon
             } else {
                 setRequestAttribute(request, CONVERSATIONS_ATTRIBUTE_NAME, getSessionAttribute(request, CONVERSATIONS_ATTRIBUTE_NAME, true));
             }
-
             return true;
-        } else {
-            return false;
-        }
     }
 
     @Override
@@ -222,17 +215,15 @@ public abstract class AbstractConversationContext<R, S> extends AbstractBoundCon
 
     @Override
     public void activate(String cid) {
-        if (!isActive()) {
-            if (!isAssociated()) {
-                throw ConversationLogger.LOG.mustCallAssociateBeforeActivate();
-            }
-            // Activate the context
-            super.setActive(true);
-
-            initialize(cid);
-        } else {
-            throw ConversationLogger.LOG.contextAlreadyActive();
+        if (!isAssociated()) {
+            throw ConversationLogger.LOG.mustCallAssociateBeforeActivate();
         }
+        if (!isActive()) {
+            super.setActive(true);
+        } else {
+            ConversationLogger.LOG.contextAlreadyActive(getRequest());
+        }
+        initialize(cid);
     }
 
     protected void initialize(String cid) {

--- a/impl/src/main/java/org/jboss/weld/context/http/LazyHttpConversationContextImpl.java
+++ b/impl/src/main/java/org/jboss/weld/context/http/LazyHttpConversationContextImpl.java
@@ -67,14 +67,13 @@ public class LazyHttpConversationContextImpl extends HttpConversationContextImpl
 
     @Override
     public void activate() {
+        if (!isAssociated()) {
+            throw ConversationLogger.LOG.mustCallAssociateBeforeActivate();
+        }
         if (!isActive()) {
-            if (!isAssociated()) {
-                throw ConversationLogger.LOG.mustCallAssociateBeforeActivate();
-            }
-            // Activate the context
             super.setActive(true);
         } else {
-            throw ConversationLogger.LOG.contextAlreadyActive();
+            ConversationLogger.LOG.contextAlreadyActive(getRequest());
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/logging/ConversationLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/ConversationLogger.java
@@ -103,8 +103,9 @@ public interface ConversationLogger extends WeldLogger {
     @Message(id = 334, value = "Must call associate() before calling deactivate()", format = Format.MESSAGE_FORMAT)
     IllegalStateException mustCallAssociateBeforeDeactivate();
 
-    @Message(id = 335, value = "Context is already active", format = Format.MESSAGE_FORMAT)
-    IllegalStateException contextAlreadyActive();
+    @LogMessage(level = Level.WARN)
+    @Message(id = 335, value = "Conversation context is already active, most likely a leak from previous request processing: {0}", format = Format.MESSAGE_FORMAT)
+    void contextAlreadyActive(Object request);
 
     @Message(id = 336, value = "Context is not active", format = Format.MESSAGE_FORMAT)
     IllegalStateException contextNotActive();


### PR DESCRIPTION
- do not throw an exception when the conversation context is already
  active (just log a warning that it's most likely a ThreadLocal leak)
- always associate the conversation context with the current HTTP
  request
