### PR TITLE
Increase container connection timeout for SE tests. Windows machines …

### DIFF
--- a/environments/se/tests/src/test/resources/arquillian.xml
+++ b/environments/se/tests/src/test/resources/arquillian.xml
@@ -15,7 +15,7 @@
          <property name="logLevel">INFO</property>
          <property name="keepDeploymentArchives">false</property>
          <property name="additionalJavaOpts">${surefire.plugin.jdk9.args} ${jacoco.agent}</property>
-         <property name="waitTime">15</property>
+         <property name="waitTime">${connection.wait.time:15}</property>
       </configuration>
    </container>
 


### PR DESCRIPTION
…were failing.

I came across a (random) timeout on Win machine during release testing. I think it will do no harm to increase the timeout here.