### PR TITLE
WELD-2273 Decorated bean with private constructors only cause NPE in SE  

### DIFF
--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/Bravo.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/Bravo.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.decorator;
+
+
+public interface Bravo {
+
+    String saySomething();
+
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/BravoDecorator.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/BravoDecorator.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.decorator;
+
+import javax.annotation.Priority;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.context.Dependent;
+import javax.inject.Inject;
+
+@Dependent
+@Decorator
+@Priority(1)
+public abstract class BravoDecorator implements Bravo{
+
+    @Inject
+    @Delegate
+    Bravo decorated;
+
+    @Override
+    public String saySomething() {
+        return decorated.saySomething() + " decorated";
+    }
+
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/BravoImpl.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/BravoImpl.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.decorator;
+
+import javax.enterprise.context.ApplicationScoped;
+
+
+@ApplicationScoped
+public class BravoImpl implements Bravo{
+
+    private BravoImpl() {
+    }
+
+    @Override
+    public String saySomething() {
+        return "bravo";
+    }
+
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/BravoImpl.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/BravoImpl.java
@@ -26,6 +26,9 @@ public class BravoImpl implements Bravo{
     private BravoImpl() {
     }
 
+    public BravoImpl(String foo) {
+    }
+
     @Override
     public String saySomething() {
         return "bravo";

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/DecoratedWithPrivateConstructorTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/DecoratedWithPrivateConstructorTest.java
@@ -42,15 +42,12 @@ public class DecoratedWithPrivateConstructorTest {
                 .build();
     }
 
-    @Test
+    @Test(expected = DeploymentException.class)
     public void privateConstructorTest() {
-        try {
-            WeldContainer container = new Weld().initialize();
-            Assert.fail();
-        } catch (DeploymentException e) {
-            Assert.assertTrue(e.getMessage().contains("Bean class which has decorators should declare at least one non private constructor"));
-        }
-
+        WeldContainer container = new Weld()
+                .property("org.jboss.weld.construction.relaxed", true)
+                .initialize();
+        Assert.fail();
     }
 }
 

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/DecoratedWithPrivateConstructorTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/DecoratedWithPrivateConstructorTest.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.decorator;
+
+
+import javax.enterprise.inject.spi.DeploymentException;
+
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class DecoratedWithPrivateConstructorTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ClassPath.builder().add(ShrinkWrap.create(BeanArchive.class)
+                                               .addPackage(Bravo.class.getPackage()))
+                .build();
+    }
+
+    @Test
+    public void privateConstructorTest() {
+        try {
+            WeldContainer container = new Weld().initialize();
+        } catch (DeploymentException e) {
+            Assert.assertTrue(e.getMessage().contains("Bean class which has decorators should declare at least one non private constructor"));
+        }
+
+    }
+}
+

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/DecoratedWithPrivateConstructorTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/decorator/DecoratedWithPrivateConstructorTest.java
@@ -46,6 +46,7 @@ public class DecoratedWithPrivateConstructorTest {
     public void privateConstructorTest() {
         try {
             WeldContainer container = new Weld().initialize();
+            Assert.fail();
         } catch (DeploymentException e) {
             Assert.assertTrue(e.getMessage().contains("Bean class which has decorators should declare at least one non private constructor"));
         }

--- a/impl/src/main/java/org/jboss/weld/injection/producer/BeanInjectionTarget.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/BeanInjectionTarget.java
@@ -24,6 +24,7 @@ import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.Decorator;
 import javax.enterprise.inject.spi.Interceptor;
+import javax.inject.Inject;
 
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedConstructor;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedMethod;
@@ -147,11 +148,12 @@ public class BeanInjectionTarget<T> extends BasicInjectionTarget<T> {
     }
 
     protected void checkNonPrivateConstructor(EnhancedAnnotatedType<T> type) {
-        if (type.getEnhancedConstructors().stream().anyMatch(c -> !c.isPrivate())) {
-            return;
-        } else {
-            throw BeanLogger.LOG.decoratedMustHaveNonPrivateConstructor(this);
+        for (EnhancedAnnotatedConstructor<T> eac : type.getEnhancedConstructors()) {
+            if (!eac.isPrivate() && (eac.getParameters().size() == 0 || eac.isAnnotationPresent(Inject.class))) {
+                return;
+            }
         }
+        throw BeanLogger.LOG.decoratedMustHaveNonPrivateConstructor(this);
     }
 
     protected void checkNoArgsConstructor(EnhancedAnnotatedType<T> type) {

--- a/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
@@ -519,7 +519,7 @@ public interface BeanLogger extends WeldLogger {
     @Message(id = 1569, value = "Cannot inject injection point metadata in a non @Dependent bean: {0}", format = Format.MESSAGE_FORMAT)
     IllegalArgumentException cannotInjectInjectionPointMetadataIntoNonDependent(Object bean);
 
-    @Message(id = 1570, value = "Bean class which has decorators should declare at least one non private constructor: {0}\n  StackTrace:", format = Format.MESSAGE_FORMAT)
+    @Message(id = 1570, value = "Bean class which has decorators in relaxed mode should declare at least one non private constructor with no args or annotated with @Inject: {0}\n  StackTrace:", format = Format.MESSAGE_FORMAT)
     DeploymentException decoratedMustHaveNonPrivateConstructor(Object param1);
 
 }

--- a/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
@@ -519,4 +519,7 @@ public interface BeanLogger extends WeldLogger {
     @Message(id = 1569, value = "Cannot inject injection point metadata in a non @Dependent bean: {0}", format = Format.MESSAGE_FORMAT)
     IllegalArgumentException cannotInjectInjectionPointMetadataIntoNonDependent(Object bean);
 
+    @Message(id = 1570, value = "Bean class which has decorators should declare at least one non private constructor: {0}\n  StackTrace:", format = Format.MESSAGE_FORMAT)
+    DeploymentException decoratedMustHaveNonPrivateConstructor(Object param1);
+
 }


### PR DESCRIPTION
When Weld relaxed mode is true, some checks are skipped, which could trigger an NPE if a decorated bean has no non private constructor.