### PR TITLE
Weld-2195 Guava: new collection types

### DIFF
--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/AbstractEnhancedAnnotated.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/AbstractEnhancedAnnotated.java
@@ -39,8 +39,8 @@ import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.logging.ReflectionLogger;
 import org.jboss.weld.resources.ClassTransformer;
 import org.jboss.weld.util.collections.ArraySet;
-import org.jboss.weld.util.collections.ArraySetMultimap;
 import org.jboss.weld.util.collections.Arrays2;
+import org.jboss.weld.util.collections.SetMultimap;
 import org.jboss.weld.util.reflection.Reflections;
 
 /**
@@ -88,23 +88,16 @@ public abstract class AbstractEnhancedAnnotated<T, S> implements EnhancedAnnotat
         return annotationMap;
     }
 
-
-    protected static void addMetaAnnotations(ArraySetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap, Annotation annotation, Annotation[] metaAnnotations, boolean declared) {
+    protected static void addMetaAnnotations(SetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap, Annotation annotation, Iterable<Annotation> metaAnnotations, boolean declared) {
         for (Annotation metaAnnotation : metaAnnotations) {
             addMetaAnnotation(metaAnnotationMap, annotation, metaAnnotation.annotationType(), declared);
         }
     }
 
-    protected static void addMetaAnnotations(ArraySetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap, Annotation annotation, Iterable<Annotation> metaAnnotations, boolean declared) {
-        for (Annotation metaAnnotation : metaAnnotations) {
-            addMetaAnnotation(metaAnnotationMap, annotation, metaAnnotation.annotationType(), declared);
-        }
-    }
-
-    private static void addMetaAnnotation(ArraySetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap, Annotation annotation, Class<? extends Annotation> metaAnnotationType, boolean declared) {
+    private static void addMetaAnnotation(SetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap, Annotation annotation, Class<? extends Annotation> metaAnnotationType, boolean declared) {
         // Only map meta-annotations we are interested in
         if (declared ? MAPPED_DECLARED_METAANNOTATIONS.contains(metaAnnotationType) : MAPPED_METAANNOTATIONS.contains(metaAnnotationType)) {
-            metaAnnotationMap.putSingleElement(metaAnnotationType, annotation);
+            metaAnnotationMap.put(metaAnnotationType, annotation);
         }
     }
 
@@ -112,7 +105,7 @@ public abstract class AbstractEnhancedAnnotated<T, S> implements EnhancedAnnotat
     private final Map<Class<? extends Annotation>, Annotation> annotationMap;
     // The meta-annotation map (annotation type -> set of annotations containing
     // meta-annotation) of the item
-    private final ArraySetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap;
+    private final SetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap;
 
     private final Class<T> rawType;
     private final Type[] actualTypeArguments;
@@ -138,7 +131,7 @@ public abstract class AbstractEnhancedAnnotated<T, S> implements EnhancedAnnotat
             throw ReflectionLogger.LOG.annotationMapNull();
         }
         this.annotationMap = immutableMap(annotationMap);
-        ArraySetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap = new ArraySetMultimap<Class<? extends Annotation>, Annotation>();
+        SetMultimap<Class<? extends Annotation>, Annotation> metaAnnotationMap = SetMultimap.newSetMultimap();
         for (Annotation annotation : annotationMap.values()) {
 
             // WELD-1310 Include synthetic annotations
@@ -146,7 +139,7 @@ public abstract class AbstractEnhancedAnnotated<T, S> implements EnhancedAnnotat
                     .getSyntheticAnnotationAnnotatedType(annotation.annotationType());
             if (syntheticAnnotationAnnotatedType == null) {
                 addMetaAnnotations(metaAnnotationMap, annotation,
-                        classTransformer.getReflectionCache().getAnnotations(annotation.annotationType()), false);
+                        classTransformer.getReflectionCache().getAnnotationSet(annotation.annotationType()), false);
             } else {
                 addMetaAnnotations(metaAnnotationMap, annotation, syntheticAnnotationAnnotatedType.getAnnotations(), false);
             }

--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
@@ -268,11 +268,6 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
             this.declaredMethods = new ArraySet<EnhancedAnnotatedMethod<?, ? super T>>(declaredMethodsTemp);
         }
 
-//<<<<<<< HEAD
-//        this.declaredMethods.trimToSize();
-//        this.declaredAnnotatedMethods.trimToSize();
-//        this.declaredMethodsByAnnotatedParameters.trimToSize();
-//
             SetMultimap<Class<? extends Annotation>, Annotation> declaredMetaAnnotationMap = SetMultimap.newSetMultimap();
             for (Annotation declaredAnnotation : declaredAnnotationMap.values()) {
 

--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
@@ -16,7 +16,6 @@
  */
 package org.jboss.weld.annotated.enhanced.jlr;
 
-import static org.jboss.weld.util.collections.WeldCollections.immutableMap;
 import static org.jboss.weld.util.collections.WeldCollections.immutableSet;
 
 import java.lang.annotation.Annotation;
@@ -28,7 +27,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -52,17 +50,15 @@ import org.jboss.weld.interceptor.spi.model.InterceptionType;
 import org.jboss.weld.interceptor.util.InterceptionTypeRegistry;
 import org.jboss.weld.resources.ClassTransformer;
 import org.jboss.weld.util.collections.ArraySet;
-import org.jboss.weld.util.collections.ArraySetMultimap;
 import org.jboss.weld.util.collections.Arrays2;
 import org.jboss.weld.util.collections.ImmutableSet;
+import org.jboss.weld.util.collections.ListMultimap;
 import org.jboss.weld.util.collections.Multimap;
 import org.jboss.weld.util.collections.Multimaps;
 import org.jboss.weld.util.collections.SetMultimap;
 import org.jboss.weld.util.collections.Sets;
 import org.jboss.weld.util.reflection.Formats;
 import org.jboss.weld.util.reflection.Reflections;
-
-import com.google.common.collect.ArrayListMultimap;
 
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
@@ -100,12 +96,12 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     // The set of abstracted fields
     private final Set<EnhancedAnnotatedField<?, ? super T>> fields;
     // The map from annotation type to abstracted field with annotation
-    private final ArrayListMultimap<Class<? extends Annotation>, EnhancedAnnotatedField<?, ?>> annotatedFields;
+    private final ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedField<?, ?>> annotatedFields;
 
     // The set of abstracted fields
-    private final ArraySet<EnhancedAnnotatedField<?, ? super T>> declaredFields;
+    private final Set<EnhancedAnnotatedField<?, ? super T>> declaredFields;
     // The map from annotation type to abstracted field with annotation
-    private final ArrayListMultimap<Class<? extends Annotation>, EnhancedAnnotatedField<?, ? super T>> declaredAnnotatedFields;
+    private final ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedField<?, ? super T>> declaredAnnotatedFields;
 
     // The set of abstracted methods
     private final Set<EnhancedAnnotatedMethod<?, ? super T>> methods;
@@ -119,9 +115,9 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     // The set of abstracted methods
     private final ArraySet<EnhancedAnnotatedMethod<?, ? super T>> declaredMethods;
     // The map from annotation type to abstracted method with annotation
-    private final ArrayListMultimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> declaredAnnotatedMethods;
+    private final ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> declaredAnnotatedMethods;
     // The map from annotation type to method with a parameter with annotation
-    private final ArrayListMultimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> declaredMethodsByAnnotatedParameters;
+    private final ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> declaredMethodsByAnnotatedParameters;
 
     // The set of abstracted constructors
     private final ArraySet<EnhancedAnnotatedConstructor<T>> constructors;
@@ -129,7 +125,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
 
     // The meta-annotation map (annotation type -> set of annotations containing
     // meta-annotation) of the item
-    private final Map<Class<? extends Annotation>, List<Annotation>> declaredMetaAnnotationMap;
+    private final Multimap<Class<? extends Annotation>, Annotation> declaredMetaAnnotationMap;
 
     private final boolean discovered;
 
@@ -161,7 +157,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
         }
 
         // Assign class field information
-        this.declaredAnnotatedFields = ArrayListMultimap.<Class<? extends Annotation>, EnhancedAnnotatedField<?, ? super T>>create();
+        this.declaredAnnotatedFields = new ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedField<?, ? super T>>();
         Set<EnhancedAnnotatedField<?, ? super T>> fieldsTemp = null;
         ArrayList<EnhancedAnnotatedField<?, ? super T>> declaredFieldsTemp = new ArrayList<EnhancedAnnotatedField<?, ? super T>>();
 
