### PR TITLE
Correct links in Weld doc to point into CDI 1.2 specification

### DIFF
--- a/docs/reference/src/main/asciidoc/configure.asciidoc
+++ b/docs/reference/src/main/asciidoc/configure.asciidoc
@@ -256,8 +256,8 @@ to deployment problem.
 CDI 1.1 allows you to exclude classes in your archive from being
 scanned, having container lifecycle events fired, and being deployed as
 beans. See also
-http://docs.jboss.org/cdi/spec/1.1/cdi-spec.html#bean_discovery[12.4.
-Bean discovery].
+http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#exclude_filters[12.4.2
+Exclude filters].
 
 NOTE: Weld still supports the original non-portable way of excluding classes
 from discovery. The formal specification can be found in the xsd,

--- a/docs/reference/src/main/asciidoc/ee.asciidoc
+++ b/docs/reference/src/main/asciidoc/ee.asciidoc
@@ -261,7 +261,7 @@ archive.
 
 NOTE: Any scope type is a bean defining annotation. If you place a scope type
 on a bean class, then it has a bean defining annotation. See
-http://docs.jboss.org/cdi/spec/1.1/cdi-spec.html#bean_defining_annotations[2.5.
+http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#bean_defining_annotations[2.5.1.
 Bean defining annotations] to learn more.
 
 ==== What archive is not a bean archive

--- a/docs/reference/src/main/asciidoc/injection.asciidoc
+++ b/docs/reference/src/main/asciidoc/injection.asciidoc
@@ -388,7 +388,7 @@ To fix an _ambiguous dependency_, either:
 * introduce a qualifier to distinguish between the two implementations
 of the bean type,
 * exclude one of the beans from discovery (either by means of
-http://docs.jboss.org/cdi/api/1.1/javax/enterprise/inject/Vetoed.html[@Vetoed]
+http://docs.jboss.org/cdi/api/1.2/javax/enterprise/inject/Vetoed.html[@Vetoed]
 or `beans.xml`),
 * disable one of the beans by annotating it `@Alternative`,
 * move one of the implementations to a module that is not in the

--- a/docs/reference/src/main/asciidoc/ri-spi.asciidoc
+++ b/docs/reference/src/main/asciidoc/ri-spi.asciidoc
@@ -511,7 +511,7 @@ bytecode-scanning capabilities to Weld. If present, Weld will try to use
 the service to avoid loading of classes that do not need to be loaded.
 These are classes that:
 
-* are not http://docs.jboss.org/cdi/spec/1.1/cdi-spec.html#what_classes_are_beans[CDI managed beans] and
+* are not http://docs.jboss.org/cdi/spec/1.2/cdi-spec.html#what_classes_are_beans[CDI managed beans] and
 * are not assignable to any ProcessAnnotatedType observer
 
 This usually yields improved bootstrap performance especially in large


### PR DESCRIPTION
I found out Weld doc has linnks to CDI 1.1  spec instead of CDI 1.2.
Grep showed me only these three occurrences, so here is a PR.