### PR TITLE
BZ-1388757 Backport WELD-1256 - AbstractConversationContext calls conversation.end() without checking if its transient

### DIFF
--- a/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
+++ b/impl/src/main/java/org/jboss/weld/context/AbstractConversationContext.java
@@ -320,7 +320,10 @@ public abstract class AbstractConversationContext<R, S> extends AbstractBoundCon
                 setActive(true);
                 for (ManagedConversation conversation : conversations.values()) {
                     String id = conversation.getId();
-                    conversation.end();
+                    if (!conversation.isTransient()) {
+                        // the currently associated conversation will be destroyed at the end of the current request
+                        conversation.end();
+                    }
                     destroyConversation(session, id);
                 }
                 setActive(false);


### PR DESCRIPTION
https://issues.jboss.org/browse/WELD-1256
https://github.com/weld/core/commit/ad3c7f997cd30130a96986598dfb9bf8db00de3a