### PR TITLE
WELD-2405 Do not optimize self invocation for default methods

### DIFF
--- a/tests-arquillian/src/test/java8/org/jboss/weld/tests/defaultmethod/decorated/DecoratedInteraceWithDefaultMethodTest.java
+++ b/tests-arquillian/src/test/java8/org/jboss/weld/tests/defaultmethod/decorated/DecoratedInteraceWithDefaultMethodTest.java
@@ -23,15 +23,11 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.weld.test.util.Utils;
-import org.jboss.weld.tests.category.EmbeddedContainer;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-// this needs jboss-classfilewriter 1.2.0 and newer - see WELD-2093 and WELD-2407
-@Category(EmbeddedContainer.class)
 public class DecoratedInteraceWithDefaultMethodTest {
 
     @Deployment

--- a/tests-arquillian/src/test/java8/org/jboss/weld/tests/defaultmethod/intercepted/InterfaceDefaultMethodInterceptedTest.java
+++ b/tests-arquillian/src/test/java8/org/jboss/weld/tests/defaultmethod/intercepted/InterfaceDefaultMethodInterceptedTest.java
@@ -25,9 +25,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.weld.test.util.Utils;
-import org.jboss.weld.tests.category.EmbeddedContainer;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 /**
@@ -36,7 +34,6 @@ import org.junit.runner.RunWith;
  * @see WELD-2093
  */
 @RunWith(Arquillian.class)
-@Category(EmbeddedContainer.class)
 public class InterfaceDefaultMethodInterceptedTest {
 
     @Deployment


### PR DESCRIPTION
- based on #1703 from @hypnoce
- redundant test removed
- we must obtain the current stack first otherwise
DecoratedInteraceWithDefaultMethodTest fails