### PR TITLE
Weld 2335 Having different types between InterceptionFactory and instance to intercept should fail

### DIFF
--- a/impl/src/main/java/org/jboss/weld/injection/InterceptionFactoryImpl.java
+++ b/impl/src/main/java/org/jboss/weld/injection/InterceptionFactoryImpl.java
@@ -112,6 +112,10 @@ public class InterceptionFactoryImpl<T> implements InterceptionFactory<T> {
         }
         used = true;
 
+        if (annotatedType.getJavaClass().isInterface()) {
+            throw InterceptorLogger.LOG.interceptionFactoryNotOnInstance(annotatedType.getJavaClass().getCanonicalName());
+        }
+
         Optional<InterceptionFactoryData<T>> cached = beanManager.getServices().get(InterceptionFactoryDataCache.class)
                 .getInterceptionFactoryData(configurator != null ? configurator.complete() : annotatedType);
 

--- a/impl/src/main/java/org/jboss/weld/logging/InterceptorLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/InterceptorLogger.java
@@ -78,4 +78,7 @@ public interface InterceptorLogger extends WeldLogger {
     @Message(id = 1710, value = "InterceptionFactory skipped wrapper creation for an internal container construct of type {0}", format = Format.MESSAGE_FORMAT)
     void interceptionFactoryInternalContainerConstruct(Object type);
 
+    @Message(id = 1711, value = "InterceptionFactory is not supported on interfaces. Check InterceptionFactory<{0}>", format= Format.MESSAGE_FORMAT)
+    IllegalStateException interceptionFactoryNotOnInstance(Object param1);
+
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/InterceptionFactoryTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/InterceptionFactoryTest.java
@@ -18,8 +18,10 @@
 package org.jboss.weld.tests.interceptors.producer;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import javax.enterprise.inject.Instance;
@@ -29,6 +31,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.exceptions.IllegalStateException;
 import org.jboss.weld.test.util.Utils;
 import org.jboss.weld.tests.interceptors.producer.Producer.Bar;
 import org.jboss.weld.tests.interceptors.producer.Producer.Foo;
@@ -87,5 +90,23 @@ public class InterceptionFactoryTest {
         map.put(params[0], params[1]);
         assertEquals(1, Producer.INVOCATIONS.size());
         assertEquals(Arrays.toString(params), Producer.INVOCATIONS.get(0));
+    }
+
+    @Test
+    public void testListAdd(@Produced Instance<List<Object>> lists) {
+        // resolving via Instance just to make the NPE exception human-readable (direct method injection will blow up with Arq. stack)
+        // Invalid producer using an InterceptionFactory for List (interface) and applying it to ArrayList
+        try {
+            lists.get();
+            fail();
+        } catch (IllegalStateException e) {
+            //Expected
+        }
+    }
+
+
+    @Test
+    public void testParent(@Produced Producer.FooParent foo) {
+        assertEquals("Hello Parent pong", foo.ping());
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/Producer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/Producer.java
@@ -87,6 +87,31 @@ public class Producer {
         }).findFirst().get().add(Monitor.Literal.INSTANCE);
         return interceptionFactory.createInterceptedInstance(new HashMap<>());
     }
+    
+    @Produced
+    @Dependent
+    @Produces
+    public List<Object> produceList(InterceptionFactory<List<Object>> interceptionFactory) {
+        interceptionFactory.ignoreFinalMethods().configure().filterMethods((m) -> {
+            if (m.getJavaMember().getName().equals("add")
+                    && m.getJavaMember().getParameterCount() == 1) {
+                return true;
+            }
+            return false;
+        }).findFirst().get().add(Monitor.Literal.INSTANCE);
+        return interceptionFactory.createInterceptedInstance(new ArrayList<>());
+    }
+
+
+    @Produces
+    @Produced
+    public FooParent produceFooParent(InterceptionFactory<FooParent> interceptionFactory) {
+        interceptionFactory.configure().filterMethods((m) ->
+            m.getJavaMember().getName().equals("ping")
+        ).findFirst().get().add(Hello.Literal.INSTANCE);
+        return interceptionFactory.createInterceptedInstance(new FooChild());
+    }
+
 
     static class Foo {
 
@@ -107,5 +132,16 @@ public class Producer {
 
     static void reset() {
         INVOCATIONS.clear();
+    }
+
+    public static class FooParent {
+
+        String ping() {
+            return "Parent pong";
+        }
+    }
+
+    public static class FooChild extends FooParent {
+
     }
 }


### PR DESCRIPTION
As the idea behind InterceptionFactory is to customise the underlying AnnotatedType to add interceptor binding on class or method, it doesn't make sense to pass an instance of a different type than the parameter type used to defined the InterceptionFactory.