@@ -186,7 +182,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
             }
             this.declaredFields = new ArraySet<EnhancedAnnotatedField<?, ? super T>>(declaredFieldsTemp);
         } else {
-            this.annotatedFields = ArrayListMultimap.<Class<? extends Annotation>, EnhancedAnnotatedField<?, ?>>create();
+            this.annotatedFields = new ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedField<?, ?>>();
             fieldsTemp = new HashSet<EnhancedAnnotatedField<?, ? super T>>();
             for (AnnotatedField<? super T> annotatedField : annotatedType.getFields()) {
                 EnhancedAnnotatedField<?, ? super T> weldField = EnhancedAnnotatedFieldImpl.of(annotatedField, this, classTransformer);
@@ -201,13 +197,9 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
                     }
                 }
             }
-            this.declaredFields = new ArraySet<EnhancedAnnotatedField<?, ? super T>>(declaredFieldsTemp);
-            fieldsTemp = new ArraySet<EnhancedAnnotatedField<?, ? super T>>(fieldsTemp).trimToSize();
-            this.annotatedFields.trimToSize();
+            this.declaredFields = new HashSet<EnhancedAnnotatedField<?, ? super T>>(declaredFieldsTemp);
         }
         this.fields = fieldsTemp;
-        this.declaredFields.trimToSize();
-        this.declaredAnnotatedFields.trimToSize();
 
         // Assign constructor information
         this.constructors = new ArraySet<EnhancedAnnotatedConstructor<T>>();
@@ -221,8 +213,8 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
         this.constructors.trimToSize();
 
         // Assign method information
-        this.declaredAnnotatedMethods = ArrayListMultimap.<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>>create();
-        this.declaredMethodsByAnnotatedParameters = ArrayListMultimap.<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>>create();
+        this.declaredAnnotatedMethods = new ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>>();
+        this.declaredMethodsByAnnotatedParameters = new ListMultimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>>();
 
         Set<EnhancedAnnotatedMethod<?, ? super T>> methodsTemp = new HashSet<EnhancedAnnotatedMethod<?,? super T>>();
         ArrayList<EnhancedAnnotatedMethod<?, ? super T>> declaredMethodsTemp = new ArrayList<EnhancedAnnotatedMethod<?, ? super T>>();
@@ -276,28 +268,29 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
             this.declaredMethods = new ArraySet<EnhancedAnnotatedMethod<?, ? super T>>(declaredMethodsTemp);
         }
 
-        this.declaredMethods.trimToSize();
-        this.declaredAnnotatedMethods.trimToSize();
-        this.declaredMethodsByAnnotatedParameters.trimToSize();
-
-        ArraySetMultimap<Class<? extends Annotation>, Annotation> declaredMetaAnnotationMap = new ArraySetMultimap<Class<? extends Annotation>, Annotation>();
-        for (Annotation declaredAnnotation : declaredAnnotationMap.values()) {
+//<<<<<<< HEAD
+//        this.declaredMethods.trimToSize();
+//        this.declaredAnnotatedMethods.trimToSize();
+//        this.declaredMethodsByAnnotatedParameters.trimToSize();
+//
+            SetMultimap<Class<? extends Annotation>, Annotation> declaredMetaAnnotationMap = SetMultimap.newSetMultimap();
+            for (Annotation declaredAnnotation : declaredAnnotationMap.values()) {
 
             // WELD-1310 Include synthetic annotations
             SlimAnnotatedType<?> syntheticAnnotationAnnotatedType = classTransformer
                     .getSyntheticAnnotationAnnotatedType(declaredAnnotation.annotationType());
             if (syntheticAnnotationAnnotatedType == null) {
                 addMetaAnnotations(declaredMetaAnnotationMap, declaredAnnotation, classTransformer.getReflectionCache()
-                        .getAnnotations(declaredAnnotation.annotationType()), true);
+                        .getAnnotationSet(declaredAnnotation.annotationType()), true);
             } else {
                 addMetaAnnotations(declaredMetaAnnotationMap, declaredAnnotation,
                         syntheticAnnotationAnnotatedType.getAnnotations(), true);
             }
 
             addMetaAnnotations(declaredMetaAnnotationMap, declaredAnnotation, classTransformer.getTypeStore().get(declaredAnnotation.annotationType()), true);
-            declaredMetaAnnotationMap.putSingleElement(declaredAnnotation.annotationType(), declaredAnnotation);
+            declaredMetaAnnotationMap.put(declaredAnnotation.annotationType(), declaredAnnotation);
         }
-        this.declaredMetaAnnotationMap = immutableMap(declaredMetaAnnotationMap);
+        this.declaredMetaAnnotationMap = Multimaps.unmodifiableMultimap(declaredMetaAnnotationMap);
         this.overriddenMethods = getOverriddenMethods(this, methodsTemp);
 
         // WELD-1548 remove all overriden methods except for those which are overriden by a bridge method

--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
@@ -54,16 +54,15 @@ import org.jboss.weld.resources.ClassTransformer;
 import org.jboss.weld.util.collections.ArraySet;
 import org.jboss.weld.util.collections.ArraySetMultimap;
 import org.jboss.weld.util.collections.Arrays2;
-import org.jboss.weld.util.collections.HashSetSupplier;
 import org.jboss.weld.util.collections.ImmutableSet;
+import org.jboss.weld.util.collections.Multimap;
+import org.jboss.weld.util.collections.Multimaps;
+import org.jboss.weld.util.collections.SetMultimap;
 import org.jboss.weld.util.collections.Sets;
 import org.jboss.weld.util.reflection.Formats;
 import org.jboss.weld.util.reflection.Reflections;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
 
 import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
