### PR TITLE
[JBEAP-2350]   Interceptors in seperated jar not working

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
@@ -494,12 +494,12 @@ public class Validator implements Service {
     }
 
     private void validateEnabledInterceptorClasses(BeanManagerImpl beanManager) {
-        Set<Class<?>> interceptorBeanClasses = new HashSet<Class<?>>();
+        Set<String> interceptorBeanClasses = new HashSet<String>();
         for (Interceptor<?> interceptor : beanManager.getAccessibleInterceptors()) {
-            interceptorBeanClasses.add(interceptor.getBeanClass());
+            interceptorBeanClasses.add(interceptor.getBeanClass().getCanonicalName());
         }
         for (Metadata<Class<?>> enabledInterceptorClass : beanManager.getEnabled().getInterceptors()) {
-            if (!interceptorBeanClasses.contains(enabledInterceptorClass.getValue())) {
+            if (!interceptorBeanClasses.contains(enabledInterceptorClass.getValue().getCanonicalName())) {
                 throw new DeploymentException(INTERCEPTOR_NOT_ANNOTATED_OR_REGISTERED, enabledInterceptorClass);
             }
         }


### PR DESCRIPTION
[BZ-1290277]      Interceptors in seperated jar not working
[GSS-01549262] Interceptors in seperated jar not working

no upstream required

During deployment stage weld is searching for interceptors in jars/ear, once for jars and twice for ears. As we can see, the collection of found interceptors is hash-based and on the second pass (in ear case) it contains com.ych.jar.chronolog.SimpleInterceptor and beamManager also contains the same com.ych.jar.chronolog.SimpleInterceptor, but interceptorBeanClasses.contains (...) fails because of different hashCodes. That's why we see that org.jboss.weld.exceptions.DeploymentException and deployment fail. I think the simplest way to fix this is to change HashSet<Class<?>> to HashSet<String>.
Probably the same problem with Decorators.
