### PR TITLE
WELD-2115, refactor BOM.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,13 +5,6 @@
     <packaging>pom</packaging>
     <version>2.3.4-SNAPSHOT</version>
 
-    <parent>
-        <groupId>org.jboss.weld</groupId>
-        <artifactId>weld-core-parent</artifactId>
-        <version>2.3.4-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
-    </parent>
-
     <name>Weld Core BOM</name>
 
     <!-- Minimal project metadata, for more see parent/pom.xml -->
@@ -35,80 +28,70 @@
         </developer>
     </developers>
 
-    <dependencies>
+    <properties>
+        <weld.api.bom.version>2.3.SP1</weld.api.bom.version>
+    </properties>
+    
+    <dependencyManagement>
+        <dependencies>
+            <!-- Weld API BOM-->
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-api-bom</artifactId>
+                <version>${weld.api.bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            
+            <!-- Weld core implementation -->
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-core-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-api-bom</artifactId>
-            <version>${weld.api.version}</version>
-            <!-- This seems to cause a NPE if removed -->
-            <scope>import</scope>
-            <type>pom</type>
-        </dependency>
+            <!-- Weld JSF core -->
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-core-jsf</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-impl</artifactId>
-        </dependency>
+            <!-- Weld Servlet Uber Jar -->
+            <dependency>
+                <groupId>org.jboss.weld.servlet</groupId>
+                <artifactId>weld-servlet</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-jsf</artifactId>
-        </dependency>
+            <!-- Weld Servlet Core -->
+            <dependency>
+                <groupId>org.jboss.weld.servlet</groupId>
+                <artifactId>weld-servlet-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-        </dependency>
+            <!-- Weld SE uber Jar -->
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se</artifactId>
+                <version>${project.version}</version>
+            </dependency>
 
-        <dependency>
-            <groupId>org.jboss.weld</groupId>
-            <artifactId>weld-core-test</artifactId>
-        </dependency>
+            <!-- Weld SE Core -->
+            <dependency>
+                <groupId>org.jboss.weld.se</groupId>
+                <artifactId>weld-se-core</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
-        <dependency>
-            <groupId>org.jboss.weld.servlet</groupId>
-            <artifactId>weld-servlet</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.weld.servlet</groupId>
-            <artifactId>weld-servlet-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss.classfilewriter</groupId>
-            <artifactId>jboss-classfilewriter</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject-tck</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-
-    </dependencies>
-
-    <!-- SCM and distribution management -->
+    <!-- SCM -->
     <scm>
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-      <tag>HEAD</tag>
-  </scm>
-
+        <tag>HEAD</tag>
+    </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
         <module>jsf</module>
         <module>bundles/impl</module>
         <module>probe</module>
+        <module>bom</module>
     </modules>
 
     <!-- Dependency management. KEEP IN ALPHABETICAL ORDER -->
@@ -119,8 +120,8 @@
             </dependency>
 
             <dependency>
-               <groupId>org.jboss.spec.javax.el</groupId>
-               <artifactId>jboss-el-api_3.0_spec</artifactId>
+                <groupId>org.jboss.spec.javax.el</groupId>
+                <artifactId>jboss-el-api_3.0_spec</artifactId>
                 <version>${jboss.spec.el-api.version}</version>
             </dependency>
 
@@ -137,22 +138,22 @@
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.logging</groupId>
-              <artifactId>jboss-logging-processor</artifactId>
-              <version>${jboss.logging.processor.version}</version>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging-processor</artifactId>
+                <version>${jboss.logging.processor.version}</version>
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.logging</groupId>
-              <artifactId>jboss-logging</artifactId>
-              <version>${jboss.logging.version}</version>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${jboss.logging.version}</version>
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.logmanager</groupId>
-              <artifactId>jboss-logmanager</artifactId>
-              <version>${jboss.logmanager.version}</version>
-              <scope>test</scope>
+                <groupId>org.jboss.logmanager</groupId>
+                <artifactId>jboss-logmanager</artifactId>
+                <version>${jboss.logmanager.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -306,6 +307,14 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-api-bom</artifactId>
+                <version>${weld.api.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-api-parent</artifactId>
                 <version>${weld.api.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
@@ -485,7 +494,7 @@
                     <version>${selenium.maven.plugin.version}</version>
                 </plugin>
                 <!-- So m2e doesn't throw errors for features it doesn't
-                    support in the POM -->
+                support in the POM -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -533,8 +542,8 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
 
     <profiles>


### PR DESCRIPTION
Re-worked BOM - it now only contains ```dependencyManagement``` section and no direct dependencies.
Also it has no parent in order to avoid fetching unnecessary stuff (depending on weld-core-parent brought in loads of other things).

@tremes WDYT? Does this solution make sense? Or should we do it some other way, e.g. create common parent  somewhere?