### PR TITLE
 Update Arq. SE container to CR2, add waitTime option to avoid test f…

### DIFF
--- a/environments/se/tests/src/test/resources/arquillian.xml
+++ b/environments/se/tests/src/test/resources/arquillian.xml
@@ -14,6 +14,7 @@
          <property name="debug">false</property>
          <property name="logLevel">INFO</property>
          <property name="keepDeploymentArchives">false</property>
+         <property name="waitTime">15</property>
       </configuration>
    </container>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <arquillian.drone.version>2.0.0.Alpha5</arquillian.drone.version>
         <arquillian.graphene.version>2.1.0.Alpha2</arquillian.graphene.version>
         <arquillian.weld.version>1.0.0.CR9</arquillian.weld.version>
-        <arquillian.se.container.version>1.0.0.CR1</arquillian.se.container.version>
+        <arquillian.se.container.version>1.0.0.CR2</arquillian.se.container.version>
         <arquillian.tomcat.version>1.0.0.CR6</arquillian.tomcat.version>
         <arquillian.jetty.version>1.0.0.CR2</arquillian.jetty.version>
         <arquillian.glassfish.version>1.0.0.CR1</arquillian.glassfish.version>


### PR DESCRIPTION
…ailures on slower machines

Should be merged after Arq. SE container CR2 release. Setting 'hold' label for now.
Wait time 15 sec is intentionally high to allow even the laziest of Jenkins virtual machines to keep up with it.