### PR TITLE
WELD-2336 Log info about important phases during bootstrap

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/Tracker.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Tracker.java
@@ -1,0 +1,67 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.bootstrap;
+
+/**
+ * A simple tracker used to monitor bootstrap operations. It is not thread-safe and may not be shared between threads.
+ *
+ * @author Martin Kouba
+ */
+interface Tracker extends AutoCloseable {
+
+    String OP_BOOTSTRAP = "bootstrap";
+    String OP_START_CONTAINER = "startContainer";
+    String OP_INIT_SERVICES = "initServices";
+    String OP_CONTEXTS = "builtinContexts";
+    String OP_READ_DEPLOYMENT = "readDeploymentStructure";
+    String OP_START_INIT = "startInitialization";
+    String OP_DEPLOY_BEANS = "deployBeans";
+    String OP_VALIDATE_BEANS = "validateBeans";
+    String OP_END_INIT = "endInitialization";
+    String OP_BBD = "BeforeBeanDiscovery";
+    String OP_ATD = "AfterTypeDiscovery";
+    String OP_ABD = "AfterBeanDiscovery";
+    String OP_ADV = "AfterDeploymentValidation";
+
+    /**
+     * Starts an operation - push.
+     *
+     * @param operation
+     * @return self
+     */
+    Tracker start(String operation);
+
+    /**
+     * Ends the last operation on the stack - pop.
+     *
+     * @return self
+     */
+    Tracker end();
+
+    /**
+     * Could be used to monitor the current operation progress.
+     *
+     * @param info
+     */
+    void split(String info);
+
+    /**
+     * End all operations.
+     */
+    void close();
+
+}

--- a/impl/src/main/java/org/jboss/weld/bootstrap/Trackers.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Trackers.java
@@ -1,0 +1,126 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.bootstrap;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.weld.logging.BootstrapLogger;
+
+/**
+ *
+ * @author Martin Kouba
+ */
+final class Trackers {
+
+    private Trackers() {
+    }
+
+    private static final Tracker NOOP_INSTANCE = new NoopTracker() {
+    };
+
+    static Tracker create(String startOperation) {
+        return create().start(startOperation);
+    }
+
+    static Tracker create() {
+        return BootstrapLogger.TRACKER_LOG.isDebugEnabled() ? new LoggingTracker() : NOOP_INSTANCE;
+    }
+
+    private static class NoopTracker implements Tracker {
+
+        @Override
+        public Tracker start(String operation) {
+            return this;
+        }
+
+        @Override
+        public Tracker end() {
+            return this;
+        }
+
+        @Override
+        public void split(String info) {
+        }
+
+        @Override
+        public void close() {
+        }
+
+    }
+
+    private static class LoggingTracker implements Tracker {
+
+        private final List<Operation> operations;
+
+        LoggingTracker() {
+            this.operations = new LinkedList<>();
+        }
+
+        @Override
+        public Tracker start(String operation) {
+            if (!operations.isEmpty()) {
+                operation = operations.get(operations.size() - 1).name + " > " + operation;
+            }
+            operations.add(new Operation(operation));
+            BootstrapLogger.TRACKER_LOG.debugf("START %s ", operation);
+            return this;
+        }
+
+        @Override
+        public void split(String info) {
+            Operation operation = operations.get(operations.size() - 1);
+            BootstrapLogger.TRACKER_LOG.debugf(" TIME %s:%s (%s ms)", operation.name, info, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - operation.start));
+        }
+
+        public Tracker end() {
+            Operation operation = operations.remove(operations.size() - 1);
+            logEnd(operation.name, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - operation.start));
+            return this;
+        }
+
+        @Override
+        public void close() {
+            for (ListIterator<Operation> iterator = operations.listIterator(operations.size()); iterator.hasPrevious();) {
+                Operation operation = (Operation) iterator.previous();
+                logEnd(operation.name, TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - operation.start));
+                iterator.remove();
+            }
+        }
+
+        private void logEnd(String info, long time) {
+            BootstrapLogger.TRACKER_LOG.debugf("  END %s (%s ms)", info, time);
+        }
+
+        private static class Operation {
+
+            private final String name;
+
+            private final Long start;
+
+            public Operation(String operation) {
+                this.name = operation;
+                this.start = System.nanoTime();
+            }
+
+        }
+
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
@@ -43,6 +43,8 @@ public interface BootstrapLogger extends WeldLogger {
 
     BootstrapLogger LOG = Logger.getMessageLogger(BootstrapLogger.class, Category.BOOTSTRAP.getName());
 
+    BootstrapLogger TRACKER_LOG = Logger.getMessageLogger(BootstrapLogger.class, Category.BOOTSTRAP_TRACKER.getName());
+
     @LogMessage(level = Level.DEBUG)
     @Message(id = 100, value = "Weld initialized. Validating beans")
     void validatingBeans();

--- a/impl/src/main/java/org/jboss/weld/logging/Category.java
+++ b/impl/src/main/java/org/jboss/weld/logging/Category.java
@@ -19,6 +19,7 @@ package org.jboss.weld.logging;
 public enum Category {
 
     BOOTSTRAP("Bootstrap"),
+    BOOTSTRAP_TRACKER("BootstrapTracker"),
     VERSION("Version"),
     UTIL("Utilities"),
     BEAN("Bean"),


### PR DESCRIPTION
Sample log output:
```
[main] INFO org.jboss.weld.Version - WELD-000900: 3.0.0 (2017-02-16 10:13)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: startContainer 
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: startContainer > initServices 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: startContainer > initServices (76 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: startContainer > builtinContexts 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: startContainer > builtinContexts (60 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: startContainer > readDeploymentStructure 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: startContainer > readDeploymentStructure (17 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: startContainer (190 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: startInitialization 
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: startInitialization > BeforeBeanDiscovery 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: startInitialization > BeforeBeanDiscovery (26 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: startInitialization > AfterTypeDiscovery 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: startInitialization > AfterTypeDiscovery (0 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: startInitialization (80 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: deployBeans 
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: deployBeans > AfterBeanDiscovery 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: deployBeans > AfterBeanDiscovery (2 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: deployBeans (119 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: validateBeans 
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: validateBeans > AfterDeploymentValidation 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: validateBeans > AfterDeploymentValidation (0 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: validateBeans (11 ms)
[main] DEBUG org.jboss.weld.BootstrapTracker - ST: endInitialization 
[main] DEBUG org.jboss.weld.BootstrapTracker - EN: endInitialization (6 ms)
```