### PR TITLE
WELD-2055 added a profile to exclude shutdown hook test on Windows. M…

### DIFF
--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -405,6 +405,11 @@ public class HelloWorld
 }
 ------------------------------------------------------------------------------------------------------
 
+NOTE: Weld automatically registers shutdown hook during initialization in order to properly terminate
+all running containers should the VM be terminated or program exited. Even though it is possible to register 
+an alternative hook and implement the logic, it is not recommended. The behavior across OS platforms may 
+differ and specifically on Windows it proves to be problematic.
+
 ==== Bootstrapping CDI SE
 
 CDI SE applications can be bootstrapped in the following ways.

--- a/pom.xml
+++ b/pom.xml
@@ -663,6 +663,28 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- Following profile is automatically triggered in Windows environment and allows to handle behaviour/problems 
+            specific for this OS. For instance excluding a test here will skip its execution on Windows. -->
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/ShutdownHookTest.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
 </project>


### PR DESCRIPTION
…entioned shutdown hook behaviour in docs.

I decided to add the profile to core pom since most our profiles reside there and since it may come handy should we need to modify the test execution on Windows further.