### PR TITLE
WELD-2302 Wro4j maven plugin does not work with JDK 9

### DIFF
--- a/probe/core/pom.xml
+++ b/probe/core/pom.xml
@@ -106,7 +106,15 @@
                     <plugin>
                         <groupId>ro.isdc.wro4j</groupId>
                         <artifactId>wro4j-maven-plugin</artifactId>
-                        <version>1.7.7</version>
+                        <version>1.8.0</version>
+                        <dependencies>
+                            <!-- dependency for JDK 9 compilation support -->
+                            <dependency>
+                                <groupId>org.mockito</groupId>
+                                <artifactId>mockito-core</artifactId>
+                                <version>2.7.6</version>
+                            </dependency>
+                        </dependencies>
                         <executions>
                             <execution>
                                 <phase>compile</phase>


### PR DESCRIPTION
upgrade plugin and Mockito dependency to have a Mockito version supporting Java 9