### PR TITLE
WELD-2331 Misleading error message when Extension observer method is (wrongly) static

### DIFF
--- a/impl/src/main/java/org/jboss/weld/logging/EventLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/EventLogger.java
@@ -83,7 +83,7 @@ public interface EventLogger extends WeldLogger {
     @Message(id = 413, value = "{0} cannot be replaced by an observer method with a different bean class {1}", format = Format.MESSAGE_FORMAT)
     DefinitionException beanClassMismatch(ObserverMethod<?> originalObserverMethod, ObserverMethod<?> observerMethod);
 
-    @Message(id = 414, value = "Observer method for container lifecycle events cannot be asynchronous. {0}\n\tat {1}\n  StackTrace:", format = Format.MESSAGE_FORMAT)
+    @Message(id = 414, value = "Observer method for container lifecycle event cannot be asynchronous. {0}\n\tat {1}\n  StackTrace:", format = Format.MESSAGE_FORMAT)
     DefinitionException asyncContainerLifecycleEventObserver(ObserverMethod<?> observer, Object stackElement);
 
     @Message(id = 415, value = "Custom implementation of observer method does not override either notify(T) or notify(EventContext<T>): {0}", format = Format.MESSAGE_FORMAT)
@@ -95,5 +95,8 @@ public interface EventLogger extends WeldLogger {
     @LogMessage(level = Level.WARN)
     @Message(id = 417, value = "The original observed type {0} is not assignable from {1} set by extension {2} - the observer method invocation may result in runtime exception!", format = Format.MESSAGE_FORMAT)
     void originalObservedTypeIsNotAssignableFrom(Object originalObservedType, Object observedType, Object extension);
+
+    @Message(id = 418, value = "Observer method for container lifecycle event cannot be static. {0}\n\tat {1}\n  StackTrace:", format = Format.MESSAGE_FORMAT)
+    DefinitionException staticContainerLifecycleEventObserver(ObserverMethod<?> observer, Object stackElement);
 
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/ExtensionWithStaticLifecycleEventObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/ExtensionWithStaticLifecycleEventObserver.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.extensions.staticObserver;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessAnnotatedType;
+
+/**
+ * @author Antoine Sabot-Durand
+ */
+public class ExtensionWithStaticLifecycleEventObserver implements Extension {
+
+    static void processAnnotatedType(@Observes ProcessAnnotatedType<?> pat) {
+
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/ExtensionWithStaticNonLifecycleEventObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/ExtensionWithStaticNonLifecycleEventObserver.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.extensions.staticObserver;
+
+import java.util.Set;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.Extension;
+
+/**
+ * @author Antoine Sabot-Durand
+ */
+public class ExtensionWithStaticNonLifecycleEventObserver implements Extension {
+    public static final String SYNC = "sync";
+
+    static void processSyncStrings(@Observes Set<String> str) {
+        str.add(SYNC);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/StaticLifecycleEventObserverTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/StaticLifecycleEventObserverTest.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.extensions.staticObserver;
+
+import javax.enterprise.inject.spi.DefinitionException;
+import javax.enterprise.inject.spi.Extension;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Testing that a deployment error occurs extension has static lifecycle event observer method
+ *
+ * @author Antoine Sabot-Durand
+ */
+@RunWith(Arquillian.class)
+public class StaticLifecycleEventObserverTest {
+
+    @Deployment
+    @ShouldThrowException(DefinitionException.class)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(StaticLifecycleEventObserverTest.class))
+                .addClass(ExtensionWithStaticLifecycleEventObserver.class)
+                .addAsServiceProvider(Extension.class, ExtensionWithStaticLifecycleEventObserver.class);
+    }
+
+    @Test
+    public void neverCalled() {
+        // Deployment fails before the method is called
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/StaticNonLifecycleEventObserverTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/staticObserver/StaticNonLifecycleEventObserverTest.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.extensions.staticObserver;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.event.Event;
+import javax.enterprise.inject.spi.Extension;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Testing that static observers for non Lifecycle event in extension are called
+ *
+ * @author Antoine Sabot-Durand
+ */
+@RunWith(Arquillian.class)
+public class StaticNonLifecycleEventObserverTest {
+
+    private Set<String> stringSet = new HashSet<>();
+
+    @Inject
+    private Event<Set<String>> evt;
+
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(StaticNonLifecycleEventObserverTest.class))
+                .addClass(ExtensionWithStaticNonLifecycleEventObserver.class)
+                .addAsServiceProvider(Extension.class, ExtensionWithStaticNonLifecycleEventObserver.class);
+    }
+
+    @Test
+    public void testSync() {
+        evt.fire(stringSet);
+        Assert.assertTrue(stringSet.contains(ExtensionWithStaticNonLifecycleEventObserver.SYNC));
+    }
+
+}


### PR DESCRIPTION
Added specific deployment error and test for it
Activated WeldExceptionTransformer to test specific error messages at deployment