### PR TITLE
WELD-2397 Allow to create WildFly patch through Maven profile.

### DIFF
--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -28,8 +28,26 @@
 
     <properties>
         <!-- We have to explicitly state the project version. We cannot use ${project.version}
-            as the release plugin won't deal with double evaluation -->
+        as the release plugin won't deal with double evaluation -->
         <weld.update.version>2.4.5-SNAPSHOT</weld.update.version>
+        
+        <!-- Following section is dedicated to WFLY download/update and patch creation -->
+        <!--Path to the patched WFLY server, if you chose to let Mavne download it, this default will be used-->
+        <wildflyPatched>${project.build.directory}/wildfly-patched</wildflyPatched>
+        <!--Path to patch file; only change if you have your own, else Maven downloads it-->
+        <patchConfigFile>${project.build.directory}/patch.xml</patchConfigFile>
+        <!--These patches are automatically downloaded from github.com/weld/build/tree/master/wildfly, specify the file name here to determine which one to use-->
+        <patch.file.name>patch-config-wildfly-10-weld-2.4.xml</patch.file.name>
+        <!--Use this property to set the path to and the name of the resulting patch zip file-->
+        <patchOutputFile>${project.build.directory}/patch.zip</patchOutputFile>
+        <!--Path to original (pristine) WFLY-->
+        <!--Running with -Pdownload-wfly will make Maven download the version specified below-->
+        <wildflyOriginal>${project.build.directory}/wildfly-original</wildflyOriginal>
+        <wildfly.download.version>10.1.0.Final</wildfly.download.version>
+        
+        <!--Plugin versions-->
+        <download.maven.plugin>1.3.0</download.maven.plugin>
+        <patch.gen.plugin>2.0.1.Alpha5</patch.gen.plugin>
     </properties>
 
     <dependencies>
@@ -59,6 +77,68 @@
         </dependency>
     </dependencies>
     <profiles>
+        <!--Downloads WildFly and sets JBOSS_HOME so that this WFLY gets patched-->
+        <!--Also makes a copy of the pristine WFLY so that we can use it for patch creation-->
+        <profile>
+            <id>download-wfly</id>
+            <properties>
+                <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-${wildfly.download.version}</wildflyOriginal>
+                <!--Set jboss.home property to the location of the copy of WFLY we download-->
+                <jboss.home>${project.build.directory}/wildfly-patched/wildfly-${wildfly.download.version}</jboss.home>
+                <!--Set wildflyPatched property for patch creation, this assumes you patch the WFLY by running -Pupdate-jboss-as as well-->
+                <wildflyPatched>${project.build.directory}/wildfly-patched/wildfly-${wildfly.download.version}</wildflyPatched>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <!-- Extract WildFly twice: one copy to be left as is, the other to be updated with the new JARs -->
+                            <execution>
+                                <id>unpack-wildfly</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>${wildfly.download.version}</version>
+                                            <type>tar.gz</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}/wildfly-original</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <!-- Execute this after we've downloaded WFLY -->
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/wildfly-patched</outputDirectory>
+                                    <resources>          
+                                        <resource>
+                                            <directory>${project.build.directory}/wildfly-original</directory>
+                                        </resource>
+                                    </resources>              
+                                </configuration>            
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>update-jboss-as</id>
             <build>
@@ -82,33 +162,33 @@
 
                                         <echo>
 
-=========================================================================
+                                            =========================================================================
 
-Updating Weld modules
+                                            Updating Weld modules
 
-Weld version: ${weld.update.version}
+                                            Weld version: ${weld.update.version}
 
-JBOSS_HOME: ${jboss.home}
+                                            JBOSS_HOME: ${jboss.home}
 
-=========================================================================
+                                            =========================================================================
 
                                         </echo>
 
                                         <available file="${jboss.home}/modules/system" property="module.dir" value="${jboss.home}/modules/system/layers/base/org/jboss/weld" />
                                         <!-- The older versions of JBoss AS used
-                                            this location for modules -->
+                                        this location for modules -->
                                         <property name="module.dir" value="${jboss.home}/modules/org/jboss/weld" />
                                         <property name="jsf.injection.dir" value="${module.dir}/../as/jsf-injection/main" />
 
                                         <!-- Check to see if this version of
-                                            AS / WildFly uses a separate weld-core-jsf artifact or not -->
+                                        AS / WildFly uses a separate weld-core-jsf artifact or not -->
                                         <pathconvert property="weld.jsf.path" pathsep=" " setonempty="false">
                                             <path>
                                                 <fileset dir="${jsf.injection.dir}" includes="weld-core-jsf*.jar" />
                                             </path>
                                         </pathconvert>
                                         <!-- weld-core-impl is the right core
