### PR TITLE
WELD-2079 Do not register ScheduledExecutorServiceFactory by default

### DIFF
--- a/docs/reference/src/main/asciidoc/ri-spi.asciidoc
+++ b/docs/reference/src/main/asciidoc/ri-spi.asciidoc
@@ -961,3 +961,5 @@ Instead, this dependency needs to be deployed separately to the OSGi container.
 * Java 6 support was dropped. Java 7 or newer is now required for both compile time and runtime.
 
 * An observer for `@Initialized(ConversationScoped.class)` or `@Destroyed(ConversationScoped.class)` event no longer forces eager conversation context initialization. See also <<_lazy_and_eager_conversation_context_initialization>>.
+
+* `ScheduledExecutorServiceFactory` is deprecated and no default implementation is provided by default. This service has not been used by Weld internals at least since version 1.1.0.Final.

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
@@ -120,11 +120,9 @@ import org.jboss.weld.resources.MemberTransformer;
 import org.jboss.weld.resources.ReflectionCache;
 import org.jboss.weld.resources.ReflectionCacheFactory;
 import org.jboss.weld.resources.SharedObjectCache;
-import org.jboss.weld.resources.SingleThreadScheduledExecutorServiceFactory;
 import org.jboss.weld.resources.WeldClassLoaderResourceLoader;
 import org.jboss.weld.resources.spi.ClassFileServices;
 import org.jboss.weld.resources.spi.ResourceLoader;
-import org.jboss.weld.resources.spi.ScheduledExecutorServiceFactory;
 import org.jboss.weld.serialization.BeanIdentifierIndex;
 import org.jboss.weld.serialization.ContextualStoreImpl;
 import org.jboss.weld.serialization.spi.ContextualStore;
@@ -200,9 +198,6 @@ public class WeldStartup {
         WeldConfiguration configuration = new WeldConfiguration(registry, deployment);
         registry.add(WeldConfiguration.class, configuration);
 
-        if (!registry.contains(ScheduledExecutorServiceFactory.class)) {
-            registry.add(ScheduledExecutorServiceFactory.class, new SingleThreadScheduledExecutorServiceFactory());
-        }
         if (!registry.contains(ProxyServices.class)) {
             registry.add(ProxyServices.class, new SimpleProxyServices());
         }

--- a/impl/src/main/java/org/jboss/weld/resources/SingleThreadScheduledExecutorServiceFactory.java
+++ b/impl/src/main/java/org/jboss/weld/resources/SingleThreadScheduledExecutorServiceFactory.java
@@ -16,11 +16,16 @@
  */
 package org.jboss.weld.resources;
 
-import org.jboss.weld.resources.spi.ScheduledExecutorServiceFactory;
-
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.jboss.weld.resources.spi.ScheduledExecutorServiceFactory;
+
+/**
+*
+* @see WELD-2079
+*/
+@Deprecated
 public class SingleThreadScheduledExecutorServiceFactory implements ScheduledExecutorServiceFactory {
 
     private final ScheduledExecutorService executorService;

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <shrinkwrap.version>1.1.3</shrinkwrap.version>
         <shrinkwrap.descriptors.version>1.1.0-beta-1</shrinkwrap.descriptors.version>
         <testng.version>5.10</testng.version>
-        <weld.api.version>2.3.Final</weld.api.version>
+        <weld.api.version>2.3.SP1</weld.api.version>
         <weld.logging.tools.version>1.0.1.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>1.0.1.Final</wildfly.arquillian.version>
     </properties>
@@ -664,7 +664,7 @@
             </build>
         </profile>
         <profile>
-            <!-- Following profile is automatically triggered in Windows environment and allows to handle behaviour/problems 
+            <!-- Following profile is automatically triggered in Windows environment and allows to handle behaviour/problems
             specific for this OS. For instance excluding a test here will skip its execution on Windows. -->
             <activation>
                 <os>


### PR DESCRIPTION
Travis CI build will fail because Weld API 2.3.SP1 is not in Maven central repo yet.