### PR TITLE
WELD-1924 fix osgi paint example.

### DIFF
--- a/examples/osgi/README.md
+++ b/examples/osgi/README.md
@@ -18,7 +18,7 @@ Make sure you have Apache Karaf installed.
 
 3. Install Pax CDI and Weld by running the following command in the Karaf console:
 
-        feature:install pax-cdi weld
+        feature:install pax-cdi-weld
 
 4. Deploy the Paint API artifact 
 

--- a/examples/osgi/paint-square/src/main/java/org/jboss/weld/examples/osgi/paint/square/SquareShapeProvider.java
+++ b/examples/osgi/paint-square/src/main/java/org/jboss/weld/examples/osgi/paint/square/SquareShapeProvider.java
@@ -17,14 +17,10 @@
 
 package org.jboss.weld.examples.osgi.paint.square;
 
-
-import javax.enterprise.context.ApplicationScoped;
-
 import org.jboss.weld.examples.osgi.paint.api.Shape;
 import org.jboss.weld.examples.osgi.paint.api.ShapeProvider;
 import org.ops4j.pax.cdi.api.OsgiServiceProvider;
 
-@ApplicationScoped
 @OsgiServiceProvider
 public class SquareShapeProvider implements ShapeProvider {
 

--- a/examples/osgi/paint-triangle/src/main/java/org/jboss/weld/examples/osgi/paint/triangle/TriangleShapeProvider.java
+++ b/examples/osgi/paint-triangle/src/main/java/org/jboss/weld/examples/osgi/paint/triangle/TriangleShapeProvider.java
@@ -18,14 +18,11 @@
 package org.jboss.weld.examples.osgi.paint.triangle;
 
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.jboss.weld.examples.osgi.paint.api.Shape;
 import org.jboss.weld.examples.osgi.paint.api.ShapeProvider;
 import org.ops4j.pax.cdi.api.OsgiServiceProvider;
 
 @OsgiServiceProvider
-@ApplicationScoped
 public class TriangleShapeProvider implements ShapeProvider {
 
     @Override

--- a/examples/osgi/pom.xml
+++ b/examples/osgi/pom.xml
@@ -17,7 +17,7 @@
     <url>http://weld.cdi-spec.org</url>
 
     <properties>
-        <pax.cdi.version>0.8.0</pax.cdi.version>
+        <pax.cdi.version>0.11.0</pax.cdi.version>
     </properties>
 
     <developers>


### PR DESCRIPTION
The ApplicationScoped annotation was removed (hopefully temporarily) due to https://ops4j1.jira.com/browse/PAXCDI-133