### PR TITLE
WELD-2260 When the WeldManager has been located, track its id as a co…

### DIFF
--- a/environments/servlet/tests/jetty/pom.xml
+++ b/environments/servlet/tests/jetty/pom.xml
@@ -314,9 +314,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <excludes>
-                                <exclude>%regex[.*servlet/test/(?!se).*]</exclude>
-                            </excludes>
+                            <includes>
+                                <include>org.jboss.weld.environment.servlet.test.se.coop.BootstrapNotNeededTest</include>
+                                <include>org.jboss.weld.environment.servlet.test.se.coop.builder.WeldSeBuilderTest</include>
+                            </includes>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
…ntext attribute.

Later on in `WeldInitialListener`, the ID is used to locate the underlying bean manager.  This was failing in 2.4.1 due to the changes in how IDs are used (when not specified).  Specifically this line https://github.com/weld/core/blob/2.4/impl/src/main/java/org/jboss/weld/servlet/WeldInitialListener.java#L85 that is looking it up.  The failure was happening on line #94.