### PR TITLE
Enhance Utils.deserialize, fix EE producer test and re-enable it.

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/ee/EEResourceProducerFieldPassivationCapableTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/ee/EEResourceProducerFieldPassivationCapableTest.java
@@ -54,9 +54,10 @@ public class EEResourceProducerFieldPassivationCapableTest {
     }
 
     @Test
-    @Ignore("WFLY-835")
+    @Ignore("Will work once we start testing with WFLY 11+, as there will be fix for JBTM-2449")
     public void testResource(@Produced UserTransaction userTransaction) throws Throwable {
-        UserTransaction userTransaction1 = Utils.deserialize(Utils.serialize(userTransaction));
+        // invoke deserialization with special class loader as the underlying class will not be otherwise visible to Weld
+        UserTransaction userTransaction1 = Utils.deserialize(Utils.serialize(userTransaction), userTransaction.getClass().getClassLoader());
         Assert.assertTrue(checkUserTransaction(userTransaction1));
     }
 


### PR DESCRIPTION
Will **not pass** until we run it against WFLY 11 as it contains fix for WFLY-835.