### PR TITLE
Use correct Jandex class when checking presence of new method

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/FastAnnotatedTypeLoader.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/FastAnnotatedTypeLoader.java
@@ -126,7 +126,7 @@ class FastAnnotatedTypeLoader extends AnnotatedTypeLoader {
 
     private boolean isJandexSetFlagsAvailable() {
         try {
-            Method setFlags = AccessController.doPrivileged(GetDeclaredMethodAction.of(ClassFileInfo.class, "setFlags", short.class));
+            Method setFlags = AccessController.doPrivileged(GetDeclaredMethodAction.of(org.jboss.jandex.ClassInfo.class, "setFlags", short.class));
             return setFlags != null;
         } catch (Exception e) {
             return false;


### PR DESCRIPTION
Code was checking wrongly a class inside Weld that use that same name ClassInfo that the one on Jandex that is where the new method is present.

Patch should be backported to 2.4.0Final that has the same problem.