### PR TITLE
WELD-2401 Revert the behaviour - this cannot be fixed on WFLY side.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
@@ -693,7 +693,7 @@ public class WeldStartup {
     }
 
     private boolean isEEModulesAwareEnvironment() {
-        return Environments.EE.equals(environment) || Environments.EE_INJECT.equals(environment) || Environments.SERVLET.equals(environment);
+        return !Environments.SE.equals(environment);
     }
 
     private void validationFailed(Exception failure) {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/ear/noWebArchive/ApplicationContextInitializedEventFiredWithNoWebArchiveTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/ear/noWebArchive/ApplicationContextInitializedEventFiredWithNoWebArchiveTest.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.weld.tests.contexts.application.event.ear.noWebArchive;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.Testable;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.weld.tests.category.Integration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+/**
+ * Testcase for WFLY-3334, WELD-2401
+ * @author Matej Novotny
+ *
+ */
+@RunWith(Arquillian.class)
+@Category(Integration.class)
+public class ApplicationContextInitializedEventFiredWithNoWebArchiveTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        JavaArchive lib = ShrinkWrap.create(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").addClasses(Library.class, ApplicationContextInitializedEventFiredWithNoWebArchiveTest.class);
+        JavaArchive ejb = Testable.archiveToTest(ShrinkWrap.create(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml").addClass(SessionBean.class));
+        return ShrinkWrap.create(EnterpriseArchive.class).addAsModule(ejb).addAsLibrary(lib);
+    }
+
+    @Test
+    public void testEjbJar() {
+        Assert.assertNotNull(SessionBean.EVENT);
+    }
+
+    @Test
+    public void testLibrary() {
+        Assert.assertNotNull(Library.EVENT);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/ear/noWebArchive/Library.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/ear/noWebArchive/Library.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.weld.tests.contexts.application.event.ear.noWebArchive;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+
+public class Library {
+
+    public static volatile Object EVENT;
+
+    public static void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        if (EVENT != null) {
+            throw new IllegalStateException("Event already received: " + EVENT);
+        }
+        EVENT = event;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/ear/noWebArchive/SessionBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/application/event/ear/noWebArchive/SessionBean.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.weld.tests.contexts.application.event.ear.noWebArchive;
+
+import javax.ejb.Stateless;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+
+@Stateless
+public class SessionBean {
+
+    public static volatile Object EVENT;
+
+    public static void init(@Observes @Initialized(ApplicationScoped.class) Object event) {
+        if (EVENT != null) {
+            throw new IllegalStateException("Event already received: " + EVENT);
+        }
+        EVENT = event;
+    }
+
+    public void ping() {
+    }
+}


### PR DESCRIPTION
This does not seem fixable on WFLY side (so that Swarm stays untouched) and in the same time we cannot do much unless we want to break Weld API. Therefore we should probably revert the change and leave it like that (and think this through for 3.x).

We can leave this PR hanging here for a while and see if we can come up with anything better.