### PR TITLE
WELD-2011 Simplify JandexIndexBeanArchiveHandler

### DIFF
--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/JandexIndexBeanArchiveHandler.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/JandexIndexBeanArchiveHandler.java
@@ -17,114 +17,72 @@
 package org.jboss.weld.environment.deployment.discovery.jandex;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexReader;
 import org.jboss.jandex.UnsupportedVersion;
+import org.jboss.logging.Logger;
 import org.jboss.weld.environment.deployment.discovery.BeanArchiveBuilder;
 import org.jboss.weld.environment.deployment.discovery.BeanArchiveHandler;
 import org.jboss.weld.environment.logging.CommonLogger;
 import org.jboss.weld.util.Preconditions;
 
 /**
- * This class uses a Jandex-Index ("META-INF/jandex.idx") to scan the the archive. If no index is available the {@link JandexIndexBeanArchiveHandler#handle(String)}
- * method will return null. To prevent this, use {@link JandexIndexBeanArchiveHandler#canHandle(String)} to check if an index is available and supported.
+ * This class uses an existing Jandex-Index ("META-INF/jandex.idx") to scan the bean archive. If no index is available the
+ * {@link JandexIndexBeanArchiveHandler#handle(String)} method will return null.
+ *
  * <p>
- * The class is not thread-safe and should only be used by a single thread
+ * The class is not thread-safe and should only be used by a single thread.
+ * </p>
  *
  * @author Stefan Großmann
  */
 public class JandexIndexBeanArchiveHandler implements BeanArchiveHandler {
+
+    private static final Logger logger = Logger.getLogger(JandexIndexBeanArchiveHandler.class);
+
     private static final String JANDEX_INDEX_NAME = "META-INF/jandex.idx";
 
-    private static final String JAR_URL_PREFIX = "jar:";
-    private static final String FILE_URL_PREFIX = "file:";
-    private static final String SEPARATOR = "!/";
-
-    private Index indexCache = null;
-    private String indexCacheUrlPath = null;
-
-    public boolean canHandle(String urlPath) {
-        return getIndex(urlPath) != null;
-    }
-
     @Override
-    public BeanArchiveBuilder handle(String urlPath) {
-        Index index = getIndex(urlPath);
+    public BeanArchiveBuilder handle(String path) {
+        File beanArchiveFile = new File(path);
+        if (!beanArchiveFile.canRead() || beanArchiveFile.isDirectory()) {
+            // Currently only JAR files are supported
+            return null;
+        }
+        Index index = getIndex(beanArchiveFile);
         if (index == null) {
             return null;
         }
-
         BeanArchiveBuilder builder = new BeanArchiveBuilder().setAttribute(JandexDiscoveryStrategy.INDEX_ATTRIBUTE_NAME, index);
         handleArchiveByIndex(index, builder);
         return builder;
     }
 
-    private Index getIndex(final String urlPath) {
-        Preconditions.checkArgumentNotNull(urlPath, "urlPath");
-
-        if (indexCacheUrlPath == null || !indexCacheUrlPath.equals(urlPath)) {
-            Index newIndex = loadJandexIndex(urlPath);
-            indexCache = newIndex;
-            indexCacheUrlPath = urlPath;
-        }
-
-        return indexCache;
-    }
-
-    private Index loadJandexIndex(final String urlPath) {
-        URL indexURL = null;
+    private Index getIndex(final File beanArchiveFile) {
+        Preconditions.checkArgumentNotNull(beanArchiveFile, "beanArchiveFile");
+        logger.debugv("Try to get Jandex index for: {0}", beanArchiveFile);
         Index index = null;
-
-        final String indexUrlString = getJandexIndexURLString(urlPath);
-        try {
-            indexURL = new URL(indexUrlString);
-        } catch (MalformedURLException e) {
-            return null;
-        }
-
-        InputStream indexFileStream = null;
-        try {
-            indexFileStream = indexURL.openStream();
-            CommonLogger.LOG.foundJandexIndex(indexURL);
-            final IndexReader indexFileReader = new IndexReader(indexFileStream);
-            index = indexFileReader.read();
-        } catch (IllegalArgumentException e) {
-            CommonLogger.LOG.warnv("Jandex index at {0} is not valid", indexUrlString);
-        } catch (UnsupportedVersion e) {
-            CommonLogger.LOG.warnv("Version of Jandex index at {0} is not supported", indexUrlString);
-        } catch (FileNotFoundException ignore) {
-            // There is no index available.
-            CommonLogger.LOG.tracev("No Jandex index found at {0}", indexUrlString);
-        } catch (IOException ioe) {
-            CommonLogger.LOG.warnv("Cannot load Jandex index at {0}", indexUrlString);
-            CommonLogger.LOG.catchingDebug(ioe);
-        } finally {
-            if (indexFileStream != null) {
-                try {
-                    indexFileStream.close();
-                } catch (IOException ioe) {
-                    CommonLogger.LOG.couldNotCloseStreamOfJandexIndex(urlPath, ioe);
-                }
+        try (ZipFile zip = new ZipFile(beanArchiveFile)) {
+            // Open the bean archive and try to find the index file
+            ZipEntry entry = zip.getEntry(JANDEX_INDEX_NAME);
+            if (entry != null) {
+                index = new IndexReader(zip.getInputStream(entry)).read();
             }
+        } catch (IllegalArgumentException e) {
+            CommonLogger.LOG.warnv("Jandex index is not valid: {0}", beanArchiveFile);
+        } catch (UnsupportedVersion e) {
+            CommonLogger.LOG.warnv("Version of Jandex index is not supported: {0}", beanArchiveFile);
+        } catch (IOException e) {
+            CommonLogger.LOG.warnv("Cannot get Jandex index from: {0}", beanArchiveFile);
+            CommonLogger.LOG.catchingDebug(e);
         }
-
+        logger.debugv("Jandex index {0}found: {1}", index == null ? "NOT " : "", beanArchiveFile);
         return index;
-    }
-
-    private String getJandexIndexURLString(final String urlPath) {
-        String indexUrlString = FILE_URL_PREFIX + urlPath + SEPARATOR + JANDEX_INDEX_NAME;
-        if (new File(urlPath).isFile()) {
-            indexUrlString = JAR_URL_PREFIX + indexUrlString;
-        }
-
-        return indexUrlString;
     }
 
     private void handleArchiveByIndex(Index index, BeanArchiveBuilder builder) {


### PR DESCRIPTION
- index cache is not needed
- fail fast if a bean reference is not a zip file
- open archive and try to get index file instead of using URL