### PR TITLE
WELD-1957 BeanBuilder - init default qualifiers

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanBuilderTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanBuilderTest.java
@@ -113,6 +113,13 @@ public class BeanBuilderTest {
         assertEquals(Dependent.class, fooBean.getScope());
         Foo randomFoo = (Foo) beanManager.getReference(fooBean, Foo.class, beanManager.createCreationalContext(listBean));
         assertEquals(Long.valueOf(-1), randomFoo.getId());
+
+        beans = beanManager.getBeans(Configuration.class);
+        assertEquals(1, beans.size());
+        Bean<Configuration> configBean = (Bean<Configuration>) beans.iterator().next();
+        assertEquals(Dependent.class, configBean.getScope());
+        Configuration configuration = (Configuration) beanManager.getReference(configBean, Configuration.class, beanManager.createCreationalContext(configBean));
+        assertEquals(1, configuration.getId());
     }
 
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BuilderExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BuilderExtension.java
@@ -83,5 +83,8 @@ public class BuilderExtension implements Extension {
         // Test transitive type closure
         event.addBean().addTransitiveTypeClosure(Foo.class).addQualifier(Random.Literal.INSTANCE)
                 .produceWith(() -> new Foo(-1l));
+
+        // Test default qualifiers
+        event.addBean().addType(Configuration.class).producing(new Configuration(1));
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/Configuration.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/Configuration.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.custombeans;
+
+
+/**
+ *
+ * @author Martin Kouba
+ */
+// This qualifier is ignored
+@Juicy
+public class Configuration {
+
+    private long id;
+
+    Configuration(long id) {
+        this.id = id;
+    }
+
+    long getId() {
+        return id;
+    }
+
+}


### PR DESCRIPTION
Note that the impl is not entirely per the spec - the additional qualifier `@Default` is also added if the builder qualifiers are `@Any` or `@Any` and `@Named`. See also https://issues.jboss.org/browse/CDI-528.