### PR TITLE
WELD-2373 BeanManager#createInstance can only be invoked after deploy…

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerProxy.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerProxy.java
@@ -182,6 +182,7 @@ public class BeanManagerProxy extends ForwardingBeanManager implements WeldManag
 
     @Override
     public WeldInstance<Object> createInstance() {
+        checkContainerState("createInstance()", ContainerState.VALIDATED);
         return delegate().createInstance();
     }
 


### PR DESCRIPTION
…ment validation.

@mkouba I did not create a test here, because that should be covered in [TCK-571](https://issues.jboss.org/browse/CDITCK-571). No point in having that duplicated IMO.