### PR TITLE
Weld Probe: Added test profile which allows to execute all tests (int…

### DIFF
--- a/probe/tests/pom.xml
+++ b/probe/tests/pom.xml
@@ -295,6 +295,62 @@
                 </plugins>
             </build>
         </profile>
+        
+        <profile>
+            <id>alltests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-ftest-source</id>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/ftest/java</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>add-ftest-resource</id>
+                                <goals>
+                                    <goal>add-test-resource</goal>
+                                </goals>
+                                <configuration>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/ftest/java</directory>
+                                            <targetPath>.</targetPath>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <arquillian.xml>src/ftest/resources/arquillian-ftest.xml</arquillian.xml>
+                                <jacoco.agent>${jacoco.agent}</jacoco.agent>
+                                <additional.vm.args>${additional.vm.args}</additional.vm.args>
+                                <org.jboss.remoting-jmx.timeout>360</org.jboss.remoting-jmx.timeout>
+                            </systemProperties>
+                            <test>${test}</test>
+                            <parallel>none</parallel>
+                            <includes>
+                                <include>**/*Test.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 	 
         <profile>
             <id>jacoco</id>


### PR DESCRIPTION
…egration and ftest) with one command.

Given the latest test addition to Probe tests, we now have integration and ftests. While it is good to have them separated I think we might also make use of a profile which will fire off all the tests. 
For instance our release Jenkins jobs will surely want to run the whole test suite.

WDYT @mkouba @tremes ?