### PR TITLE
WELD-1837:Weld SE does not support empty beans.xml files

### DIFF
--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
@@ -22,13 +22,13 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import org.jboss.logging.Logger;
 import org.jboss.weld.bootstrap.api.Bootstrap;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.environment.deployment.WeldBeanDeploymentArchive;
+import org.jboss.weld.environment.deployment.discovery.BeanArchiveScanner.ScanResult;
 import org.jboss.weld.environment.logging.CommonLogger;
 import org.jboss.weld.exceptions.UnsupportedOperationException;
 import org.jboss.weld.resources.spi.ClassFileServices;
@@ -80,14 +80,14 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
         }
 
         final Collection<BeanArchiveBuilder> beanArchiveBuilders = new ArrayList<BeanArchiveBuilder>();
-        for (Entry<BeansXml, String> entry : scanner.scan().entrySet()) {
-            String ref = entry.getValue();
+        for (ScanResult scanResult : scanner.scan().values()) {
+            final String ref = scanResult.getBeanArchiveRef();
             BeanArchiveBuilder builder = null;
             for (BeanArchiveHandler handler : handlers) {
                 builder = handler.handle(ref);
                 if (builder != null) {
                     builder.setId(ref);
-                    builder.setBeansXml(entry.getKey());
+                    builder.setBeansXml(scanResult.getBeansXml());
                     beanArchiveBuilders.add(builder);
                     break;
                 }

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/BeanArchiveScanner.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/BeanArchiveScanner.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.weld.environment.deployment.discovery;
 
+import java.net.URL;
 import java.util.Map;
 
 import org.jboss.weld.bootstrap.spi.BeansXml;
@@ -29,12 +30,28 @@ import org.jboss.weld.bootstrap.spi.BeansXml;
  * @author Martin Kouba
  */
 public interface BeanArchiveScanner {
+    public static class ScanResult {
+        private final String beanArchiveRef;
+        private final BeansXml beansXml;
+
+        public ScanResult(final BeansXml beansXml, final String beanArchiveRef) {
+            this.beansXml = beansXml;
+            this.beanArchiveRef = beanArchiveRef;
+        }
+
+        public String getBeanArchiveRef() {
+            return beanArchiveRef;
+        }
+
+        public BeansXml getBeansXml() {
+            return beansXml;
+        }
+    }
 
     /**
      * Scans for bean archives identified by beans.xml files.
      *
-     * @return the map of {@link BeansXml} representations mapped to the bean archive reference (the root path of the bean archive)
+     * @return the map of {@link ScanResult} representations mapped by url of the beans xml.
      */
-    Map<BeansXml, String> scan();
-
+    Map<URL, ScanResult> scan();
 }

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DefaultBeanArchiveScanner.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DefaultBeanArchiveScanner.java
@@ -39,6 +39,7 @@ import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.environment.deployment.AbstractWeldDeployment;
 import org.jboss.weld.environment.deployment.WeldResourceLoader;
+import org.jboss.weld.environment.deployment.discovery.BeanArchiveScanner.ScanResult;
 import org.jboss.weld.environment.logging.CommonLogger;
 import org.jboss.weld.resources.spi.ResourceLoader;
 
@@ -66,17 +67,17 @@ public class DefaultBeanArchiveScanner implements BeanArchiveScanner {
     }
 
     @Override
-    public Map<BeansXml, String> scan() {
-        Map<BeansXml, String> beansXmlMap = new HashMap<BeansXml, String>();
+    public Map<URL, ScanResult> scan() {
+        final Map<URL, ScanResult>  beansXmlMap = new HashMap<URL, ScanResult> ();
         // META-INF/beans.xml
-        String[] resources = AbstractWeldDeployment.RESOURCES;
+        final String[] resources = AbstractWeldDeployment.RESOURCES;
 
         // Find all beans.xml files
         for (String resourceName : resources) {
             for (URL beansXmlUrl : resourceLoader.getResources(resourceName)) {
-                BeansXml beansXml = bootstrap.parse(beansXmlUrl);
+                final BeansXml beansXml = bootstrap.parse(beansXmlUrl);
                 if (accept(beansXml)) {
-                    beansXmlMap.put(beansXml, getBeanArchiveReference(beansXmlUrl));
+                    beansXmlMap.put(beansXmlUrl, new ScanResult(beansXml, getBeanArchiveReference(beansXmlUrl)));
                 }
             }
         }

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/BeanDiscoveryEmtyBeansXmlTest.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/BeanDiscoveryEmtyBeansXmlTest.java
@@ -1,0 +1,50 @@
+package org.jboss.weld.environment.se.test.beandiscovery;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.enterprise.inject.spi.BeanManager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.weld.environment.se.test.arquillian.WeldSEClassPath;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class BeanDiscoveryEmtyBeansXmlTest {
+    @Deployment
+    public static Archive<?> getDeployment() {
+        JavaArchive archive01 = ShrinkWrap.create(BeanArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(Dog.class, Cat.class, Cow.class);
+        JavaArchive archive02 = ShrinkWrap.create(BeanArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(Plant.class, Tree.class, Stone.class);
+        JavaArchive archive03 = ShrinkWrap.create(BeanArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addClasses(Flat.class, House.class);
+        return ShrinkWrap.create(WeldSEClassPath.class).add(archive01, archive02, archive03);
+    }
+
+    @Test
+    public void testArchive01(BeanManager manager) {
+        assertEquals(1, manager.getBeans(Dog.class).size());
+        assertEquals(1, manager.getBeans(Cat.class).size());
+        assertEquals(1, manager.getBeans(Cow.class).size());
+    }
+
+    @Test
+    public void testArchive02(BeanManager manager) {
+        assertEquals(1, manager.getBeans(Tree.class).size());
+        assertEquals(1, manager.getBeans(Plant.class).size());
+        assertEquals(1, manager.getBeans(Stone.class).size());
+    }
+
+    @Test
+    public void testArchive03(BeanManager manager) {
+        assertEquals(1, manager.getBeans(Flat.class).size());
+        assertEquals(1, manager.getBeans(House.class).size());
+    }
+}

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/BeanDiscoveryInjectionTest.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/beandiscovery/BeanDiscoveryInjectionTest.java
@@ -37,22 +37,15 @@ public class BeanDiscoveryInjectionTest {
 
     @Deployment
     public static Archive<?> getDeployment() {
-        WeldSEClassPath archives = ShrinkWrap.create(WeldSEClassPath.class);
         JavaArchive archive01 = ShrinkWrap.create(BeanArchive.class).addAsManifestResource(new BeansXml(BeanDiscoveryMode.ALL), "beans.xml")
                 .addClasses(Dog.class, Cat.class, Cow.class);
         JavaArchive archive02 = ShrinkWrap.create(BeanArchive.class).addAsManifestResource(new BeansXml(BeanDiscoveryMode.ANNOTATED), "beans.xml")
                 .addClasses(Plant.class, Tree.class, Stone.class);
         JavaArchive archive03 = ShrinkWrap.create(BeanArchive.class).addAsManifestResource(new BeansXml(BeanDiscoveryMode.NONE), "beans.xml")
                 .addClasses(Flat.class, House.class);
-        archives.add(archive01);
-        archives.add(archive02);
-        archives.add(archive03);
-        return archives;
+        return ShrinkWrap.create(WeldSEClassPath.class).add(archive01, archive02, archive03);
     }
 
-    /**
-     * Test bean discovery in SE.
-     */
     @Test
     public void testAllBeanDiscovery(BeanManager manager) {
         assertEquals(1, manager.getBeans(Dog.class).size());
@@ -72,7 +65,4 @@ public class BeanDiscoveryInjectionTest {
         assertEquals(0, manager.getBeans(Flat.class).size());
         assertEquals(0, manager.getBeans(House.class).size());
     }
-
-
-
 }

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java
@@ -59,8 +59,8 @@ public class WebAppBeanArchiveScanner extends DefaultBeanArchiveScanner {
     }
 
     @Override
-    public Map<BeansXml, String> scan() {
-        Map<BeansXml, String> beansXmlMap = super.scan();
+    public Map<URL, ScanResult> scan() {
+        Map<URL, ScanResult> beansXmlMap = super.scan();
         try {
             // WEB-INF/classes
             URL beansXmlUrl = null;
@@ -79,10 +79,10 @@ public class WebAppBeanArchiveScanner extends DefaultBeanArchiveScanner {
                 if (accept(beansXml)) {
                     File webInfClasses = Servlets.getRealFile(servletContext, WEB_INF_CLASSES);
                     if (webInfClasses != null) {
-                        beansXmlMap.put(beansXml, webInfClasses.getPath());
+                        beansXmlMap.put(beansXmlUrl, new ScanResult(beansXml, webInfClasses.getPath()));
                     } else {
                         // The WAR is not extracted to the file system - make use of ServletContext.getResourcePaths()
-                        beansXmlMap.put(beansXml, WEB_INF_CLASSES);
+                        beansXmlMap.put(beansXmlUrl, new ScanResult(beansXml, WEB_INF_CLASSES));
                     }
                 }
             }


### PR DESCRIPTION
Weld SE has a problem while scanning bean archives, if the application has multiple archives with an empty beans.xml. Only the last detected archive is considered.

An empty beans.xml is represented with the constant org.jboss.weld.bootstrap.spi.BeansXml.EMPTY_BEANS_XML. The problem is, that implementations of org.jboss.weld.environment.deployment.discovery.BeansXml use this .EMPTY_BEANS_XML as key in a HashMap, which should contain all discovered bean archives. But because the key for jars with an empty beans.xml is always the same, they are not discovered properly.

The approach to solve this problem is to use the beansXmlUrl as key for the Map. I introduced a new helper class "ScanResult" which aggregates the beansXml  and beanArchiveRef so that further processing of the scan result is influenced as less as possible. 

Remark: I did not test the WebAppBeanArchiveScanner because this is not used in my environment. The DefaultBeanArchiveScanner seams to work correctly after this change.