### PR TITLE
WELD-2056 Proxy class initializer - add ACC_STATIC flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 jdk:
+  - oraclejdk8
   - oraclejdk7
+  - openjdk7
 script: "mvn verify"
 sudo: false
+cache:
+  directories:
+   - $HOME/.m2/repository

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -454,8 +454,8 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
         }
         List<DeferredBytecode> initialValueBytecode = new ArrayList<DeferredBytecode>();
 
-
-        ClassMethod staticConstructor = proxyClassType.addMethod(AccessFlag.PUBLIC, "<clinit>", "V");
+        // Workaround for IBM JVM - the ACC_STATIC flag should only be required for class file with version number 51.0 or above
+        ClassMethod staticConstructor = proxyClassType.addMethod(AccessFlag.of(AccessFlag.PUBLIC, AccessFlag.STATIC), "<clinit>", "V");
 
         addFields(proxyClassType, initialValueBytecode);
         addConstructors(proxyClassType, initialValueBytecode);


### PR DESCRIPTION
- the ACC_STATIC flag should only be required for class files with
version number 51.0 or above and weld proxies are 50.0 (java6)
- see also DELTASPIKE-1010 adn https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-2.html#jvms-2.9