### PR TITLE
WELD-2408 Beans.xml with only comment will be treated as an empty bea…

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/xml/commentOnly/BeansXmlWithCommentOnlyTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/xml/commentOnly/BeansXmlWithCommentOnlyTest.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.xml.commentOnly;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RunWith(Arquillian.class)
+public class BeansXmlWithCommentOnlyTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(WebArchive.class, Utils.getDeploymentNameAsHash(BeansXmlWithCommentOnlyTest.class, Utils.ARCHIVE_TYPE.WAR))
+            .addPackage(BeansXmlWithCommentOnlyTest.class.getPackage())
+            .addAsWebInfResource(new StringAsset("<!--\n"
+                    + "\n"
+                    + "empty beans xml\n"
+                    + "\n"
+                    + "-->"), "beans.xml");
+    }
+
+    @Inject
+    SomeBean bean;
+    
+    @Test
+    public void testXmlIsParsedWithoutException() {
+        // this beans.xml should be treated as an empty one
+        bean.ping();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/xml/commentOnly/SomeBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/xml/commentOnly/SomeBean.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.xml.commentOnly;
+
+/**
+ * Should be picked up by CDI
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class SomeBean {
+
+    public void ping() {
+
+    }
+}


### PR DESCRIPTION
…ns.xml

_Technically speaking, XML containing only comments is invalid_ (according to w3c scheme which we use) but so is empty XML file and CDI spec requires empty file to work.
The question is then, what does empty mean? No chars at all, or no meaningful elements?

I just played around with what we could do to make this work, not sure we should do it at all. Opinions are welcome.