### PR TITLE
Remove outdated test ignores - we now require WF10 for the testsuite …

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/index/processAnnotatedType/type/ProcessAnnotatedTypeResolutionTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/index/processAnnotatedType/type/ProcessAnnotatedTypeResolutionTest.java
@@ -33,7 +33,7 @@ import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 @Category(Integration.class)
-@Ignore("Ignored until WF9")
+@Ignore("WELD-2005")
 public class ProcessAnnotatedTypeResolutionTest {
 
     @Inject

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/MultiWarTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/MultiWarTest.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.weld.tests.category.Integration;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -43,7 +42,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @Category(Integration.class)
-@Ignore("WFLY-3334 - this test is ignored until a fixed version of WildFly 10 is generally available")
 public class MultiWarTest {
 
     @Deployment

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/ejb/singleton/SingletonStartupTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/ejb/singleton/SingletonStartupTest.java
@@ -25,7 +25,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.weld.tests.category.Integration;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,7 +44,6 @@ public class SingletonStartupTest {
     }
 
     @Test
-    @Ignore("WFLY-4438")
     public void testSingletonStartupCount(Foo foo) {
         int count = 10;
         for (int i = 0; foo.getSomeValue() && i < count; i++) {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/jsf/managedbeans/ManagedBeansWithCDITest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/jsf/managedbeans/ManagedBeansWithCDITest.java
@@ -30,7 +30,6 @@ import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.weld.tests.category.Integration;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -45,7 +44,6 @@ import com.gargoylesoftware.htmlunit.WebClient;
  */
 @Category(Integration.class)
 @RunWith(Arquillian.class)
-@Ignore("WELD-1839")
 public class ManagedBeansWithCDITest {
 
     @Deployment(testable = false)

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/synthetic/SyntheticProxyTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/synthetic/SyntheticProxyTest.java
@@ -23,7 +23,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,7 +33,6 @@ import org.junit.runner.RunWith;
  *
  */
 @RunWith(Arquillian.class)
-@Ignore("Ignore these tests for now until jboss-classfilewriter is available (WildFly 9.0.0.Final, 10.0.0.Alpha4)")
 public class SyntheticProxyTest {
 
     @Deployment

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/service/additional/AdditionalServiceTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/service/additional/AdditionalServiceTest.java
@@ -29,7 +29,6 @@ import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.transaction.spi.TransactionServices;
 import org.jboss.weld.util.ServiceLoader;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,9 +54,8 @@ public class AdditionalServiceTest {
             Bravo1Service.class,
             Bravo2Service.class,
             BravoImpl.class,
-            // WFLY-3951
-            // TransactionServices1.class,
-            // TransactionServices2.class,
+             TransactionServices1.class,
+             TransactionServices2.class,
         };
         return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addClasses(classes)
@@ -84,7 +82,6 @@ public class AdditionalServiceTest {
     }
 
     @Test
-    @Ignore("WFLY-3951")
     public void testOverridingService() {
         TransactionServices transactionServices = manager.getServices().get(TransactionServices.class);
         Assert.assertNotNull(transactionServices);


### PR DESCRIPTION
…to fully pass