-                                            artifact if weld-core-jsf is used by the application server -->
+                                        artifact if weld-core-jsf is used by the application server -->
                                         <condition property="weld.core.file" value="weld-core-impl.jar">
                                             <and>
                                                 <isset property="weld.jsf.path" />
@@ -120,7 +200,7 @@ JBOSS_HOME: ${jboss.home}
                                             </and>
                                         </condition>
                                         <!-- otherwise, use the old artifact
-                                            (weld-core) -->
+                                        (weld-core) -->
                                         <property name="weld.core.file" value="weld-core.jar" />
                                         <property name="weld.probe.file" value="weld-probe-core.jar" />
 
@@ -170,7 +250,7 @@ JBOSS_HOME: ${jboss.home}
                                         <replaceregexp file="${module.dir}/api/main/module.xml" match="path=&quot;.*?&quot;" replace="path=&quot;weld-api.jar&quot;" byline="true" />
 
                                         <!-- Update the weld-core-jsf artifact
-                                            (this one is only used post WF 8.0.0.Alpha1) -->
+                                        (this one is only used post WF 8.0.0.Alpha1) -->
                                         <copy todir="${jsf.injection.dir}" overwrite="true">
                                             <fileset dir="target/dependency/lib">
                                                 <include name="${weld.jsf.file}" />
