### PR TITLE
WFLY update should now target WildFly 11.

### DIFF
--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -39,13 +39,13 @@
         <!--Path to patch file; only change if you have your own, else Maven downloads it-->
         <patchConfigFile>${project.build.directory}/patch.xml</patchConfigFile>
         <!--These patches are automatically downloaded from github.com/weld/build/tree/master/wildfly; specify the file name here to determine which one to use-->
-        <patch.file.name>patch-config-wildfly-10-weld-3.0.xml</patch.file.name>
+        <patch.file.name>patch-config-wildfly-11-weld-3.0.xml</patch.file.name>
         <!--Use this property to set the path to and the name of the resulting patch zip file-->
         <patchOutputFile>${project.build.directory}/patch.zip</patchOutputFile>
         <!--Path to original (pristine) WFLY-->
         <!--Running with -Pdownload-wfly will make Maven download the version specified below-->
         <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-${wildfly.download.version}</wildflyOriginal>
-        <wildfly.download.version>10.1.0.Final</wildfly.download.version>
+        <wildfly.download.version>11.0.0.Final</wildfly.download.version>
         
         <!--Plugin versions-->
         <download.maven.plugin>1.3.0</download.maven.plugin>


### PR DESCRIPTION
The execution of CI jobs on this PR also verifies that the CI job executes against patched version of WFLY 11.