### PR TITLE
WELD-2155 JDK9: force-add java BCEL internal classes to unnamed module

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -149,6 +149,26 @@
 
     <profiles>
         <profile>
+            <id>jdk9</id>
+            <activation>
+                <!--auto-activate on JDK 1.9+-->
+                <jdk>[1.9,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <!-- Temporary workaround to ensure BCEL internal classes are available in JDK 9. Force-exports these packages into unnamed module.-->
+                        <!-- Later on we should seek another approach! -->
+                        <configuration>
+                            <argLine>-XaddExports:java.xml/com.sun.org.apache.bcel.internal=ALL-UNNAMED -XaddExports:java.xml/com.sun.org.apache.bcel.internal.classfile=ALL-UNNAMED</argLine>                            
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>javax.xml.ws</id>
             <activation>
                 <jdk>1.5</jdk>


### PR DESCRIPTION
This is probably the easiest solution to WELD-2155. Yet it might be temporary (in a very long term with regard to Java development speed) as this approach might be deprecated.

The idea is to force-export internal java modules (BCEL classes for our `Formats` class) into unnamed module hence making them accessible for Weld. This is done via a profile which only kicks in when running JDK 9.