### PR TITLE
Add missing packages not exported

### DIFF
--- a/bundles/osgi/pom.xml
+++ b/bundles/osgi/pom.xml
@@ -74,16 +74,18 @@
                             javax.decorator;
                             javax.enterprise.*;
                             version=${osgi.version},
-                            org.jboss.weld.context;
+                            org.jboss.weld;
                             org.jboss.weld.ejb;
                             org.jboss.weld.bean;
                             org.jboss.weld.bean.builtin;
                             org.jboss.weld.bean.proxy;
                             org.jboss.weld.*.api.*;
                             org.jboss.weld.*.spi.*;
-                            org.jboss.weld.conversation;
-                            org.jboss.weld;
                             org.jboss.weld.bootstrap;
+                            org.jboss.weld.config;
+                            org.jboss.weld.context;
+                            org.jboss.weld.conversation;
+                            org.jboss.weld.exceptions;
                             org.jboss.weld.event;
                             org.jboss.weld.injection;
                             org.jboss.weld.introspector;


### PR DESCRIPTION
The packages org.jboss.weld.exceptions and org.jboss.weld.config which are required when we use org.jboss.weld.environment/weld-environment-common/2.3.0.Final and org.jboss.weld.servlet/weld-servlet-core/2.3.0.Final in a an OSGI container are not declared within the Packages to be exported

This change should be perhaps backported to 2.3.x branch ?