### PR TITLE
WELD-1823 Ensure that there is no injection point associated during

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/builtin/AbstractBuiltInMetadataBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/AbstractBuiltInMetadataBean.java
@@ -24,6 +24,7 @@ import javax.enterprise.inject.spi.Interceptor;
 
 import org.jboss.weld.context.WeldCreationalContext;
 import org.jboss.weld.injection.CurrentInjectionPoint;
+import org.jboss.weld.injection.EmptyInjectionPoint;
 import org.jboss.weld.logging.BeanLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.serialization.spi.BeanIdentifier;
@@ -46,7 +47,7 @@ public abstract class AbstractBuiltInMetadataBean<T> extends AbstractBuiltInBean
     @Override
     public T create(CreationalContext<T> creationalContext) {
         InjectionPoint ip = cip.peek();
-        if (ip == null) {
+        if (ip == null || EmptyInjectionPoint.INSTANCE.equals(ip)) {
             throw BeanLogger.LOG.dynamicLookupOfBuiltInNotAllowed(toString());
         }
         return newInstance(ip, creationalContext);

--- a/impl/src/main/java/org/jboss/weld/bean/builtin/AbstractDecorableBuiltInBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/AbstractDecorableBuiltInBean.java
@@ -26,6 +26,7 @@ import org.jboss.weld.bean.BeanIdentifiers;
 import org.jboss.weld.bean.DecorableBean;
 import org.jboss.weld.bean.StringBeanIdentifier;
 import org.jboss.weld.injection.CurrentInjectionPoint;
+import org.jboss.weld.injection.EmptyInjectionPoint;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.util.Decorators;
 
@@ -47,7 +48,6 @@ public abstract class AbstractDecorableBuiltInBean<T> extends AbstractBuiltInBea
     @Override
     public T create(CreationalContext<T> creationalContext) {
         InjectionPoint ip = getInjectionPoint(cip);
-
         List<Decorator<?>> decorators = getDecorators(ip);
         T instance = newInstance(ip, creationalContext);
         if (decorators.isEmpty()) {
@@ -63,7 +63,8 @@ public abstract class AbstractDecorableBuiltInBean<T> extends AbstractBuiltInBea
     protected abstract Class<T> getProxyClass();
 
     protected InjectionPoint getInjectionPoint(CurrentInjectionPoint cip) {
-        return cip.peek();
+        InjectionPoint ip = cip.peek();
+        return EmptyInjectionPoint.INSTANCE.equals(ip) ? null : ip;
     }
 
     @Override

--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -113,6 +113,7 @@ import org.jboss.weld.exceptions.IllegalArgumentException;
 import org.jboss.weld.exceptions.IllegalStateException;
 import org.jboss.weld.exceptions.InjectionException;
 import org.jboss.weld.injection.CurrentInjectionPoint;
+import org.jboss.weld.injection.EmptyInjectionPoint;
 import org.jboss.weld.injection.ThreadLocalStack.ThreadLocalStackReference;
 import org.jboss.weld.injection.attributes.FieldInjectionPointAttributes;
 import org.jboss.weld.injection.attributes.InferringFieldInjectionPointAttributes;
@@ -714,7 +715,13 @@ public class BeanManagerImpl implements WeldManager, Serializable {
         if (!BeanTypeAssignabilityRules.instance().matches(requestedType, bean.getTypes())) {
             throw BeanManagerLogger.LOG.specifiedTypeNotBeanType(requestedType, bean);
         }
-        return getReference(bean, requestedType, creationalContext, false);
+        // Ensure that there is no injection point associated
+        final ThreadLocalStackReference<InjectionPoint> stack = currentInjectionPoint.push(EmptyInjectionPoint.INSTANCE);
+        try {
+            return getReference(bean, requestedType, creationalContext, false);
+        } finally {
+             stack.pop();
+        }
     }
 
     /**

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionPoint/weld1823/CDIBean2.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionPoint/weld1823/CDIBean2.java
@@ -20,7 +20,12 @@ package org.jboss.weld.tests.injectionPoint.weld1823;
  *@author Emily Jiang
  */
 public class CDIBean2 {
+
     private String data;
+
+    public CDIBean2(String data) {
+        this.data = data;
+    }
 
     public String getData() {
         return data;

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionPoint/weld1823/CDIBean2Producer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionPoint/weld1823/CDIBean2Producer.java
@@ -30,6 +30,6 @@ public class CDIBean2Producer {
         if (ip != null) {
             throw new RuntimeException("InjectionPoint exists when producing CDIBean2: " + ip.toString());
         }
-        return new CDIBean2();
+        return new CDIBean2(null);
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionPoint/weld1823/Weld1823Test.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionPoint/weld1823/Weld1823Test.java
@@ -32,7 +32,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.weld.tests.category.Integration;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -42,7 +41,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @Category(Integration.class)
-@Ignore("WELD-1823")
+//@Ignore("WELD-1823")
 public class Weld1823Test {
 
     @Deployment(testable = false)


### PR DESCRIPTION
invocation of BeanManager.getReference()

`org.jboss.weld.tests.injectionPoint.weld1823.Weld1823Test` should be revised (see also my comments for https://github.com/weld/core/pull/803).