### PR TITLE
Add comment to unit test failing with IBM JVM

### DIFF
--- a/impl/src/test/java/org/jboss/weld/tests/unit/util/reflection/FormatsTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/util/reflection/FormatsTest.java
@@ -40,6 +40,11 @@ import org.junit.Test;
  */
 public class FormatsTest {
 
+    /**
+     * This test will FAIL with IBM JVM, because Apache BCEL classes are not present there. Therefore util method
+     * Formats.getLineNumber always returns 0 as line number. 
+     * Apache BCEL classes are used to look up the line numbers in bytecode.
+     */
     @Test
     public void testGetLineNumber() throws NoSuchMethodException, SecurityException {
 


### PR DESCRIPTION
Added a comment with explanation. Rest of the test suite works fine with IBM java.