### PR TITLE
WELD-2251 check whether SeContainer is running when getting BeanManager.

### DIFF
--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/WeldContainer.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/WeldContainer.java
@@ -189,6 +189,7 @@ public class WeldContainer extends AbstractCDI<Object> implements AutoCloseable,
      * @return the instance
      */
     public Instance<Object> instance() {
+        checkState();
         return instance;
     }
 
@@ -202,6 +203,7 @@ public class WeldContainer extends AbstractCDI<Object> implements AutoCloseable,
      * @return the event
      */
     public Event<Object> event() {
+        checkState();
         return event;
     }
 
@@ -218,6 +220,7 @@ public class WeldContainer extends AbstractCDI<Object> implements AutoCloseable,
      * Provides direct access to the BeanManager.
      */
     public BeanManager getBeanManager() {
+        checkState();
         return manager;
     }
 
@@ -279,6 +282,13 @@ public class WeldContainer extends AbstractCDI<Object> implements AutoCloseable,
                     System.out.println(String.format("Weld SE container %s shut down by shutdown hook", id));
                 }
             }
+        }
+    }
+
+    @Override
+    protected void checkState() {
+        if (!isRunning()) {
+            throw WeldSELogger.LOG.weldContainerAlreadyShutDown(id);
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/AbstractCDI.java
+++ b/impl/src/main/java/org/jboss/weld/AbstractCDI.java
@@ -63,41 +63,49 @@ public abstract class AbstractCDI<T> extends CDI<T> {
 
     @Override
     public Iterator<T> iterator() {
+        checkState();
         return getInstance().iterator();
     }
 
     @Override
     public T get() {
+        checkState();
         return getInstance().get();
     }
 
     @Override
     public Instance<T> select(Annotation... qualifiers) {
+        checkState();
         return getInstance().select(qualifiers);
     }
 
     @Override
     public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers) {
+        checkState();
         return getInstance().select(subtype, qualifiers);
     }
 
     @Override
     public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers) {
+        checkState();
         return getInstance().select(subtype, qualifiers);
     }
 
     @Override
     public boolean isUnsatisfied() {
+        checkState();
         return getInstance().isUnsatisfied();
     }
 
     @Override
     public boolean isAmbiguous() {
+        checkState();
         return getInstance().isAmbiguous();
     }
 
     @Override
     public void destroy(T instance) {
+        checkState();
         getInstance().destroy(instance);
     }
 
@@ -126,6 +134,13 @@ public abstract class AbstractCDI<T> extends CDI<T> {
      */
     protected Instance<T> getInstance() {
         return instanceCache.getValue(BeanManagerProxy.unwrap(getBeanManager()));
+    }
+
+    /**
+     * Check whether container is running
+     */
+    protected void checkState(){
+      //no-op
     }
 
 }


### PR DESCRIPTION
This log message is a little bit questionable (we don't know if container was running before or not). Maybe we can introduce new logging message
