### PR TITLE
WELD-2405 Do not optimize self invocation for default methods

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
@@ -292,27 +292,31 @@ public class InterceptedSubclassFactory<T> extends ProxyFactory<T> {
         b.aload(0);
         getMethodHandlerField(method.getClassFile(), b);
 
-        // this is a self invocation optimisation
-        // test to see if this is a self invocation, and if so invokespecial the
-        // superclass method directly
         if (addProceed) {
             b.dup();
 
             // get the Stack
             b.invokestatic(InterceptionDecorationContext.class.getName(), "getStack", "()" + DescriptorUtils.makeDescriptor(Stack.class));
-            b.dupX1(); // Handler, Stack -> Stack, Handler, Stack
-            b.invokevirtual(COMBINED_INTERCEPTOR_AND_DECORATOR_STACK_METHOD_HANDLER_CLASS_NAME, "isDisabledHandler", "(" + DescriptorUtils.makeDescriptor(Stack.class) + ")" + BytecodeUtils.BOOLEAN_CLASS_DESCRIPTOR);
 
-            b.iconst(0);
-            BranchEnd invokeSuperDirectly = b.ifIcmpeq();
-            // now build the bytecode that invokes the super class method
-            b.pop2(); // pop Stack and Handler
-            b.aload(0);
-            // create the method invocation
-            b.loadMethodParameters();
-            b.invokespecial(methodInfo.getDeclaringClass(), methodInfo.getName(), methodInfo.getDescriptor());
-            b.returnInstruction();
-            b.branchEnd(invokeSuperDirectly);
+            // this is a self invocation optimisation
+            // test to see if this is a self invocation, and if so invokespecial the
+            // superclass method directly
+            // do not optimize in the case of default methods
+            if (!Reflections.isDefault(methodInfo.getMethod())) {
+                b.dupX1(); // Handler, Stack -> Stack, Handler, Stack
+                b.invokevirtual(COMBINED_INTERCEPTOR_AND_DECORATOR_STACK_METHOD_HANDLER_CLASS_NAME, "isDisabledHandler",
+                        "(" + DescriptorUtils.makeDescriptor(Stack.class) + ")" + BytecodeUtils.BOOLEAN_CLASS_DESCRIPTOR);
+                b.iconst(0);
+                BranchEnd invokeSuperDirectly = b.ifIcmpeq();
+                // now build the bytecode that invokes the super class method
+                b.pop2(); // pop Stack and Handler
+                b.aload(0);
+                // create the method invocation
+                b.loadMethodParameters();
+                b.invokespecial(methodInfo.getDeclaringClass(), methodInfo.getName(), methodInfo.getDescriptor());
+                b.returnInstruction();
+                b.branchEnd(invokeSuperDirectly);
+            }
         } else {
             b.aconstNull();
         }
@@ -422,6 +426,7 @@ public class InterceptedSubclassFactory<T> extends ProxyFactory<T> {
         return CombinedInterceptorAndDecoratorStackMethodHandler.class;
     }
 
+    @SuppressWarnings("unchecked")
     private void createDelegateMethod(ClassFile proxyClassType, Method method, MethodInformation methodInformation) {
         int modifiers = (method.getModifiers() | AccessFlag.SYNTHETIC | AccessFlag.PRIVATE) & ~AccessFlag.PUBLIC
                 & ~AccessFlag.PROTECTED;

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/DecoratedInteraceWithDefaultMethodTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/DecoratedInteraceWithDefaultMethodTest.java
@@ -23,15 +23,11 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.weld.test.util.Utils;
-import org.jboss.weld.tests.category.EmbeddedContainer;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-// this needs jboss-classfilewriter 1.2.0 and newer - see WELD-2093 and WELD-2407
-@Category(EmbeddedContainer.class)
 public class DecoratedInteraceWithDefaultMethodTest {
 
     @Deployment

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/defaultmethod/InterfaceDefaultMethodInterceptedTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/defaultmethod/InterfaceDefaultMethodInterceptedTest.java
@@ -25,9 +25,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.weld.test.util.Utils;
-import org.jboss.weld.tests.category.EmbeddedContainer;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -36,7 +34,6 @@ import org.junit.runner.RunWith;
  * @see WELD-2093
  */
 @RunWith(Arquillian.class)
-@Category(EmbeddedContainer.class)
 public class InterfaceDefaultMethodInterceptedTest {
 
     @Deployment


### PR DESCRIPTION
This PR is based on https://github.com/weld/core/pull/1703 from @hypnoce:
- redundant test removed
- we must obtain the current stack first otherwise
`DecoratedInteraceWithDefaultMethodTest` fails