### PR TITLE
WELD-1539 Add generic signatures on proxy classes

### DIFF
--- a/impl/src/main/java/org/jboss/weld/config/ConfigurationKey.java
+++ b/impl/src/main/java/org/jboss/weld/config/ConfigurationKey.java
@@ -144,6 +144,11 @@ public enum ConfigurationKey {
      */
     BEAN_IDENTIFIER_INDEX_OPTIMIZATION("org.jboss.weld.serialization.beanIdentifierIndexOptimization", true),
 
+    /**
+     * If set to <code>true</code> Weld will try to set the method signature so that methods declared on proxies may retain the generic info.
+     */
+    PROXY_METHOD_SIGNATURES("org.jboss.weld.proxy.methodSignatures", true),
+
     ;
 
     /**

--- a/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
@@ -492,4 +492,12 @@ public interface BeanLogger extends WeldLogger {
 
     @Message(id = 1560, value = "Bean builder {0} does not define a destroy lifecycle callback.", format = Format.MESSAGE_FORMAT)
     DefinitionException beanBuilderInvalidDestroyCallback(Object param1);
+
+    @LogMessage(level = Level.WARN)
+    @Message(id = 1561, value = "Unable to encode the method signature for {0}", format = Format.MESSAGE_FORMAT)
+    void unableToEncodeMethodSignature(Object method, @Cause Throwable cause);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 1562, value = "jboss-classfilewriter 1.1+ not found on classpath. Methods declared on proxies will not retain generic info.")
+    void unableToSetMethodSignatures();
 }

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <bundle.plugin.version>2.5.3</bundle.plugin.version>
         <cdi.tck-1-2.version>1.2.4.Final</cdi.tck-1-2.version>
         <cdi.tck-2-0.version>2.0.0.Alpha1</cdi.tck-2-0.version>
-        <classfilewriter.version>1.0.5.Final</classfilewriter.version>
+        <classfilewriter.version>1.1.0.Final</classfilewriter.version>
         <contiperf.version>1.06</contiperf.version>
         <findbugs-maven-plugin.version>3.0.0</findbugs-maven-plugin.version>
         <glassfish.el.version>2.1.2-b04</glassfish.el.version>

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/AbstractBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/AbstractBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.proxy.generics;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class AbstractBean {
+
+    public <T> Set<T> getCopy(Set<T> set) {
+        return new HashSet<T>(set);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/Child.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/Child.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.proxy.generics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Child extends Parent<String> {
+
+    public void invoke(String param) {
+    }
+
+    public List<String> getCopy(List<String> list) {
+        return new ArrayList<String>(list);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/InterceptedDependent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/InterceptedDependent.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.proxy.generics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@TestBinding
+public class InterceptedDependent extends AbstractBean {
+
+    public List<String> getCopy(List<String> list) {
+        return new ArrayList<String>(list);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/Parent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/Parent.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.proxy.generics;
+
+
+public class Parent<T> extends AbstractBean {
+
+    public void invoke(T param) {
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/ProxyGenericMethodTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/ProxyGenericMethodTest.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.proxy.generics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.weld.bean.proxy.ProxyObject;
+import org.jboss.weld.tests.category.EmbeddedContainer;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+@Category(EmbeddedContainer.class)
+@RunWith(Arquillian.class)
+public class ProxyGenericMethodTest {
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(BeanArchive.class).addPackage(ProxyGenericMethodTest.class.getPackage());
+    }
+
+    @Inject
+    SimpleNormalScoped simple;
+
+    @Inject
+    Child child;
+
+    @Inject
+    InterceptedDependent interceptedDependent;
+
+    @Test
+    public void testClientProxy() throws Exception {
+        assertNotNull(simple);
+        assertTrue(simple instanceof ProxyObject);
+        assertMethods(simple.getClass());
+    }
+
+    @Test
+    public void testClientProxySyntheticMethod() throws Exception {
+        assertNotNull(child);
+        assertTrue(child instanceof ProxyObject);
+        child.invoke("foo");
+        assertMethods(child.getClass());
+    }
+
+    // We can't add generic signatures on subclasses because of JDK-8062582 and others
+    // @Test
+    // public void testSubclass() throws Exception {
+    // assertNotNull(interceptedDependent);
+    // assertTrue(interceptedDependent instanceof ProxyObject);
+    // assertMethods(interceptedDependent.getClass());
+    // }
+
+    private void assertMethods(Class<?> clazz) throws NoSuchMethodException, SecurityException {
+        Method m = clazz.getMethod("getCopy", List.class);
+        assertNotNull(m);
+        Type[] paramTypes = m.getGenericParameterTypes();
+        assertEquals(1, paramTypes.length);
+        assertTrue(paramTypes[0] instanceof ParameterizedType);
+        ParameterizedType paramType = (ParameterizedType) paramTypes[0];
+        assertEquals(List.class, paramType.getRawType());
+        Type[] typeArguments = paramType.getActualTypeArguments();
+        assertEquals(1, typeArguments.length);
+        assertTrue(typeArguments[0].equals(String.class));
+
+        m = clazz.getMethod("getCopy", Set.class);
+        assertNotNull(m);
+        paramTypes = m.getGenericParameterTypes();
+        assertEquals(1, paramTypes.length);
+        assertTrue(paramTypes[0] instanceof ParameterizedType);
+        paramType = (ParameterizedType) paramTypes[0];
+        assertEquals(Set.class, paramType.getRawType());
+        typeArguments = paramType.getActualTypeArguments();
+        assertEquals(1, typeArguments.length);
+        assertTrue(typeArguments[0] instanceof TypeVariable);
+        TypeVariable<?> typeVariable = (TypeVariable<?>) typeArguments[0];
+        assertEquals("T", typeVariable.getName());
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/SimpleNormalScoped.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/SimpleNormalScoped.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.proxy.generics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SimpleNormalScoped extends AbstractBean {
+
+    public List<String> getCopy(List<String> list) {
+        return new ArrayList<String>(list);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/TestBinding.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/TestBinding.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.proxy.generics;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Retention(RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Documented
+public @interface TestBinding {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/TestInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/generics/TestInterceptor.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.proxy.generics;
+
+import java.io.Serializable;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@SuppressWarnings("serial")
+@Priority(1000)
+@TestBinding
+@Interceptor
+public class TestInterceptor implements Serializable {
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext invocationContext) throws Exception {
+        return invocationContext.proceed();
+    }
+}


### PR DESCRIPTION
- adding signatures has some drawbacks caused by JDK bugs
 - if generic signatures exist in the class file some methods behave differently - see https://bugs.openjdk.java.net/browse/JDK-8062582 for more info
 - therefore we can't add signatures on subclasses because it breaks creation of Annotated types
- the feature is configurable and compatible with older versions of jboss-classfilewriter