@@ -234,9 +314,68 @@ JBOSS_HOME: ${jboss.home}
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>wfly-patch-gen</id>
+            <build>
+                <plugins>
+                    <!--Downloads given patch file from our build repository-->
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>download-patch-file</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <configuration>
+                                    <url>https://raw.githubusercontent.com/weld/build/master/wildfly/${patch.file.name}</url>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <outputFileName>patch.xml</outputFileName>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.jboss.as</groupId>
+                        <artifactId>patch-gen-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>create-patch-file</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>generate-patch</goal>
+                                </goals>
+                                <configuration>
+                                    <appliesToDist>${wildflyOriginal}</appliesToDist>
+                                    <updatedDist>${wildflyPatched}</updatedDist>
+                                    <patchConfig>${patchConfigFile}</patchConfig>
+                                    <outputFile>${patchOutputFile}</outputFile>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>com.googlecode.maven-download-plugin</groupId>
+                    <artifactId>download-maven-plugin</artifactId>
+                    <version>${download.maven.plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jboss.as</groupId>
+                    <artifactId>patch-gen-maven-plugin</artifactId>
+                    <version>${patch.gen.plugin}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -33,7 +33,7 @@
         
         <!-- Following section is dedicated to WFLY download/update and patch creation -->
         <!--Path to the patched WFLY server, if you chose to let Mavne download it, this default will be used-->
-        <wildflyPatched>${project.build.directory}/wildfly-patched</wildflyPatched>
+        <wildflyPatched>${project.build.directory}/wildfly-patched/wildfly-${wildfly.download.version}</wildflyPatched>
         <!--Path to patch file; only change if you have your own, else Maven downloads it-->
         <patchConfigFile>${project.build.directory}/patch.xml</patchConfigFile>
         <!--These patches are automatically downloaded from github.com/weld/build/tree/master/wildfly, specify the file name here to determine which one to use-->
@@ -42,7 +42,7 @@
         <patchOutputFile>${project.build.directory}/patch.zip</patchOutputFile>
         <!--Path to original (pristine) WFLY-->
         <!--Running with -Pdownload-wfly will make Maven download the version specified below-->
-        <wildflyOriginal>${project.build.directory}/wildfly-original</wildflyOriginal>
+        <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-${wildfly.download.version}</wildflyOriginal>
         <wildfly.download.version>10.1.0.Final</wildfly.download.version>
         
         <!--Plugin versions-->
@@ -189,20 +189,20 @@
                                         </pathconvert>
                                         <!-- weld-core-impl is the right core
                                         artifact if weld-core-jsf is used by the application server -->
-                                        <condition property="weld.core.file" value="weld-core-impl.jar">
+                                        <condition property="weld.core.file" value="weld-core-impl-${weld.update.version}.jar">
                                             <and>
                                                 <isset property="weld.jsf.path" />
                                             </and>
                                         </condition>
-                                        <condition property="weld.jsf.file" value="weld-core-jsf.jar">
+                                        <condition property="weld.jsf.file" value="weld-core-jsf-${weld.update.version}.jar">
                                             <and>
                                                 <isset property="weld.jsf.path" />
                                             </and>
                                         </condition>
                                         <!-- otherwise, use the old artifact
                                         (weld-core) -->
-                                        <property name="weld.core.file" value="weld-core.jar" />
-                                        <property name="weld.probe.file" value="weld-probe-core.jar" />
+                                        <property name="weld.core.file" value="weld-core-${weld.update.version}.jar" />
+                                        <property name="weld.probe.file" value="weld-probe-core-${weld.update.version}.jar" />
 
                                         <delete>
                                             <fileset dir="${module.dir}/core/main" includes="*.jar" />
@@ -235,19 +235,19 @@
 
                                         <copy todir="${module.dir}/spi/main" overwrite="true">
                                             <fileset dir="target/dependency/lib">
-                                                <include name="weld-spi.jar" />
+                                                <include name="weld-spi-${weld.api.version}.jar" />
                                             </fileset>
                                         </copy>
 
-                                        <replaceregexp file="${module.dir}/spi/main/module.xml" match="path=&quot;.*?&quot;" replace="path=&quot;weld-spi.jar&quot;" byline="true" />
+                                        <replaceregexp file="${module.dir}/spi/main/module.xml" match="path=&quot;.*?&quot;" replace="path=&quot;weld-spi-${weld.api.version}.jar&quot;" byline="true" />
 
                                         <copy todir="${module.dir}/api/main" overwrite="true">
                                             <fileset dir="target/dependency/lib">
-                                                <include name="weld-api.jar" />
+                                                <include name="weld-api-${weld.api.version}.jar" />
                                             </fileset>
                                         </copy>
 
-                                        <replaceregexp file="${module.dir}/api/main/module.xml" match="path=&quot;.*?&quot;" replace="path=&quot;weld-api.jar&quot;" byline="true" />
+                                        <replaceregexp file="${module.dir}/api/main/module.xml" match="path=&quot;.*?&quot;" replace="path=&quot;weld-api-${weld.api.version}.jar&quot;" byline="true" />
 
                                         <!-- Update the weld-core-jsf artifact
                                         (this one is only used post WF 8.0.0.Alpha1) -->
@@ -257,7 +257,7 @@
                                             </fileset>
                                         </copy>
 
-                                        <replaceregexp file="${jsf.injection.dir}/module.xml" match="path=&quot;weld-core-jsf.*?&quot;" replace="path=&quot;weld-core-jsf.jar&quot;" byline="true" />
+                                        <replaceregexp file="${jsf.injection.dir}/module.xml" match="path=&quot;weld-core-jsf.*?&quot;" replace="path=&quot;weld-core-jsf-${weld.update.version}.jar&quot;" byline="true" />
                                     </target>
                                 </configuration>
                             </execution>
@@ -303,7 +303,7 @@
                                     <target>
                                         <copy todir="${env.JBOSS_HOME}/standalone/lib/ext" overwrite="true">
                                             <fileset dir="target/dependency/lib">
-                                                <include name="cdi-tck-ext-lib.jar" />
+                                                <include name="cdi-tck-ext-lib-${cdi.tck-1-2.version}.jar" />
                                             </fileset>
                                         </copy>
                                     </target>
@@ -390,7 +390,6 @@
                         <configuration>
                             <outputDirectory>${project.build.directory}/dependency/lib</outputDirectory>
                             <overWriteSnapshots>true</overWriteSnapshots>
-                            <stripVersion>true</stripVersion>
                             <includeArtifactIds>cdi-api,weld-api,weld-core,weld-core-impl,weld-core-jsf,weld-spi,cdi-tck-ext-lib,weld-probe-core</includeArtifactIds>
                         </configuration>
                     </execution>


### PR DESCRIPTION
With this change you can run command such as the following one to generate a patch for WFLY 10.1.0.Final (assuming you have prepared the patched WFLY previously ofc):

`mvn clean install -Pwfly-patch-gen -Dwildfly.download.version=10.1.0.Final -DpatchConfigFile=/home/manovotn/GitRepo/build/wildfly/patch-config-wildfly-10-weld-2.4.xml -DwildflyPatched=/home/manovotn/GitRepo/wildfly/dist/target/wildfly-10.1.0.Final -Denforcer.skip=true`

There are two options, you can either let Maven download the original, pristine WildFly (which is what the above command does) or you can define a path to already existing one using `-DwildflyOriginal=...`

NOTE: The plugin is in `Alpha` version, therefore our Enforcer plugin will start complaining, hence the need to silence it.

Comments/suggestions are welcome.