### PR TITLE
QualifierInstance - improve failure description

### DIFF
--- a/impl/src/main/java/org/jboss/weld/logging/ResolutionLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/ResolutionLogger.java
@@ -19,9 +19,11 @@ package org.jboss.weld.logging;
 import static org.jboss.weld.logging.WeldLogger.WELD_PROJECT_CODE;
 
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.Message.Format;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.weld.exceptions.WeldException;
 
 /**
  * Log messages for resolution classes.
@@ -51,5 +53,8 @@ public interface ResolutionLogger extends WeldLogger {
     @Deprecated
     @Message(id = 1602, value = "Unable to extract type information from {0}", format = Format.MESSAGE_FORMAT)
     String cannotExtractTypeInformation(Object param1);
+
+    @Message(id = 1603, value = "Cannot create qualifier instance model for {0}\n\tat {1}\n  StackTrace:", format = Format.MESSAGE_FORMAT)
+    WeldException cannotCreateQualifierInstanceValues(Object annotation, Object stackElement, @Cause Exception cause);
 
 }

--- a/impl/src/main/java/org/jboss/weld/resolution/QualifierInstance.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/QualifierInstance.java
@@ -30,12 +30,13 @@ import javax.enterprise.inject.spi.Bean;
 import javax.inject.Named;
 
 import org.jboss.weld.bean.RIBean;
-import org.jboss.weld.exceptions.WeldException;
+import org.jboss.weld.logging.ResolutionLogger;
 import org.jboss.weld.metadata.cache.MetaAnnotationStore;
 import org.jboss.weld.metadata.cache.QualifierModel;
 import org.jboss.weld.security.SetAccessibleAction;
 import org.jboss.weld.util.collections.ArraySet;
 import org.jboss.weld.util.collections.WeldCollections;
+import org.jboss.weld.util.reflection.Formats;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableMap;
@@ -127,9 +128,11 @@ public class QualifierInstance {
                     }
                     builder.put(method.getJavaMember().getName(), method.getJavaMember().invoke(instance));
                 } catch (IllegalAccessException e) {
-                    throw new WeldException(e);
+                    throw ResolutionLogger.LOG.cannotCreateQualifierInstanceValues(instance, Formats.formatAsStackTraceElement(method.getJavaMember()), e);
                 } catch (InvocationTargetException e) {
-                    throw new WeldException(e);
+                    throw ResolutionLogger.LOG.cannotCreateQualifierInstanceValues(instance, Formats.formatAsStackTraceElement(method.getJavaMember()), e);
+                } catch (IllegalArgumentException e) {
+                    throw ResolutionLogger.LOG.cannotCreateQualifierInstanceValues(instance, Formats.formatAsStackTraceElement(method.getJavaMember()), e);
                 }
             }
         }

--- a/impl/src/main/java/org/jboss/weld/util/reflection/Formats.java
+++ b/impl/src/main/java/org/jboss/weld/util/reflection/Formats.java
@@ -64,6 +64,10 @@ public class Formats {
             // Throwing an exception here would hide the original exception.
             return "-";
         }
+        return Formats.formatAsStackTraceElement(member);
+    }
+
+    public static String formatAsStackTraceElement(Member member) {
         return member.getDeclaringClass().getName()
             + "." + (member instanceof Constructor<?> ? "<init>" : member.getName())
             + "(" + getFileName(member.getDeclaringClass()) + ":" + getLineNumber(member) + ")";


### PR DESCRIPTION
I backported #1357 to weld 2.2.x, so it can be added to wildfly 9 if needed.

The output is:

```
10:44:31,096 ERROR [org.jboss.msc.service.fail] (MSC service thread 1-1) MSC000001: Failed to start service jboss.deployment.unit."foo-app.ear".WeldStartService: org.jboss.msc.service.StartException in service jboss.deployment.unit."foo-app.ear".WeldStartService: Failed to start service
	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1904)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: org.jboss.weld.exceptions.WeldException: WELD-001603: Cannot create qualifier instance model for @com.foo.plan.PlanQualifier(value=MICRO_ANUAL)
	at com.foo.plan.PlanQualifier.value(PlanQualifier.java:0)
  StackTrace:
	at org.jboss.weld.resolution.QualifierInstance.createValues(QualifierInstance.java:135)
	at org.jboss.weld.resolution.QualifierInstance.of(QualifierInstance.java:96)
	at org.jboss.weld.resolution.ResolvableBuilder.addQualifier(ResolvableBuilder.java:147)
	at org.jboss.weld.resolution.ResolvableBuilder.addQualifiers(ResolvableBuilder.java:197)
	at org.jboss.weld.resolution.ResolvableBuilder.addQualifiers(ResolvableBuilder.java:192)
	at org.jboss.weld.manager.BeanManagerImpl.resolveDecorators(BeanManagerImpl.java:904)
	at org.jboss.weld.injection.producer.BeanInjectionTarget.initializeAfterBeanDiscovery(BeanInjectionTarget.java:108)
	at org.jboss.weld.injection.producer.InjectionTargetInitializationContext.initialize(InjectionTargetInitializationContext.java:42)
	at org.jboss.weld.injection.producer.InjectionTargetService.initialize(InjectionTargetService.java:63)
	at org.jboss.weld.bootstrap.WeldStartup.deployBeans(WeldStartup.java:431)
	at org.jboss.weld.bootstrap.WeldBootstrap.deployBeans(WeldBootstrap.java:83)
	at org.jboss.as.weld.WeldStartService.start(WeldStartService.java:93)
	at org.jboss.msc.service.ServiceControllerImpl$StartTask.startService(ServiceControllerImpl.java:1948)
	at org.jboss.msc.service.ServiceControllerImpl$StartTask.run(ServiceControllerImpl.java:1881)
	... 3 more
Caused by: java.lang.IllegalArgumentException: object is not an instance of declaring class
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.weld.resolution.QualifierInstance.createValues(QualifierInstance.java:129)
	... 16 more

10:44:31,180 ERROR [org.jboss.as.controller.management-operation] (Controller Boot Thread) WFLYCTL0013: Operation ("deploy") failed - address: ([("deployment" => "foo-app.ear")]) - failure description: {"WFLYCTL0080: Failed services" => {"jboss.deployment.unit.\"foo-app.ear\".WeldStartService" => "org.jboss.msc.service.StartException in service jboss.deployment.unit.\"foo-app.ear\".WeldStartService: Failed to start service
    Caused by: org.jboss.weld.exceptions.WeldException: WELD-001603: Cannot create qualifier instance model for @com.foo.plan.PlanQualifier(value=MICRO_ANUAL)
	at com.foo.plan.PlanQualifier.value(PlanQualifier.java:0)
  StackTrace:
    Caused by: java.lang.IllegalArgumentException: object is not an instance of declaring class"}}
```