### PR TITLE
Fix the version of jacoco-maven-plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <findbugs-annotations-version>1.3.2</findbugs-annotations-version>
         <glassfish.el.version>2.1.2-b04</glassfish.el.version>
         <htmlunit.version>2.20</htmlunit.version>
-        <jacoco.version>0.7.9-20170117.215116-13</jacoco.version>
+        <jacoco.version>0.7.9</jacoco.version>
         <jandex.version>2.0.3.Final</jandex.version>
         <javax.activation.version>1.1</javax.activation.version>
         <javax.el.version>3.0.0</javax.el.version>


### PR DESCRIPTION
The previous version now fails since it is no longer present in Maven repo.
Build works with this new one - see  [Jenkins job](https://jenkins.hosts.mwqe.eng.bos.redhat.com/hudson/view/Weld/view/Weld%203%20CI/job/Weld-3.x-jacoco/164/)