### PR TITLE
WELD-2149 Weld build fails on checkstyle with JDK9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-parent</artifactId>
-        <version>33</version>
+        <version>34-SNAPSHOT</version>
     </parent>
 
     <prerequisites>
@@ -43,7 +43,7 @@
         <arquillian.jetty.version>1.0.0.CR3</arquillian.jetty.version>
         <arquillian.glassfish.version>1.0.0.CR1</arquillian.glassfish.version>
         <atinject.tck.version>1</atinject.tck.version>
-        <build.config.version>9</build.config.version>
+        <build.config.version>10-SNAPSHOT</build.config.version>
         <bundle.plugin.version>2.5.3</bundle.plugin.version>
         <cdi.tck-1-2.version>1.2.9.Final</cdi.tck-1-2.version>
         <cdi.tck-2-0.version>2.0.0.Alpha7</cdi.tck-2-0.version>


### PR DESCRIPTION
WELD-2149 Weld build fails on checkstyle with JDK9
- Change Weld Parent version to use correct version of checkstyle
- Change Weld common build version to remove tools.jar dependency when under JDK9