### PR TITLE
WELD-2064 with configurable parameter and an automated test

### DIFF
--- a/docs/reference/src/main/asciidoc/configure.asciidoc
+++ b/docs/reference/src/main/asciidoc/configure.asciidoc
@@ -187,6 +187,21 @@ This optimization is used to reduce the HTTP session replication overhead. Howev
 
 NOTE: This optimization is disabled by default in <<weld-servlet,Servlet containers>>.
 
+==== Rolling upgrades ID delimiter
+
+The delimiter is used while generating IDs, such as bean ID. The original ID, obtained from
+`BeanDeploymentArchive.getId()`, will be abbreviated based on the provided delimiter.
+An example: Given an application with two versions going by the names __test+++__+++1-1.war__ and __test+++__+++1-2.war__, Weld normally
+cannot replicate sessions between these two deployments. Using this configuration option with delimiter "__" will allow Weld to
+see both applications simply as test.war, hence allowing for session replication.
+
+.Supported configuration properties
+[cols=",,",options="header",]
+|=======================================================================
+|Configuration key |Default value |Description
+|`org.jboss.weld.clustering.rollingUpgradesIdDelimiter` ||The delimiter used during ID generation.
+|=======================================================================
+
 [[config-dev-mode]]
 ==== Development Mode
 

