### PR TITLE
Fixes support on Oracle and IcedTea JNLP implementations

### DIFF
--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/JandexIndexBeanArchiveHandler.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/JandexIndexBeanArchiveHandler.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.weld.environment.deployment.discovery.jandex;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -119,7 +120,7 @@ public class JandexIndexBeanArchiveHandler implements BeanArchiveHandler {
 
     private String getJandexIndexURLString(final String urlPath) {
         String indexUrlString = FILE_URL_PREFIX + urlPath + SEPARATOR + JANDEX_INDEX_NAME;
-        if (urlPath.toLowerCase().endsWith(".jar")) {
+        if (new File(urlPath).isFile()) {
             indexUrlString = JAR_URL_PREFIX + indexUrlString;
         }
 


### PR DESCRIPTION
These patches restore proper support for using Weld on JNLP applications on Oracle JVM. IcedTea support is added doing reflection on their private API class loader much the same way it is done over the Oracle JNLPClassLoader. IcedTea API for their class loader has been the same at least from 1.4 (Current is 1.5) and their repository HEAD shows no change.