### PR TITLE
WELD-2307 Allow reflection calls for jboss-classfilewriter in tests.

### DIFF
--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -143,6 +143,13 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${surefire.plugin.jdk9.args}</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -151,7 +158,7 @@
             <!--Groovy compilation is disabled for JDK 1.9+-->
             <id>weld-groovy-compilation</id>
             <activation>
-                <jdk>(,1.9)</jdk>
+                <jdk>(,9)</jdk>
             </activation>
             <build>
                 <plugins>

--- a/environments/se/tests/pom.xml
+++ b/environments/se/tests/pom.xml
@@ -114,6 +114,7 @@
                   <libPath>${project.build.outputDirectory}</libPath>
                   <jacoco.agent>${jacoco.agent}</jacoco.agent>
                   <weld.se.debug>false</weld.se.debug>
+                  <surefire.plugin.jdk9.args>${surefire.plugin.jdk9.args}</surefire.plugin.jdk9.args>
                </systemProperties>
             </configuration>
          </plugin>

--- a/environments/se/tests/src/test/resources/arquillian.xml
+++ b/environments/se/tests/src/test/resources/arquillian.xml
@@ -14,7 +14,7 @@
          <property name="debug">${weld.se.debug}</property>
          <property name="logLevel">INFO</property>
          <property name="keepDeploymentArchives">false</property>
-         <property name="additionalJavaOpts">${jacoco.agent}</property>
+         <property name="additionalJavaOpts">${surefire.plugin.jdk9.args} ${jacoco.agent}</property>
          <property name="waitTime">15</property>
       </configuration>
    </container>

--- a/environments/servlet/core/pom.xml
+++ b/environments/servlet/core/pom.xml
@@ -175,4 +175,16 @@
         </dependency>
 
     </dependencies>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>${surefire.plugin.jdk9.args}</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/inject-tck-runner/pom.xml
+++ b/inject-tck-runner/pom.xml
@@ -81,6 +81,7 @@
                     <includes>
                         <include>**/AtInjectTCK.java</include>
                     </includes>
+                    <argLine>${surefire.plugin.jdk9.args}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -161,7 +161,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4425695 -->
-                    <argLine>-Xmx768m -Dsun.zip.disableMemoryMapping=true</argLine>
+                    <argLine>-Xmx768m -Dsun.zip.disableMemoryMapping=true ${surefire.plugin.jdk9.args}</argLine>
                     <forkMode>once</forkMode>
                     <properties>
                         <property>
@@ -483,6 +483,7 @@
                             <systemPropertyVariables>
                                 <arquillian.launch>weld-se</arquillian.launch>
                                 <libPath>${project.build.outputDirectory}</libPath>
+                                <surefire.plugin.jdk9.args>${surefire.plugin.jdk9.args}</surefire.plugin.jdk9.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/jboss-tck-runner/src/test/weld-se/arquillian.xml
+++ b/jboss-tck-runner/src/test/weld-se/arquillian.xml
@@ -11,6 +11,7 @@
         <protocol type="simple-jmx"/>
         <configuration>
             <property name="librariesPath">${libPath}</property>
+            <property name="additionalJavaOpts">${surefire.plugin.jdk9.args}</property>
             <!--<property name="debug">true</property>-->
             <!--<property name="logLevel">FINE</property>-->
             <!--<property name="keepDeploymentArchives">true</property>-->

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,9 @@
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
         <!-- Travis CI build workaround -->
         <travis.surefire.argLine>-Xmx1024m</travis.surefire.argLine>
+        
+        <!-- Only initialized in JDK 9 profile to provide extra CMD args to surefire -->
+        <surefire.plugin.jdk9.args></surefire.plugin.jdk9.args>
 
         <manifest.specification.title>JSR-365 Contexts and Dependency Injection for Java</manifest.specification.title>
         <manifest.specification.version>2.0</manifest.specification.version>
@@ -743,6 +746,11 @@
             <activation>
                 <jdk>9</jdk>
             </activation>
+            <properties>
+                <!--This property will be added to surefire jvm args when needed. Due to reflection usage we have to to open 
+                package java.lang in module java.base to unnamed module, hence making it available for reflection-->
+                <surefire.plugin.jdk9.args>--add-opens java.base/java.lang=ALL-UNNAMED </surefire.plugin.jdk9.args>
+            </properties>
             <build>
                 <pluginManagement>
                     <plugins>
@@ -759,7 +767,6 @@
                             <artifactId>maven-compiler-plugin</artifactId>
                             <version>3.6.0</version>
                         </plugin>
-
                     </plugins>
                 </pluginManagement>
             </build>

--- a/tests-arquillian/pom.xml
+++ b/tests-arquillian/pom.xml
@@ -227,7 +227,7 @@
                             </systemProperties>
                             <test>${test}</test>
                             <!-- Travis CI build workaround -->
-                            <argLine>${travis.surefire.argLine}</argLine>
+                            <argLine>${surefire.plugin.jdk9.args} ${travis.surefire.argLine}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -272,7 +272,7 @@
                                 <arquillian.xml>wildfly-arquillian.xml</arquillian.xml>
                                 <jacoco.agent>${jacoco.agent}</jacoco.agent>
                                 <node.address>${node.address}</node.address>
-                                <additional.vm.args>${additional.vm.args}</additional.vm.args>
+                                <additional.vm.args>${surefire.plugin.jdk9.args}${additional.vm.args}</additional.vm.args>
                                 <org.jboss.remoting-jmx.timeout>360</org.jboss.remoting-jmx.timeout>
                             </systemProperties>
                             <test>${test}</test>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -145,7 +145,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>-Xmx128m</argLine>
+                            <argLine>${surefire.plugin.jdk9.args} -Xmx128m</argLine>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Note that scope of WELD-2307 might be wider, e.g. more PRs might be coming due to reflection changes.
This one ensures that whenever jboss-classfilewriter is used, it is "granted reflection access" to JDK internals.