@@ -324,8 +323,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     protected Set<EnhancedAnnotatedMethod<?, ? super T>> getOverriddenMethods(EnhancedAnnotatedType<T> annotatedType,
             Set<EnhancedAnnotatedMethod<?, ? super T>> methods, boolean skipOverridingBridgeMethods) {
         Set<EnhancedAnnotatedMethod<?, ? super T>> overriddenMethods = new HashSet<EnhancedAnnotatedMethod<?, ? super T>>();
-        Multimap<MethodSignature, Package> seenMethods = Multimaps.newSetMultimap(new HashMap<MethodSignature, Collection<Package>>(),
-                HashSetSupplier.<Package> instance());
+        Multimap<MethodSignature, Package> seenMethods = new SetMultimap<>();
         for (Class<? super T> clazz = annotatedType.getJavaClass(); clazz != null && clazz != Object.class; clazz = clazz.getSuperclass()) {
             for (EnhancedAnnotatedMethod<?, ? super T> method : methods) {
                 if (method.getJavaMember().getDeclaringClass().equals(clazz)) {
@@ -343,7 +341,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     }
 
     protected Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> buildAnnotatedMethodMultimap(Set<EnhancedAnnotatedMethod<?, ? super T>> effectiveMethods) {
-        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = HashMultimap.create();
+        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = new SetMultimap<>();
         for (EnhancedAnnotatedMethod<?, ? super T> method : effectiveMethods) {
             for (Class<? extends Annotation> annotation : MAPPED_METHOD_ANNOTATIONS) {
                 if (method.isAnnotationPresent(annotation)) {
@@ -355,7 +353,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     }
 
     protected Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> buildAnnotatedParameterMethodMultimap(Set<EnhancedAnnotatedMethod<?, ? super T>> effectiveMethods) {
-        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = HashMultimap.create();
+        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = new SetMultimap<>();
         for (EnhancedAnnotatedMethod<?, ? super T> method : effectiveMethods) {
             for (Class<? extends Annotation> annotation : MAPPED_METHOD_PARAMETER_ANNOTATIONS) {
                 if (!method.getEnhancedParameters(annotation).isEmpty()) {

--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
@@ -323,7 +323,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     protected Set<EnhancedAnnotatedMethod<?, ? super T>> getOverriddenMethods(EnhancedAnnotatedType<T> annotatedType,
             Set<EnhancedAnnotatedMethod<?, ? super T>> methods, boolean skipOverridingBridgeMethods) {
         Set<EnhancedAnnotatedMethod<?, ? super T>> overriddenMethods = new HashSet<EnhancedAnnotatedMethod<?, ? super T>>();
-        Multimap<MethodSignature, Package> seenMethods = new SetMultimap<>();
+        Multimap<MethodSignature, Package> seenMethods = SetMultimap.newSetMultimap();
         for (Class<? super T> clazz = annotatedType.getJavaClass(); clazz != null && clazz != Object.class; clazz = clazz.getSuperclass()) {
             for (EnhancedAnnotatedMethod<?, ? super T> method : methods) {
                 if (method.getJavaMember().getDeclaringClass().equals(clazz)) {
@@ -341,7 +341,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     }
 
     protected Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> buildAnnotatedMethodMultimap(Set<EnhancedAnnotatedMethod<?, ? super T>> effectiveMethods) {
-        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = new SetMultimap<>();
+        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = SetMultimap.newSetMultimap();
         for (EnhancedAnnotatedMethod<?, ? super T> method : effectiveMethods) {
             for (Class<? extends Annotation> annotation : MAPPED_METHOD_ANNOTATIONS) {
                 if (method.isAnnotationPresent(annotation)) {
@@ -353,7 +353,7 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
     }
 
     protected Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> buildAnnotatedParameterMethodMultimap(Set<EnhancedAnnotatedMethod<?, ? super T>> effectiveMethods) {
-        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = new SetMultimap<>();
+        Multimap<Class<? extends Annotation>, EnhancedAnnotatedMethod<?, ? super T>> result = SetMultimap.newSetMultimap();
         for (EnhancedAnnotatedMethod<?, ? super T> method : effectiveMethods) {
             for (Class<? extends Annotation> annotation : MAPPED_METHOD_PARAMETER_ANNOTATIONS) {
                 if (!method.getEnhancedParameters(annotation).isEmpty()) {

--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotationImpl.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotationImpl.java
@@ -17,7 +17,6 @@
 package org.jboss.weld.annotated.enhanced.jlr;
 
 import java.lang.annotation.Annotation;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,10 +30,7 @@ import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedType;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotation;
 import org.jboss.weld.annotated.slim.SlimAnnotatedType;
 import org.jboss.weld.resources.ClassTransformer;
-import org.jboss.weld.util.collections.HashSetSupplier;
-
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.SetMultimap;
+import org.jboss.weld.util.collections.SetMultimap;
 
 /**
  * Represents an annotated annotation
@@ -76,7 +72,7 @@ public class EnhancedAnnotationImpl<T extends Annotation> extends EnhancedAnnota
         super(annotatedType, annotationMap, declaredAnnotationMap, classTransformer);
         this.clazz = annotatedType.getJavaClass();
         members = new HashSet<EnhancedAnnotatedMethod<?, ?>>();
-        annotatedMembers = Multimaps.newSetMultimap(new HashMap<Class<? extends Annotation>, Collection<EnhancedAnnotatedMethod<?, ?>>>(), HashSetSupplier.<EnhancedAnnotatedMethod<?, ?>>instance());
+        annotatedMembers = new SetMultimap<>();
         for (AnnotatedMethod<? super T> annotatedMethod : annotatedType.getMethods()) {
             EnhancedAnnotatedMethod<?, ? super T> enhancedAnnotatedMethod = EnhancedAnnotatedMethodImpl.of(annotatedMethod, this, classTransformer);
             members.add(enhancedAnnotatedMethod);

--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotationImpl.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotationImpl.java
@@ -72,7 +72,7 @@ public class EnhancedAnnotationImpl<T extends Annotation> extends EnhancedAnnota
         super(annotatedType, annotationMap, declaredAnnotationMap, classTransformer);
         this.clazz = annotatedType.getJavaClass();
         members = new HashSet<EnhancedAnnotatedMethod<?, ?>>();
-        annotatedMembers = new SetMultimap<>();
+        annotatedMembers = SetMultimap.newSetMultimap();
         for (AnnotatedMethod<? super T> annotatedMethod : annotatedType.getMethods()) {
             EnhancedAnnotatedMethod<?, ? super T> enhancedAnnotatedMethod = EnhancedAnnotatedMethodImpl.of(annotatedMethod, this, classTransformer);
             members.add(enhancedAnnotatedMethod);

--- a/impl/src/main/java/org/jboss/weld/bean/InterceptorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bean/InterceptorImpl.java
@@ -23,7 +23,6 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -69,7 +68,8 @@ public class InterceptorImpl<T> extends ManagedBean<T> implements Interceptor<T>
         this.interceptorMetadata = initInterceptorMetadata();
         this.serializable = type.isSerializable();
         Set<Annotation> interceptorBindingTypesSet = new HashSet<Annotation>(Interceptors.mergeBeanInterceptorBindings(beanManager, getEnhancedAnnotated(), getStereotypes()).values());
-        this.interceptorBindingTypes = Collections.unmodifiableSet(interceptorBindingTypesSet);
+//        this.interceptorBindingTypes = Collections.unmodifiableSet(interceptorBindingTypesSet);
+        this.interceptorBindingTypes = new HashSet<>(Interceptors.mergeBeanInterceptorBindings(beanManager, getEnhancedAnnotated(), getStereotypes()).values());
 
         if (Beans.findInterceptorBindingConflicts(beanManager, interceptorBindingTypes)) {
             throw new DeploymentException(BeanLogger.LOG.conflictingInterceptorBindings(getType()));

--- a/impl/src/main/java/org/jboss/weld/bean/InterceptorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bean/InterceptorImpl.java
@@ -67,9 +67,7 @@ public class InterceptorImpl<T> extends ManagedBean<T> implements Interceptor<T>
         super(attributes, type, new StringBeanIdentifier(forInterceptor(type)), beanManager);
         this.interceptorMetadata = initInterceptorMetadata();
         this.serializable = type.isSerializable();
-        Set<Annotation> interceptorBindingTypesSet = new HashSet<Annotation>(Interceptors.mergeBeanInterceptorBindings(beanManager, getEnhancedAnnotated(), getStereotypes()).values());
-//        this.interceptorBindingTypes = Collections.unmodifiableSet(interceptorBindingTypesSet);
-        this.interceptorBindingTypes = new HashSet<>(Interceptors.mergeBeanInterceptorBindings(beanManager, getEnhancedAnnotated(), getStereotypes()).values());
+        this.interceptorBindingTypes = new HashSet<Annotation>(Interceptors.mergeBeanInterceptorBindings(beanManager, getEnhancedAnnotated(), getStereotypes()).values());
 
         if (Beans.findInterceptorBindingConflicts(beanManager, interceptorBindingTypes)) {
             throw new DeploymentException(BeanLogger.LOG.conflictingInterceptorBindings(getType()));

--- a/impl/src/main/java/org/jboss/weld/bean/InterceptorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bean/InterceptorImpl.java
@@ -68,7 +68,8 @@ public class InterceptorImpl<T> extends ManagedBean<T> implements Interceptor<T>
         super(attributes, type, new StringBeanIdentifier(forInterceptor(type)), beanManager);
         this.interceptorMetadata = initInterceptorMetadata();
         this.serializable = type.isSerializable();
-        this.interceptorBindingTypes = Collections.unmodifiableSet(new HashSet<Annotation>(Interceptors.mergeBeanInterceptorBindings(beanManager, getEnhancedAnnotated(), getStereotypes()).values()));
+        Set<Annotation> interceptorBindingTypesSet = new HashSet<Annotation>(Interceptors.mergeBeanInterceptorBindings(beanManager, getEnhancedAnnotated(), getStereotypes()).values());
+        this.interceptorBindingTypes = Collections.unmodifiableSet(interceptorBindingTypesSet);
 
         if (Beans.findInterceptorBindingConflicts(beanManager, interceptorBindingTypes)) {
             throw new DeploymentException(BeanLogger.LOG.conflictingInterceptorBindings(getType()));

--- a/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployerEnvironmentFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployerEnvironmentFactory.java
@@ -32,7 +32,7 @@ import org.jboss.weld.bootstrap.BeanDeployerEnvironment.WeldMethodKey;
 import org.jboss.weld.ejb.EjbDescriptors;
 import org.jboss.weld.ejb.InternalEjbDescriptor;
 import org.jboss.weld.manager.BeanManagerImpl;
-import org.jboss.weld.util.collections.Multimaps;
+import org.jboss.weld.util.collections.SetMultimap;
 
 public class BeanDeployerEnvironmentFactory {
 
@@ -47,12 +47,10 @@ public class BeanDeployerEnvironmentFactory {
      * Creates a new threadsafe BeanDeployerEnvironment instance. These instances are used by {@link ConcurrentBeanDeployer} during bootstrap.
      */
     public static BeanDeployerEnvironment newConcurrentEnvironment(EjbDescriptors ejbDescriptors, BeanManagerImpl manager) {
-        return new BeanDeployerEnvironment(
-                Collections.newSetFromMap(new ConcurrentHashMap<SlimAnnotatedTypeContext<?>, Boolean>()),
-                Collections.newSetFromMap(new ConcurrentHashMap<Class<?>, Boolean>()),
-                Multimaps.<Class<?>, AbstractClassBean<?>>newConcurrentSetMultimap(),
+        return new BeanDeployerEnvironment(Collections.newSetFromMap(new ConcurrentHashMap<SlimAnnotatedTypeContext<?>, Boolean>()),
+                Collections.newSetFromMap(new ConcurrentHashMap<Class<?>, Boolean>()), SetMultimap.<Class<?>, AbstractClassBean<?>> newConcurrentSetMultimap(),
                 Collections.newSetFromMap(new ConcurrentHashMap<ProducerField<?, ?>, Boolean>()),
-                Multimaps.<WeldMethodKey, ProducerMethod<?, ?>>newConcurrentSetMultimap(),
+                SetMultimap.<WeldMethodKey, ProducerMethod<?, ?>> newConcurrentSetMultimap(),
                 Collections.newSetFromMap(new ConcurrentHashMap<RIBean<?>, Boolean>()),
                 Collections.newSetFromMap(new ConcurrentHashMap<ObserverInitializationContext<?, ?>, Boolean>()),
                 Collections.newSetFromMap(new ConcurrentHashMap<DisposalMethod<?, ?>, Boolean>()),

--- a/impl/src/main/java/org/jboss/weld/bootstrap/ConcurrentValidator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/ConcurrentValidator.java
@@ -109,7 +109,7 @@ public class ConcurrentValidator extends Validator {
 
     @Override
     public void validateBeanNames(final BeanManagerImpl beanManager) {
-        final SetMultimap<String, Bean<?>> namedAccessibleBeans = new SetMultimap<>();
+        final SetMultimap<String, Bean<?>> namedAccessibleBeans = SetMultimap.newSetMultimap();
 
         for (Bean<?> bean : beanManager.getAccessibleBeans()) {
             if (bean.getName() != null) {

--- a/impl/src/main/java/org/jboss/weld/bootstrap/ConcurrentValidator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/ConcurrentValidator.java
@@ -19,7 +19,6 @@ package org.jboss.weld.bootstrap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,11 +37,8 @@ import org.jboss.weld.logging.ValidatorLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.manager.api.ExecutorServices;
 import org.jboss.weld.util.Beans;
-import org.jboss.weld.util.collections.HashSetSupplier;
+import org.jboss.weld.util.collections.SetMultimap;
 import org.jboss.weld.util.collections.WeldCollections;
-
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.SetMultimap;
 
 /**
  * Processes validation of beans, decorators and interceptors in parallel.
@@ -113,7 +109,7 @@ public class ConcurrentValidator extends Validator {
 
     @Override
     public void validateBeanNames(final BeanManagerImpl beanManager) {
-        final SetMultimap<String, Bean<?>> namedAccessibleBeans = Multimaps.newSetMultimap(new HashMap<String, Collection<Bean<?>>>(), HashSetSupplier.<Bean<?>> instance());
+        final SetMultimap<String, Bean<?>> namedAccessibleBeans = new SetMultimap<>();
 
         for (Bean<?> bean : beanManager.getAccessibleBeans()) {
             if (bean.getName() != null) {

--- a/impl/src/main/java/org/jboss/weld/bootstrap/SpecializationAndEnablementRegistry.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/SpecializationAndEnablementRegistry.java
@@ -42,7 +42,6 @@ import org.jboss.weld.util.cache.ComputingCache;
 import org.jboss.weld.util.cache.ComputingCacheBuilder;
 import org.jboss.weld.util.collections.ImmutableMap;
 import org.jboss.weld.util.collections.ImmutableSet;
-
 /**
  * Holds information about specialized beans.
  *
@@ -219,7 +218,7 @@ public class SpecializationAndEnablementRegistry extends AbstractBootstrapServic
         for (Entry<AbstractBean<?, ?>, AtomicLong> entry : entrySet ) {
             resultingMap.put(entry.getKey(), entry.getValue().longValue());
         }
-        
+
         return ImmutableMap.copyOf(resultingMap);
     }
 }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/SpecializationAndEnablementRegistry.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/SpecializationAndEnablementRegistry.java
@@ -90,9 +90,7 @@ public class SpecializationAndEnablementRegistry extends AbstractBootstrapServic
                 if (isEnabledInAnyBeanDeployment(specializingBean)) {
                     for (AbstractBean<?, ?> specializedBean : result) {
                         // replacement for computeIfAbsent and uses AtomicLong instead of LongAdder
-                        if ((! specializedBeansMap.containsKey(result)) || specializedBeansMap.get(specializedBean) == null) {
-                            specializedBeansMap.put(specializedBean, new AtomicLong(1));
-                        }
+                        specializedBeansMap.putIfAbsent(specializedBean, new AtomicLong(1));
                     }
                 }
                 return result;

--- a/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
@@ -621,7 +621,7 @@ public class Validator implements Service {
     }
 
     public void validateBeanNames(BeanManagerImpl beanManager) {
-        SetMultimap<String, Bean<?>> namedAccessibleBeans = new SetMultimap<>();
+        SetMultimap<String, Bean<?>> namedAccessibleBeans = SetMultimap.newSetMultimap();
         for (Bean<?> bean : beanManager.getAccessibleBeans()) {
             if (bean.getName() != null) {
                 namedAccessibleBeans.put(bean.getName(), bean);
@@ -702,7 +702,7 @@ public class Validator implements Service {
             Map<String, Class<?>> loadedClasses = buildClassNameMap(beanManager.getEnabled().getAlternativeClasses());
 
             // lookup structure for validation of alternatives
-            Multimap<Class<?>, Bean<?>> beansByClass = new SetMultimap<>();
+            Multimap<Class<?>, Bean<?>> beansByClass = SetMultimap.newSetMultimap();
             for (Bean<?> bean : beanManager.getAccessibleBeans()) {
                 if (!(bean instanceof NewBean)) {
                     beansByClass.put(bean.getBeanClass(), bean);

--- a/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.enterprise.context.Dependent;
@@ -115,7 +116,6 @@ import org.jboss.weld.util.reflection.Reflections;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
-import com.google.common.collect.Multiset.Entry;
 import com.google.common.collect.SetMultimap;
 
 /**
@@ -489,9 +489,9 @@ public class Validator implements Service {
 
     public void validateSpecialization(BeanManagerImpl manager) {
         SpecializationAndEnablementRegistry registry = manager.getServices().get(SpecializationAndEnablementRegistry.class);
-        for (Entry<AbstractBean<?, ?>> entry : registry.getBeansSpecializedInAnyDeploymentAsMultiset().entrySet()) {
-            if (entry.getCount() > 1) {
-                throw ValidatorLogger.LOG.beanSpecializedTooManyTimes(entry.getElement());
+        for (Entry<AbstractBean<?, ?>, Long> entry : registry.getBeansSpecializedInAnyDeploymentAsMap().entrySet()) {
+            if (entry.getValue() > 1) {
+                throw ValidatorLogger.LOG.beanSpecializedTooManyTimes(entry.getKey());
             }
         }
     }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
@@ -26,7 +26,6 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -108,15 +107,11 @@ import org.jboss.weld.util.Beans;
 import org.jboss.weld.util.Decorators;
 import org.jboss.weld.util.JtaApiAbstraction;
 import org.jboss.weld.util.Proxies;
-import org.jboss.weld.util.collections.HashSetSupplier;
+import org.jboss.weld.util.collections.Multimap;
+import org.jboss.weld.util.collections.SetMultimap;
 import org.jboss.weld.util.collections.WeldCollections;
 import org.jboss.weld.util.reflection.Formats;
 import org.jboss.weld.util.reflection.Reflections;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.SetMultimap;
 
 /**
  * Checks a list of beans for DeploymentExceptions and their subclasses
@@ -626,7 +621,7 @@ public class Validator implements Service {
     }
 
     public void validateBeanNames(BeanManagerImpl beanManager) {
-        SetMultimap<String, Bean<?>> namedAccessibleBeans = Multimaps.newSetMultimap(new HashMap<String, Collection<Bean<?>>>(), HashSetSupplier.<Bean<?>>instance());
+        SetMultimap<String, Bean<?>> namedAccessibleBeans = new SetMultimap<>();
         for (Bean<?> bean : beanManager.getAccessibleBeans()) {
             if (bean.getName() != null) {
                 namedAccessibleBeans.put(bean.getName(), bean);
@@ -707,7 +702,7 @@ public class Validator implements Service {
             Map<String, Class<?>> loadedClasses = buildClassNameMap(beanManager.getEnabled().getAlternativeClasses());
 
             // lookup structure for validation of alternatives
-            Multimap<Class<?>, Bean<?>> beansByClass = HashMultimap.create();
+            Multimap<Class<?>, Bean<?>> beansByClass = new SetMultimap<>();
             for (Bean<?> bean : beanManager.getAccessibleBeans()) {
                 if (!(bean instanceof NewBean)) {
                     beansByClass.put(bean.getBeanClass(), bean);

--- a/impl/src/main/java/org/jboss/weld/ejb/EjbDescriptors.java
+++ b/impl/src/main/java/org/jboss/weld/ejb/EjbDescriptors.java
@@ -46,7 +46,7 @@ public class EjbDescriptors implements Service, Iterable<InternalEjbDescriptor<?
      */
     public EjbDescriptors() {
         this.ejbByName = new HashMap<String, InternalEjbDescriptor<?>>();
-        this.ejbByClass = new SetMultimap<>();
+        this.ejbByClass = SetMultimap.newSetMultimap();
     }
 
     /**

--- a/impl/src/main/java/org/jboss/weld/ejb/EjbDescriptors.java
+++ b/impl/src/main/java/org/jboss/weld/ejb/EjbDescriptors.java
@@ -18,7 +18,6 @@ package org.jboss.weld.ejb;
 
 import static org.jboss.weld.util.reflection.Reflections.cast;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -27,10 +26,7 @@ import java.util.Set;
 import org.jboss.weld.bootstrap.api.Service;
 import org.jboss.weld.ejb.spi.EjbDescriptor;
 import org.jboss.weld.logging.BeanLogger;
-import org.jboss.weld.util.collections.HashSetSupplier;
-
-import com.google.common.collect.Multimaps;
-import com.google.common.collect.SetMultimap;
+import org.jboss.weld.util.collections.SetMultimap;
 
 /**
  * EJB descriptors by EJB implementation class or name
@@ -50,7 +46,7 @@ public class EjbDescriptors implements Service, Iterable<InternalEjbDescriptor<?
      */
     public EjbDescriptors() {
         this.ejbByName = new HashMap<String, InternalEjbDescriptor<?>>();
-        this.ejbByClass = Multimaps.newSetMultimap(new HashMap<Class<?>, Collection<String>>(), HashSetSupplier.<String>instance());
+        this.ejbByClass = new SetMultimap<>();
     }
 
     /**

--- a/impl/src/main/java/org/jboss/weld/injection/producer/InterceptionModelInitializer.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/InterceptionModelInitializer.java
@@ -56,7 +56,6 @@ import org.jboss.weld.util.collections.ImmutableList;
 import org.jboss.weld.util.collections.Iterables;
 import org.jboss.weld.util.reflection.Reflections;
 
-
 /**
  * Initializes {@link InterceptionModel} for a {@link Bean} or a non-contextual component.
  *

--- a/impl/src/main/java/org/jboss/weld/metadata/TypeStore.java
+++ b/impl/src/main/java/org/jboss/weld/metadata/TypeStore.java
@@ -42,7 +42,7 @@ public class TypeStore implements Service {
     private final Set<Class<? extends Annotation>> extraScopes;
 
     public TypeStore() {
-        this.extraAnnotations = new SetMultimap<>();
+        this.extraAnnotations = SetMultimap.newSetMultimap();
         this.extraScopes = new HashSet<Class<? extends Annotation>>();
     }
 

--- a/impl/src/main/java/org/jboss/weld/metadata/TypeStore.java
+++ b/impl/src/main/java/org/jboss/weld/metadata/TypeStore.java
@@ -17,21 +17,18 @@
 package org.jboss.weld.metadata;
 
 import java.lang.annotation.Annotation;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 import javax.enterprise.context.NormalScope;
-import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.inject.Scope;
 
 import org.jboss.weld.bootstrap.api.Service;
+import org.jboss.weld.util.Supplier;
 import org.jboss.weld.util.collections.SetMultimap;
 
 /**
- * This class requires happens-before action between {@link #add(Class, Annotation)}
- * and subsequent {@link #get(Class)} or {@link #isExtraScope(Class)}. In order to guarantee
- * this implicitly, {@link #add(Class, Annotation)} should only be called from within a {@link BeforeBeanDiscovery}
- * observer.
+ * This class is thread-safe.
  *
  * @author pmuir
  * @author Jozef Hartinger
@@ -42,8 +39,13 @@ public class TypeStore implements Service {
     private final Set<Class<? extends Annotation>> extraScopes;
 
     public TypeStore() {
-        this.extraAnnotations = SetMultimap.newSetMultimap();
-        this.extraScopes = new HashSet<Class<? extends Annotation>>();
+        this.extraAnnotations = SetMultimap.newConcurrentSetMultimap(new Supplier<Set<Annotation>>() {
+            @Override
+            public Set<Annotation> get() {
+                return new CopyOnWriteArraySet<Annotation>();
+            }
+        });
+        this.extraScopes = new CopyOnWriteArraySet<>();
     }
 
     public Set<Annotation> get(Class<? extends Annotation> annotationType) {

--- a/impl/src/main/java/org/jboss/weld/metadata/TypeStore.java
+++ b/impl/src/main/java/org/jboss/weld/metadata/TypeStore.java
@@ -25,9 +25,7 @@ import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.inject.Scope;
 
 import org.jboss.weld.bootstrap.api.Service;
-
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
+import org.jboss.weld.util.collections.SetMultimap;
 
 /**
  * This class requires happens-before action between {@link #add(Class, Annotation)}
@@ -44,7 +42,7 @@ public class TypeStore implements Service {
     private final Set<Class<? extends Annotation>> extraScopes;
 
     public TypeStore() {
-        this.extraAnnotations = HashMultimap.create();
+        this.extraAnnotations = new SetMultimap<>();
         this.extraScopes = new HashSet<Class<? extends Annotation>>();
     }
 

--- a/impl/src/main/java/org/jboss/weld/util/Interceptors.java
+++ b/impl/src/main/java/org/jboss/weld/util/Interceptors.java
@@ -32,6 +32,7 @@ import org.jboss.weld.logging.BeanManagerLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.metadata.cache.MetaAnnotationStore;
 
+
 /**
  * Helper class for working with interceptors and interceptor bindings.
  * @author Jozef Hartinger

--- a/impl/src/main/java/org/jboss/weld/util/collections/AbstractMultimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/AbstractMultimap.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.util.collections;
+
+import static org.jboss.weld.util.Preconditions.checkArgumentNotNull;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.jboss.weld.util.Supplier;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * An abstract {@link Multimap} backed by a {@link Map}.
+ *
+ * @author Martin Kouba
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ * @param <C> The collection of values type
+ */
+abstract class AbstractMultimap<K, V, C extends Collection<V>> implements Multimap<K, V>, Serializable {
+
+    private static final long serialVersionUID = -8363450390652782067L;
+
+    protected final Supplier<C> supplier;
+
+    private final Map<K, C> map;
+
+    /**
+     *
+     * @param mapSupplier
+     * @param collectionSupplier
+     * @param multimap
+     */
+    protected AbstractMultimap(Supplier<Map<K, C>> mapSupplier, Supplier<C> collectionSupplier, Multimap<K, V> multimap) {
+        checkArgumentNotNull(mapSupplier, "mapSupplier");
+        checkArgumentNotNull(collectionSupplier, "collectionSupplier");
+        this.supplier = collectionSupplier;
+        this.map = mapSupplier.get();
+        if (multimap != null) {
+            for (Entry<K, Collection<V>> entry : multimap.entrySet()) {
+                C values = supplier.get();
+                values.addAll(entry.getValue());
+                putAll(entry.getKey(), values);
+            }
+        }
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public C get(K key) {
+        // replacement for computeIfAbsent
+        if (map.get(key) == null) {
+            C newValue = supplier.get();
+            if (newValue != null) {
+                map.put(key, newValue);
+            }
+        }
+        return map.get(key);
+    }
+
+    @Override
+    public boolean put(K key, V value) {
+        return get(key).add(value);
+    }
+
+    @Override
+    public boolean putAll(K key, Collection<? extends V> values) {
+        return get(key).addAll(values);
+    }
+
+    @Override
+    public C replaceValues(K key, Iterable<? extends V> values) {
+        C replacement = supplier.get();
+        Iterables.addAll(replacement, values);
+        return map.put(key, replacement);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return ImmutableSet.copyOf(map.keySet());
+    }
+
+    @Override
+    public List<V> values() {
+        return ImmutableList.copyOf(Iterables.concat(map.values()));
+    }
+
+    @Override
+    public Set<V> uniqueValues() {
+        ImmutableSet.Builder<V> builder = ImmutableSet.builder();
+        for (C values : map.values()) {
+            builder.addAll(values);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public Set<Entry<K, Collection<V>>> entrySet() {
+        ImmutableSet.Builder<Entry<K, Collection<V>>> builder = ImmutableSet.builder();
+        for (Entry<K, C> entry : map.entrySet()) {
+            builder.add(new MultimapEntry<K, Collection<V>>(entry.getKey(), Multimaps.unmodifiableValueCollection(entry.getValue())));
+        }
+        return builder.build();
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public String toString() {
+        return map.toString();
+    }
+
+    /**
+     *
+     * @author Martin Kouba
+     *
+     * @param <K>
+     * @param <V>
+     */
+    static class MultimapEntry<K, V> implements Map.Entry<K, V> {
+
+        private final K key;
+
+        private final V value;
+
+        public MultimapEntry(K key, V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public K getKey() {
+            return key;
+        }
+
+        @Override
+        public V getValue() {
+            return value;
+        }
+
+        @Override
+        public V setValue(V value) {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/util/collections/AbstractMultimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/AbstractMultimap.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.jboss.weld.util.Supplier;
@@ -179,6 +180,28 @@ abstract class AbstractMultimap<K, V, C extends Collection<V>> implements Multim
         @Override
         public V setValue(V value) {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int hashCode() {
+            return (key == null ? 0 : key.hashCode()) ^ (value == null ? 0 : value.hashCode());
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Map.Entry)) {
+                return false;
+            }
+            Map.Entry<?, ?> e = (Map.Entry<?, ?>) o;
+            return Objects.equals(key, e.getKey()) && Objects.equals(value, e.getValue());
+        }
+
+        @Override
+        public String toString() {
+            return key + "=" + value;
         }
 
     }

--- a/impl/src/main/java/org/jboss/weld/util/collections/ListMultimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/ListMultimap.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.util.collections;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.weld.util.Supplier;
+
+/**
+ * A {@link Multimap} whose collections of values are backed by a {@link List}.
+ *
+ * @author Martin Kouba
+ *
+ * @param <K>
+ * @param <V>
+ */
+public class ListMultimap<K, V> extends AbstractMultimap<K, V, List<V>> {
+
+    private static final long serialVersionUID = 6774436969456237682L;
+
+    /**
+     * Creates a new instance backed by a {@link HashMap} and {@link ArrayList}.
+     */
+    public ListMultimap() {
+        this(new Supplier<Map<K, List<V>>>() {
+            @Override
+            public HashMap<K, List<V>> get() {
+                return new HashMap<K, List<V>>();
+            }
+        }, new Supplier<List<V>>() {
+            @Override
+            public ArrayList<V> get() {
+                return new ArrayList<V>();
+            }
+        }, null);
+    }
+
+    /**
+     * Creates a new instance backed by a {@link HashMap} and {@link ArrayList}. All key-value mappings are copied from the input multimap.
+     *
+     * @param multimap
+     */
+    public ListMultimap(Multimap<K, V> multimap) {
+        this(new Supplier<Map<K, List<V>>>() {
+            @Override
+            public HashMap<K, List<V>> get() {
+                return new HashMap<K, List<V>>();
+            }
+        }, new Supplier<List<V>>() {
+            @Override
+            public ArrayList<V> get() {
+                return new ArrayList<V>();
+            }
+        }, multimap);
+    }
+
+    /**
+     *
+     * @param mapSupplier
+     * @param collectionSupplier
+     */
+    public ListMultimap(Supplier<Map<K, List<V>>> mapSupplier, Supplier<List<V>> collectionSupplier, Multimap<K, V> multimap) {
+        super(mapSupplier, collectionSupplier, multimap);
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/util/collections/Multimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/Multimap.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.util.collections;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+/**
+ * A collection-like structure that maps keys to collections of values.
+ *
+ * @author Martin Kouba
+ * @param <K> The key
+ * @param <V> The value
+ */
+public interface Multimap<K, V> {
+
+    /**
+     * Unlike <code>com.google.common.collect.Multimap#size()</code> this method returns the number of key-value mappings.
+     *
+     * @return the number of key-value mappings
+     */
+    int size();
+
+    /**
+     *
+     * @return <code>true</code> if there are no key-value mappings
+     */
+    boolean isEmpty();
+
+    /**
+     * This method never returns null.
+     *
+     * @param key
+     * @return the collection of values for the given key
+     */
+    Collection<V> get(K key);
+
+    /**
+     *
+     * @param key
+     * @param value
+     * @return <code>true</code> if the the size of the collection associated with the given key increased, <code>false</code> otherwise (e.g. if the collection
+     *         of values doesn't allow duplicates)
+     */
+    boolean put(K key, V value);
+
+    /**
+     *
+     * @param key
+     * @param values
+     * @return <code>true</code> if the the size of the collection associated with the given key increased, <code>false</code> otherwise (e.g. if the collection
+     *         of values doesn't allow duplicates)
+     */
+    boolean putAll(K key, Collection<? extends V> values);
+
+    /**
+     * Note that the original collection of values is completely replaced by a new collection which contains all elements from the given iterable. If the
+     * collection of values doesn't allow duplicates, these elements are removed.
+     *
+     * @param key
+     * @param values
+     * @return the collection of replaced values
+     */
+    Collection<V> replaceValues(K key, Iterable<? extends V> values);
+
+    /**
+     *
+     * @param key
+     * @return <code>true</code> if the multimap contains a mapping for the given key
+     */
+    boolean containsKey(Object key);
+
+    /**
+     *
+     * @return an immutable set of keys
+     */
+    Set<K> keySet();
+
+    /**
+     * The list may include the same value multiple times if it occurs in multiple mappings or if the collection of values for the mapping allows duplicate
+     * elements.
+     *
+     * @return an immutable list of all the values in the multimap
+     */
+    List<V> values();
+
+    /**
+     *
+     * @return an immutable set of all the values in the multimap
+     */
+    Set<V> uniqueValues();
+
+    /**
+     * {@link Entry#getValue()} always returns an unmodifiable collection. {@link Entry#setValue(Object)} operation is not supported.
+     *
+     * @return an immutable set of all key-value pairs
+     */
+    Set<Entry<K, Collection<V>>> entrySet();
+
+    /**
+     * Removes all of the mappings.
+     */
+    void clear();
+
+}

--- a/impl/src/main/java/org/jboss/weld/util/collections/Multimaps.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/Multimaps.java
@@ -18,15 +18,9 @@ package org.jboss.weld.util.collections;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
-
-import org.jboss.weld.util.Function;
-import org.jboss.weld.util.cache.ComputingCache;
-import org.jboss.weld.util.cache.ComputingCacheBuilder;
 
 /**
  * Multimap utilities.
@@ -37,22 +31,6 @@ import org.jboss.weld.util.cache.ComputingCacheBuilder;
 public class Multimaps {
 
     private Multimaps() {
-    }
-
-    private static final ComputingCacheBuilder CACHE_BUILDER = ComputingCacheBuilder.newBuilder();
-
-    private static class ConcurrentSetMultimapValueSupplier<K, V> implements Function<K, Set<V>> {
-        @Override
-        public Set<V> apply(K input) {
-            return Collections.synchronizedSet(new HashSet<V>());
-        }
-    }
-
-    /**
-     * Creates a {@link ConcurrentMap} instance whose values are populated with synchronized HashSet instances.
-     */
-    public static <K, V> ComputingCache<K, Set<V>> newConcurrentSetMultimap() {
-        return CACHE_BUILDER.build(new ConcurrentSetMultimapValueSupplier<K, V>());
     }
 
     /**

--- a/impl/src/main/java/org/jboss/weld/util/collections/Multimaps.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/Multimaps.java
@@ -16,8 +16,11 @@
  */
 package org.jboss.weld.util.collections;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
@@ -51,4 +54,108 @@ public class Multimaps {
     public static <K, V> ComputingCache<K, Set<V>> newConcurrentSetMultimap() {
         return CACHE_BUILDER.build(new ConcurrentSetMultimapValueSupplier<K, V>());
     }
+
+    /**
+     * Note that {@link Multimap#get(Object)} returns unmodifiable collections.
+     *
+     * @param multimap
+     * @return an unmodifiable view of the given multimap
+     */
+    public static <K, V> Multimap<K, V> unmodifiableMultimap(Multimap<K, V> multimap) {
+        if (multimap instanceof UnmodifiableMultimap) {
+            return multimap;
+        }
+        return new UnmodifiableMultimap<K, V>(multimap);
+    }
+
+    /**
+     *
+     * @author Martin Kouba
+     *
+     * @param <K>
+     * @param <V>
+     */
+    static class UnmodifiableMultimap<K, V> implements Multimap<K, V> {
+
+        private final Multimap<K, V> delegate;
+
+        /**
+         *
+         * @param delegate
+         */
+        public UnmodifiableMultimap(Multimap<K, V> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return delegate.isEmpty();
+        }
+
+        @Override
+        public Collection<V> get(K key) {
+            return unmodifiableValueCollection(delegate.get(key));
+        }
+
+        @Override
+        public boolean put(K key, V value) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean containsKey(Object key) {
+            return delegate.containsKey(key);
+        }
+
+        @Override
+        public Set<K> keySet() {
+            return delegate.keySet();
+        }
+
+        @Override
+        public void clear() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<V> values() {
+            return delegate.values();
+        }
+
+        @Override
+        public Set<V> uniqueValues() {
+            return delegate.uniqueValues();
+        }
+
+        @Override
+        public boolean putAll(K key, Collection<? extends V> values) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<V> replaceValues(K key, Iterable<? extends V> values) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Set<Entry<K, Collection<V>>> entrySet() {
+            return delegate.entrySet();
+        }
+
+    }
+
+    static <V> Collection<V> unmodifiableValueCollection(Collection<V> values) {
+        if (values instanceof Set) {
+            return Collections.unmodifiableSet((Set<V>) values);
+        } else if (values instanceof List) {
+            return Collections.unmodifiableList((List<V>) values);
+        }
+        return Collections.unmodifiableCollection(values);
+    }
+
 }

--- a/impl/src/main/java/org/jboss/weld/util/collections/SetMultimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/SetMultimap.java
@@ -78,17 +78,24 @@ public class SetMultimap<K, V> extends AbstractMultimap<K, V, Set<V>> {
      * Creates a new instance backed by a {@link ConcurrentHashMap} and synchronized {@link HashSet}.
      */
     public static <K, V> SetMultimap<K, V> newConcurrentSetMultimap() {
-        return new SetMultimap<K, V>(new Supplier<Map<K, Set<V>>>() {
-            @Override
-            public ConcurrentHashMap<K, Set<V>> get() {
-                return new ConcurrentHashMap<K, Set<V>>();
-            }
-        }, new Supplier<Set<V>>() {
+        return newConcurrentSetMultimap(new Supplier<Set<V>>() {
             @Override
             public Set<V> get() {
                 return Collections.synchronizedSet(new HashSet<V>());
             }
-        }, null);
+        });
+    }
+
+    /**
+     * Creates a new instance backed by a {@link ConcurrentHashMap} and synchronized {@link HashSet}.
+     */
+    public static <K, V> SetMultimap<K, V> newConcurrentSetMultimap(Supplier<Set<V>> valueSupplier) {
+        return new SetMultimap<K, V>(new Supplier<Map<K, Set<V>>>() {
+            @Override
+            public Map<K, Set<V>> get() {
+                return new ConcurrentHashMap<K, Set<V>>();
+            }
+        }, valueSupplier, null);
     }
 
     /**

--- a/impl/src/main/java/org/jboss/weld/util/collections/SetMultimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/SetMultimap.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.util.collections;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.weld.util.Supplier;
+
+/**
+ * A {@link Multimap} whose collections of values are backed by a {@link Set}.
+ *
+ * @author Martin Kouba
+ *
+ * @param <K> The key type
+ * @param <V> The value type
+ */
+public class SetMultimap<K, V> extends AbstractMultimap<K, V, Set<V>> {
+
+    private static final long serialVersionUID = -7310409235342796148L;
+
+    /**
+     * Creates a new instance backed by a {@link HashMap} and {@link HashSet}.
+     */
+    public SetMultimap() {
+        this(new Supplier<Map<K, Set<V>>>() {
+            @Override
+            public HashMap<K, Set<V>> get() {
+                return new HashMap<K, Set<V>>();
+            }
+        }, new Supplier<Set<V>>() {
+            @Override
+            public HashSet<V> get() {
+                return new HashSet<V>();
+            }
+        }, null);
+    }
+
+    /**
+     * Creates a new instance backed by a {@link HashMap} and {@link HashSet}. All key-value mappings are copied from the input multimap. If any
+     * collection of values in the input multimap contains duplicate elements, these are removed in the constructed multimap.
+     *
+     * @param multimap
+     */
+    public SetMultimap(Multimap<K, V> multimap) {
+        this(new Supplier<Map<K, Set<V>>>() {
+            @Override
+            public HashMap<K, Set<V>> get() {
+                return new HashMap<K, Set<V>>();
+            }
+        }, new Supplier<Set<V>>() {
+            @Override
+            public HashSet<V> get() {
+                return new HashSet<V>();
+            }
+        }, multimap);
+    }
+
+    /**
+     *
+     * @param mapSupplier
+     * @param collectionSupplier
+     * @param multimap
+     */
+    public SetMultimap(Supplier<Map<K, Set<V>>> mapSupplier, Supplier<Set<V>> collectionSupplier, Multimap<K, V> multimap) {
+        super(mapSupplier, collectionSupplier, multimap);
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/util/collections/SetMultimap.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/SetMultimap.java
@@ -16,12 +16,14 @@
  */
 package org.jboss.weld.util.collections;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import org.jboss.weld.util.Supplier;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A {@link Multimap} whose collections of values are backed by a {@link Set}.
@@ -38,8 +40,8 @@ public class SetMultimap<K, V> extends AbstractMultimap<K, V, Set<V>> {
     /**
      * Creates a new instance backed by a {@link HashMap} and {@link HashSet}.
      */
-    public SetMultimap() {
-        this(new Supplier<Map<K, Set<V>>>() {
+    public static <K, V> SetMultimap<K, V> newSetMultimap() {
+        return new SetMultimap<K, V>(new Supplier<Map<K, Set<V>>>() {
             @Override
             public HashMap<K, Set<V>> get() {
                 return new HashMap<K, Set<V>>();
@@ -58,8 +60,8 @@ public class SetMultimap<K, V> extends AbstractMultimap<K, V, Set<V>> {
      *
      * @param multimap
      */
-    public SetMultimap(Multimap<K, V> multimap) {
-        this(new Supplier<Map<K, Set<V>>>() {
+    public static <K, V> SetMultimap<K, V> newSetMultimap(Multimap<K, V> multimap) {
+        return new SetMultimap<K, V>(new Supplier<Map<K, Set<V>>>() {
             @Override
             public HashMap<K, Set<V>> get() {
                 return new HashMap<K, Set<V>>();
@@ -73,12 +75,29 @@ public class SetMultimap<K, V> extends AbstractMultimap<K, V, Set<V>> {
     }
 
     /**
+     * Creates a new instance backed by a {@link ConcurrentHashMap} and synchronized {@link HashSet}.
+     */
+    public static <K, V> SetMultimap<K, V> newConcurrentSetMultimap() {
+        return new SetMultimap<K, V>(new Supplier<Map<K, Set<V>>>() {
+            @Override
+            public ConcurrentHashMap<K, Set<V>> get() {
+                return new ConcurrentHashMap<K, Set<V>>();
+            }
+        }, new Supplier<Set<V>>() {
+            @Override
+            public Set<V> get() {
+                return Collections.synchronizedSet(new HashSet<V>());
+            }
+        }, null);
+    }
+
+    /**
      *
      * @param mapSupplier
      * @param collectionSupplier
      * @param multimap
      */
-    public SetMultimap(Supplier<Map<K, Set<V>>> mapSupplier, Supplier<Set<V>> collectionSupplier, Multimap<K, V> multimap) {
+    private SetMultimap(Supplier<Map<K, Set<V>>> mapSupplier, Supplier<Set<V>> collectionSupplier, Multimap<K, V> multimap) {
         super(mapSupplier, collectionSupplier, multimap);
     }
 

--- a/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/ListMultimapTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/ListMultimapTest.java
@@ -89,7 +89,7 @@ public class ListMultimapTest {
 
     @Test
     public void testMultimapFromMultimap() {
-        Multimap<String, Integer> multimap = new SetMultimap<>();
+        Multimap<String, Integer> multimap = SetMultimap.newSetMultimap();
         multimap.putAll("foo", Arrays.asList(1,2,3,4));
         assertEquals(4, multimap.values().size());
         ListMultimap<String, Integer> copy = new ListMultimap<>(multimap);

--- a/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/ListMultimapTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/ListMultimapTest.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.unit.util.collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.weld.util.collections.ListMultimap;
+import org.jboss.weld.util.collections.Multimap;
+import org.jboss.weld.util.collections.SetMultimap;
+import org.junit.Test;
+
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class ListMultimapTest {
+
+    @Test
+    public void testDefaultBehaviour() {
+
+        ListMultimap<String, Integer> listMultimap = new ListMultimap<>();
+
+        assertTrue(listMultimap.put("foo", 1));
+        assertTrue(listMultimap.put("foo", 1));
+        listMultimap.put("foo", 2);
+        listMultimap.put("foo", 42);
+        listMultimap.put("bar", 42);
+        listMultimap.put("baz", 1);
+
+        assertFalse(listMultimap.isEmpty());
+        assertEquals(3, listMultimap.size());
+        assertTrue(listMultimap.containsKey("foo"));
+        assertTrue(listMultimap.containsKey("bar"));
+
+        List<Integer> fooValues = listMultimap.get("foo");
+        assertEquals(4, fooValues.size());
+        assertTrue(fooValues.contains(42));
+
+        List<Integer> bazValues = listMultimap.get("baz");
+        assertEquals(1, bazValues.size());
+        assertTrue(bazValues.contains(1));
+
+        List<Integer> barValues = listMultimap.get("bar");
+        assertEquals(1, barValues.size());
+
+        listMultimap.putAll("bar", Arrays.asList(42, 1, 5, 6, 7));
+        assertEquals(6, barValues.size());
+        assertTrue(barValues.containsAll(Arrays.asList(1, 42, 5, 6, 7)));
+
+        List<Integer> replaced = listMultimap.replaceValues("foo", Arrays.asList(1000));
+        assertEquals(4, replaced.size());
+        fooValues = listMultimap.get("foo");
+        assertEquals(1, fooValues.size());
+
+        Set<String> keySet = listMultimap.keySet();
+        assertEquals(3, keySet.size());
+
+        Set<Integer> uniqueValues = listMultimap.uniqueValues();
+        assertEquals(6, uniqueValues.size());
+
+        List<Integer> values = listMultimap.values();
+        assertEquals(8, values.size());
+
+        listMultimap.clear();
+        assertTrue(listMultimap.isEmpty());
+        assertEquals(0, listMultimap.size());
+    }
+
+    @Test
+    public void testMultimapFromMultimap() {
+        Multimap<String, Integer> multimap = new SetMultimap<>();
+        multimap.putAll("foo", Arrays.asList(1,2,3,4));
+        assertEquals(4, multimap.values().size());
+        ListMultimap<String, Integer> copy = new ListMultimap<>(multimap);
+        assertEquals(4, copy.values().size());
+        assertTrue(copy.containsKey("foo"));
+        multimap.clear();
+        assertFalse(copy.isEmpty());
+    }
+
+}

--- a/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/SetMultimapTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/SetMultimapTest.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.unit.util.collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.weld.util.collections.SetMultimap;
+import org.junit.Test;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+public class SetMultimapTest {
+
+    @Test
+    public void testDefaultBehaviour() {
+
+        SetMultimap<String, Integer> setMultimap = new SetMultimap<>();
+
+        assertTrue(setMultimap.put("foo", 1));
+        assertFalse(setMultimap.put("foo", 1));
+        setMultimap.put("foo", 2);
+        setMultimap.put("foo", 42);
+        setMultimap.put("bar", 42);
+        setMultimap.put("baz", 1);
+
+        assertFalse(setMultimap.isEmpty());
+        assertEquals(3, setMultimap.size());
+        assertTrue(setMultimap.containsKey("foo"));
+        assertTrue(setMultimap.containsKey("bar"));
+
+        Set<Integer> fooValues = setMultimap.get("foo");
+        assertEquals(3, fooValues.size());
+        assertTrue(fooValues.contains(42));
+
+        Set<Integer> bazValues = setMultimap.get("baz");
+        assertEquals(1, bazValues.size());
+        assertTrue(bazValues.contains(1));
+
+        Set<Integer> barValues = setMultimap.get("bar");
+        assertEquals(1, barValues.size());
+
+        setMultimap.putAll("bar", Arrays.asList(1, 5, 6, 7));
+        assertEquals(5, barValues.size());
+        assertTrue(barValues.containsAll(Arrays.asList(1, 42, 5, 6, 7)));
+
+        Set<Integer> replaced = setMultimap.replaceValues("foo", Arrays.asList(1000));
+        assertEquals(3, replaced.size());
+        fooValues = setMultimap.get("foo");
+        assertEquals(1, fooValues.size());
+
+        Set<String> keySet = setMultimap.keySet();
+        assertEquals(3, keySet.size());
+
+        Set<Integer> uniqueValues = setMultimap.uniqueValues();
+        assertEquals(6, uniqueValues.size());
+
+        List<Integer> values = setMultimap.values();
+        assertEquals(7, values.size());
+
+        setMultimap.clear();
+        assertTrue(setMultimap.isEmpty());
+        assertEquals(0, setMultimap.size());
+    }
+
+    @Test
+    public void testSetMultimapFromMultimap() {
+        SetMultimap<String, Integer> setMultimap = new SetMultimap<>();
+        setMultimap.putAll("foo", Arrays.asList(1,2,3,4));
+        assertEquals(4, setMultimap.values().size());
+        SetMultimap<String, Integer> copy = new SetMultimap<>(setMultimap);
+        assertEquals(4, copy.values().size());
+        assertTrue(copy.containsKey("foo"));
+        setMultimap.clear();
+        assertFalse(copy.isEmpty());
+    }
+
+}

--- a/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/SetMultimapTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/util/collections/SetMultimapTest.java
@@ -36,7 +36,7 @@ public class SetMultimapTest {
     @Test
     public void testDefaultBehaviour() {
 
-        SetMultimap<String, Integer> setMultimap = new SetMultimap<>();
+        SetMultimap<String, Integer> setMultimap = SetMultimap.newSetMultimap();
 
         assertTrue(setMultimap.put("foo", 1));
         assertFalse(setMultimap.put("foo", 1));
@@ -86,10 +86,10 @@ public class SetMultimapTest {
 
     @Test
     public void testSetMultimapFromMultimap() {
-        SetMultimap<String, Integer> setMultimap = new SetMultimap<>();
+        SetMultimap<String, Integer> setMultimap = SetMultimap.newSetMultimap();
         setMultimap.putAll("foo", Arrays.asList(1,2,3,4));
         assertEquals(4, setMultimap.values().size());
-        SetMultimap<String, Integer> copy = new SetMultimap<>(setMultimap);
+        SetMultimap<String, Integer> copy = SetMultimap.newSetMultimap(setMultimap);
         assertEquals(4, copy.values().size());
         assertTrue(copy.containsKey("foo"));
         setMultimap.clear();


### PR DESCRIPTION
Work in progress, unit tests **sometimes** fail.
This backport is also affected by changes made during WELD-1744 (same code-base was affected, Multimap was used where we do not need it now).