--- a/impl/src/main/java/org/jboss/weld/Container.java
+++ b/impl/src/main/java/org/jboss/weld/Container.java
@@ -38,8 +38,6 @@ import org.jboss.weld.manager.BeanManagerImpl;
 public class Container {
     public static final String CONTEXT_ID_KEY = "WELD_CONTEXT_ID_KEY";
 
-    public static final ThreadLocal<String> currentId = new ThreadLocal<String>();
-
     private static Singleton<Container> instance;
 
     static {

--- a/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployment.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployment.java
@@ -104,7 +104,8 @@ public class BeanDeployment {
         services.add(WSApiAbstraction.class, new WSApiAbstraction(resourceLoader));
         services.add(InterceptorsApiAbstraction.class, new InterceptorsApiAbstraction(resourceLoader));
         services.add(AnnotationApiAbstraction.class, new AnnotationApiAbstraction(resourceLoader));
-        this.beanManager = BeanManagerImpl.newManager(deploymentManager, beanDeploymentArchive.getId(), services);
+        this.beanManager = BeanManagerImpl.newManager(deploymentManager,
+                WeldBootstrap.stripArchiveIdSuffix(beanDeploymentArchive.getId()), services);
         services.add(InjectionTargetService.class, new InjectionTargetService(beanManager));
 
         services.get(WeldModules.class).postBeanArchiveServiceRegistration(services, beanManager, beanDeploymentArchive);

--- a/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployment.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployment.java
@@ -17,6 +17,8 @@
 package org.jboss.weld.bootstrap;
 
 import static java.util.Collections.emptyList;
+
+import static org.jboss.weld.config.ConfigurationKey.ROLLING_UPGRADES_ID_DELIMITER;
 import static org.jboss.weld.config.ConfigurationKey.CONCURRENT_DEPLOYMENT;
 
 import java.util.Collection;
@@ -104,8 +106,9 @@ public class BeanDeployment {
         services.add(WSApiAbstraction.class, new WSApiAbstraction(resourceLoader));
         services.add(InterceptorsApiAbstraction.class, new InterceptorsApiAbstraction(resourceLoader));
         services.add(AnnotationApiAbstraction.class, new AnnotationApiAbstraction(resourceLoader));
-        this.beanManager = BeanManagerImpl.newManager(deploymentManager,
-                WeldBootstrap.stripArchiveIdSuffix(beanDeploymentArchive.getId()), services);
+        String finalContextId = BeanDeployments.getFinalId(beanDeploymentArchive.getId(),
+            services.get(WeldConfiguration.class).getStringProperty(ROLLING_UPGRADES_ID_DELIMITER));
+        this.beanManager = BeanManagerImpl.newManager(deploymentManager, finalContextId, services);
         services.add(InjectionTargetService.class, new InjectionTargetService(beanManager));
 
         services.get(WeldModules.class).postBeanArchiveServiceRegistration(services, beanManager, beanDeploymentArchive);

--- a/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployments.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployments.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.bootstrap;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+class BeanDeployments {
+
+    /** Takes archiveId and removes the delimiter and anything beyond that.
+     * Used while creating archives if there was a delimiter specified.
+     *
+     * @param archiveId The ID of archive to be stripped of its affix
+     * @param delimiter Delimiter defined via ConfigurationKey, empty String otherwise
+     * @return archiveId if the delimiter was empty String, a substring of archiveId from index zero to the first occurrence of delimiter
+     */
+    static String getFinalId(String archiveId, String delimiter) {
+        if (delimiter.isEmpty()) {
+            return archiveId;
+        } else {
+            int idx = archiveId.indexOf(delimiter);
+            return archiveId.substring(0, idx >= 0 ? idx : archiveId.length());
+        }
+    }
+
+    private BeanDeployments() {
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
@@ -66,7 +66,7 @@ public class WeldBootstrap implements CDI11Bootstrap {
 
     @Override
     public synchronized Bootstrap startContainer(String contextId, Environment environment, Deployment deployment) {
-        weldRuntime = weldStartup.startContainer(stripArchiveIdSuffix(contextId), environment, deployment);
+        weldRuntime = weldStartup.startContainer(contextId, environment, deployment);
         return this;
     }
 
@@ -150,12 +150,4 @@ public class WeldBootstrap implements CDI11Bootstrap {
             throw BootstrapLogger.LOG.callingBootstrapMethodAfterContainerHasBeenInitialized();
         }
     }
-
-    static String stripArchiveIdSuffix(String archiveId) {
-        int idx = archiveId.indexOf(ARCHIVE_SUFFIX_DELIMITER);
-        return archiveId.substring(0, idx >= 0 ? idx : archiveId.length());
-    }
-
-
-    private static final String ARCHIVE_SUFFIX_DELIMITER = "..";
 }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
@@ -66,7 +66,7 @@ public class WeldBootstrap implements CDI11Bootstrap {
 
     @Override
     public synchronized Bootstrap startContainer(String contextId, Environment environment, Deployment deployment) {
-        weldRuntime = weldStartup.startContainer(contextId, environment, deployment);
+        weldRuntime = weldStartup.startContainer(stripArchiveIdSuffix(contextId), environment, deployment);
         return this;
     }
 
@@ -150,4 +150,12 @@ public class WeldBootstrap implements CDI11Bootstrap {
             throw BootstrapLogger.LOG.callingBootstrapMethodAfterContainerHasBeenInitialized();
         }
     }
+
+    static String stripArchiveIdSuffix(String archiveId) {
+        int idx = archiveId.indexOf(ARCHIVE_SUFFIX_DELIMITER);
+        return archiveId.substring(0, idx >= 0 ? idx : archiveId.length());
+    }
+
+
+    private static final String ARCHIVE_SUFFIX_DELIMITER = "..";
 }

--- a/impl/src/main/java/org/jboss/weld/config/ConfigurationKey.java
+++ b/impl/src/main/java/org/jboss/weld/config/ConfigurationKey.java
@@ -34,6 +34,13 @@ public enum ConfigurationKey {
      * Otherwise, single-threaded version of Deployer and Validator are used.
      *
      * By default, concurrent deployment is enabled.
+     *//**
+     * Indicates whether ConcurrentDeployer and ConcurrentValidator should be enabled. If enabled, ConcurrentDeployer and ConcurrentValidator execute their
+     * subtasks using {@link org.jboss.weld.manager.api.ExecutorServices} which can be configured separately.
+     *
+     * Otherwise, single-threaded version of Deployer and Validator are used.
+     *
+     * By default, concurrent deployment is enabled.
      */
     @Description("Indicates whether the concurrent deployment is enabled.")
     CONCURRENT_DEPLOYMENT("org.jboss.weld.bootstrap.concurrentDeployment", true),
@@ -228,8 +235,17 @@ public enum ConfigurationKey {
      *  Conversation concurrent access timeout in milliseconds represents maximum time to wait on the conversation concurrent lock. Default value is 1000 ms.
      */
     @Description("The maximum time to wait on the lock of conversation in milliseconds.")
-    CONVERSATION_CONCURRENT_ACCESS_TIMEOUT("org.jboss.weld.conversation.concurrentAccessTimeout", 1000L);
+    CONVERSATION_CONCURRENT_ACCESS_TIMEOUT("org.jboss.weld.conversation.concurrentAccessTimeout", 1000L),
 
+    /**
+     * The delimiter is used while generating IDs, such as bean ID. The original ID, obtained from
+     * <code>BeanDeploymentArchive.getId()</code>, will be abbreviated based on the provided delimiter.
+     * An example: Given an application with two versions going by the names test__1.1.war and test__1.2.war, Weld normally
+     * cannot replicate sessions between these two deployments. Passing in this option with delimiter "__" will allow Weld to
+     * see both applications simply as test.war, hence allowing for session replication.
+     */
+    @Description("The delimiter is used while generating IDs, such as bean ID. The original ID will be abbreviated based on the provided delimiter.")
+    ROLLING_UPGRADES_ID_DELIMITER("org.jboss.weld.clustering.rollingUpgradesIdDelimiter", "");
     /**
      *
      * @param key The string representation of the key

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/id/delimiter/AllKnowingBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/id/delimiter/AllKnowingBean.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.id.delimiter;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class AllKnowingBean {
+      
+    public int getAnswerToLifeUniverseAndEverything() {
+        return 42;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/id/delimiter/RemoveArchiveSuffixTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/id/delimiter/RemoveArchiveSuffixTest.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.id.delimiter;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.weld.bean.ManagedBean;
+import org.jboss.weld.config.ConfigurationKey;
+import org.jboss.weld.tests.category.Integration;
+import org.jboss.weld.tests.util.PropertiesBuilder;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/** @see WELD-2064
+ * Tests the configuration option -> ROLLING_UPGRADES_ID_DELIMITER
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RunWith(Arquillian.class)
+@Category(Integration.class)
+public class RemoveArchiveSuffixTest {
+
+    private static final String AFFIX = "version-1-1.war";   
+    private static final String ARCHIVE_NAME = "archive";
+    private static final String DELIMITER = "__";
+    private static final String FULL_ARCHIVE_NAME = ARCHIVE_NAME + DELIMITER + AFFIX;
+
+
+    @Inject
+    private AllKnowingBean allKnowingBean;
+    @Inject
+    private BeanManager manager;
+    
+    @Deployment
+    public static WebArchive getDeployment() {
+        WebArchive testDeployment = ShrinkWrap
+            .create(WebArchive.class, FULL_ARCHIVE_NAME)
+            .addPackage(RemoveArchiveSuffixTest.class.getPackage())
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+            .addAsResource(PropertiesBuilder.newBuilder().set(ConfigurationKey.ROLLING_UPGRADES_ID_DELIMITER.get(), DELIMITER).build(),
+                "weld.properties");
+        return testDeployment;
+    }
+
+    @Test
+    public void testIdWasChangedCorrectly() {
+        allKnowingBean.getAnswerToLifeUniverseAndEverything();
+        Set<Bean<?>> beans = manager.getBeans(AllKnowingBean.class);
+        
+        // there should only be one bean
+        assertTrue(beans.size() == 1);
+        
+        // cast to ManagedBean to be abble to obtain the identifier
+        String identifier = ((ManagedBean<AllKnowingBean>) beans.iterator().next()).getIdentifier().asString();
+        
+        // resulting ID should have archiveName, but should NOT have delimiter and affix
+        assertTrue(identifier.contains(ARCHIVE_NAME));
+        assertFalse(identifier.contains(DELIMITER));
+        assertFalse(identifier.contains(AFFIX));
+        
+    }
+}


### PR DESCRIPTION
Built on top of Lenny's original commit.

Introduces a configurable property allowing to set a delimiter for a bean archive ID.
I am still trying to figure out the bootstrapping part in WeldStartup. 
Also there is an automated test added which I believe could do the right thing.

In the current form, the tests-arquillian as well as unit tests in core impl pass, though I am unsure it is a correct solution.

Furthermore the names of the properties and the helper class are a subject for discussion :)