### PR TITLE
Serialization exception causes fatal error

### DIFF
--- a/modules/ejb/src/main/java/org/jboss/weld/ejb/EnterpriseBeanProxyMethodHandler.java
+++ b/modules/ejb/src/main/java/org/jboss/weld/ejb/EnterpriseBeanProxyMethodHandler.java
@@ -35,6 +35,9 @@ import org.jboss.weld.util.collections.ImmutableMap;
 import org.jboss.weld.util.reflection.HierarchyDiscovery;
 import org.jboss.weld.util.reflection.Reflections;
 
+import com.google.common.collect.ImmutableMap;
+import org.jboss.weld.exceptions.InvalidObjectException;
+
 /**
  * Method handler for enterprise bean client proxies
  *
@@ -158,7 +161,12 @@ class EnterpriseBeanProxyMethodHandler<T> implements MethodHandler, Serializable
 
     @SuppressWarnings("unchecked")
     private Object readResolve() throws ObjectStreamException {
-        return new EnterpriseBeanProxyMethodHandler<T>((SessionBeanImpl<T>) manager.getPassivationCapableBean(beanId), reference);
+        try {
+            return new EnterpriseBeanProxyMethodHandler<T>((SessionBeanImpl<T>) manager.getPassivationCapableBean(beanId), reference);
+        }
+        catch(Exception e) {
+            throw new InvalidObjectException("Weld Serialization Incompatibility");
+        }
     }
 
     private void discoverBusinessInterfaces(Map<Class<?>, Class<?>> typeToBusinessInterfaceMap, Set<Class<?>> businessInterfaces) {

--- a/modules/ejb/src/main/java/org/jboss/weld/ejb/EnterpriseBeanProxyMethodHandler.java
+++ b/modules/ejb/src/main/java/org/jboss/weld/ejb/EnterpriseBeanProxyMethodHandler.java
@@ -35,7 +35,6 @@ import org.jboss.weld.util.collections.ImmutableMap;
 import org.jboss.weld.util.reflection.HierarchyDiscovery;
 import org.jboss.weld.util.reflection.Reflections;
 
-import com.google.common.collect.ImmutableMap;
 import org.jboss.weld.exceptions.InvalidObjectException;
 
 /**


### PR DESCRIPTION
Basically, readResolve() calls a method that fails if an incompatible application saved serialized CDI objects.  These failures cause all subsequent application requests to fail for the same session.
This fix properly handles exceptions and throws InvalidObjectException instead, which causes the session to be expired and the user can log in again, and not have this issue

Here is the thread for this issue:
https://developer.jboss.org/thread/266577?start=0&tstart=0