### PR TITLE
Rolling Upgrade session state fix: https://issues.jboss.org/browse/WELD-2064

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployment.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployment.java
@@ -104,7 +104,8 @@ public class BeanDeployment {
         services.add(WSApiAbstraction.class, new WSApiAbstraction(resourceLoader));
         services.add(InterceptorsApiAbstraction.class, new InterceptorsApiAbstraction(resourceLoader));
         services.add(AnnotationApiAbstraction.class, new AnnotationApiAbstraction(resourceLoader));
-        this.beanManager = BeanManagerImpl.newManager(deploymentManager, beanDeploymentArchive.getId(), services);
+        this.beanManager = BeanManagerImpl.newManager(deploymentManager,
+                WeldBootstrap.stripArchiveIdSuffix(beanDeploymentArchive.getId()), services);
         services.add(InjectionTargetService.class, new InjectionTargetService(beanManager));
 
         services.get(WeldModules.class).postBeanArchiveServiceRegistration(services, beanManager, beanDeploymentArchive);

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
@@ -66,7 +66,7 @@ public class WeldBootstrap implements CDI11Bootstrap {
 
     @Override
     public synchronized Bootstrap startContainer(String contextId, Environment environment, Deployment deployment) {
-        weldRuntime = weldStartup.startContainer(contextId, environment, deployment);
+        weldRuntime = weldStartup.startContainer(stripArchiveIdSuffix(contextId), environment, deployment);
         return this;
     }
 
@@ -150,4 +150,12 @@ public class WeldBootstrap implements CDI11Bootstrap {
             throw BootstrapLogger.LOG.callingBootstrapMethodAfterContainerHasBeenInitialized();
         }
     }
+
+    static String stripArchiveIdSuffix(String archiveId) {
+        int idx = archiveId.indexOf(ARCHIVE_SUFFIX_DELIMITER);
+        return archiveId.substring(0, idx >= 0 ? idx : archiveId.length());
+    }
+
+
+    private static final String ARCHIVE_SUFFIX_DELIMITER = "..";
 }


### PR DESCRIPTION
This patch enables a suffixed version to be ignored by Weld and thus able to upgrade applications with different bean archive names without session or bean loss in a cluster