### PR TITLE
WELD-2452 multiversion support for WildFly

### DIFF
--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/AbstractEnhancedAnnotated.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/AbstractEnhancedAnnotated.java
@@ -30,13 +30,13 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Annotated;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.inject.Qualifier;
 
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotated;
 import org.jboss.weld.annotated.slim.SlimAnnotatedType;
+import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.logging.ReflectionLogger;
 import org.jboss.weld.resources.ClassTransformer;
 import org.jboss.weld.resources.ReflectionCache;
@@ -63,7 +63,7 @@ import org.jboss.weld.util.reflection.Reflections;
 public abstract class AbstractEnhancedAnnotated<T, S> implements EnhancedAnnotated<T, S> {
 
     // The set of default binding types
-    private static final Set<Annotation> DEFAULT_QUALIFIERS = Collections.<Annotation>singleton(Default.Literal.INSTANCE);
+    private static final Set<Annotation> DEFAULT_QUALIFIERS = Collections.<Annotation>singleton(DefaultLiteral.INSTANCE);
 
     /**
      * Builds the annotation map (annotation type -> annotation)

--- a/impl/src/main/java/org/jboss/weld/bean/AbstractBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/AbstractBean.java
@@ -35,6 +35,7 @@ import org.jboss.weld.annotated.enhanced.EnhancedAnnotated;
 import org.jboss.weld.bean.attributes.ImmutableBeanAttributes;
 import org.jboss.weld.bootstrap.BeanDeployerEnvironment;
 import org.jboss.weld.bootstrap.SpecializationAndEnablementRegistry;
+import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.logging.BeanLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.resolution.TypeEqualitySpecializationUtils;
@@ -162,7 +163,7 @@ public abstract class AbstractBean<T, S> extends RIBean<T> {
         Set<Annotation> qualifiers = new HashSet<Annotation>();
         for (Annotation qualifier : attributes().getQualifiers()) {
             // Don't include implicit javax.enterprise.inject.Default qualifier
-            if (!qualifier.equals(Default.Literal.INSTANCE) || getAnnotated().isAnnotationPresent(Default.class)) {
+            if (!qualifier.equals(DefaultLiteral.INSTANCE) || getAnnotated().isAnnotationPresent(Default.class)) {
                 qualifiers.add(qualifier);
             }
         }

--- a/impl/src/main/java/org/jboss/weld/bean/DisposalMethod.java
+++ b/impl/src/main/java/org/jboss/weld/bean/DisposalMethod.java
@@ -23,7 +23,6 @@ import java.util.Set;
 
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.event.Observes;
-import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.enterprise.inject.Specializes;
@@ -45,6 +44,7 @@ import org.jboss.weld.injection.MethodInjectionPoint;
 import org.jboss.weld.injection.MethodInjectionPoint.MethodInjectionPointType;
 import org.jboss.weld.injection.MethodInvocationStrategy;
 import org.jboss.weld.injection.ParameterInjectionPoint;
+import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.logging.BeanLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.metadata.cache.MetaAnnotationStore;
@@ -169,7 +169,7 @@ public class DisposalMethod<X, T> {
     private Set<QualifierInstance> getRequiredQualifiers(EnhancedAnnotatedParameter<?, ? super X> enhancedDisposedParameter) {
         Set<Annotation> disposedParameterQualifiers = enhancedDisposedParameter.getMetaAnnotations(Qualifier.class);
         if (disposedParameterQualifiers.isEmpty()) {
-            disposedParameterQualifiers = Collections.<Annotation> singleton(Default.Literal.INSTANCE);
+            disposedParameterQualifiers = Collections.<Annotation> singleton(DefaultLiteral.INSTANCE);
         }
         return beanManager.getServices().get(MetaAnnotationStore.class).getQualifierInstances(disposedParameterQualifiers);
     }

--- a/impl/src/main/java/org/jboss/weld/bean/attributes/BeanAttributesFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/attributes/BeanAttributesFactory.java
@@ -24,9 +24,6 @@ import java.util.Set;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.context.NormalScope;
-import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Default;
-import javax.enterprise.inject.New;
 import javax.enterprise.inject.spi.BeanAttributes;
 import javax.inject.Named;
 import javax.inject.Qualifier;
@@ -37,7 +34,10 @@ import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedField;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedMember;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedMethod;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedType;
+import org.jboss.weld.literal.AnyLiteral;
+import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.literal.NamedLiteral;
+import org.jboss.weld.literal.NewLiteral;
 import org.jboss.weld.logging.BeanLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.metadata.cache.MergedStereotypes;
@@ -53,7 +53,7 @@ import org.jboss.weld.util.reflection.Formats;
  */
 public class BeanAttributesFactory {
 
-    private static final Set<Annotation> DEFAULT_QUALIFIERS = ImmutableSet.of(Any.Literal.INSTANCE, Default.Literal.INSTANCE);
+    private static final Set<Annotation> DEFAULT_QUALIFIERS = ImmutableSet.of(AnyLiteral.INSTANCE, DefaultLiteral.INSTANCE);
 
     private BeanAttributesFactory() {
     }
@@ -66,7 +66,7 @@ public class BeanAttributesFactory {
     }
 
     public static <T> BeanAttributes<T> forNewBean(Set<Type> types, final Class<?> javaClass) {
-        Set<Annotation> qualifiers = Collections.<Annotation>singleton(New.Literal.of(javaClass));
+        Set<Annotation> qualifiers = Collections.<Annotation>singleton(new NewLiteral(javaClass));
         return new ImmutableBeanAttributes<T>(Collections.<Class<? extends Annotation>> emptySet(), false, null, qualifiers, types, Dependent.class);
     }
 
@@ -153,21 +153,21 @@ public class BeanAttributesFactory {
                 Set<Annotation> normalizedQualifiers = new HashSet<Annotation>(qualifiers.size() + 2);
                 if (qualifiers.size() == 1) {
                     Annotation qualifier = qualifiers.iterator().next();
-                    if (qualifier.annotationType().equals(Named.class) || qualifier.equals(Any.Literal.INSTANCE)) {
+                    if (qualifier.annotationType().equals(Named.class) || qualifier.equals(AnyLiteral.INSTANCE)) {
                         // Single qualifier - @Named or @Any
-                        normalizedQualifiers.add(Default.Literal.INSTANCE);
+                        normalizedQualifiers.add(DefaultLiteral.INSTANCE);
                     }
-                } else if (qualifiers.size() == 2 && qualifiers.contains(Any.Literal.INSTANCE)) {
+                } else if (qualifiers.size() == 2 && qualifiers.contains(AnyLiteral.INSTANCE)) {
                     for (Annotation qualifier : qualifiers) {
                         if (qualifier.annotationType().equals(Named.class)) {
                             // Two qualifiers - @Named and @Any
-                            normalizedQualifiers.add(Default.Literal.INSTANCE);
+                            normalizedQualifiers.add(DefaultLiteral.INSTANCE);
                             break;
                         }
                     }
                 }
                 normalizedQualifiers.addAll(qualifiers);
-                normalizedQualifiers.add(Any.Literal.INSTANCE);
+                normalizedQualifiers.add(AnyLiteral.INSTANCE);
                 if (name != null && normalizedQualifiers.remove(NamedLiteral.DEFAULT)) {
                     normalizedQualifiers.add(new NamedLiteral(name));
                 }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/ContextHolder.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/ContextHolder.java
@@ -1,9 +1,8 @@
 package org.jboss.weld.bootstrap;
 
+import javax.enterprise.context.spi.Context;
 import java.lang.annotation.Annotation;
 import java.util.Set;
-
-import javax.enterprise.context.spi.Context;
 
 public class ContextHolder<T extends Context> {
 

--- a/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
@@ -42,7 +42,6 @@ import javax.enterprise.context.NormalScope;
 import javax.enterprise.event.Event;
 import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Decorated;
-import javax.enterprise.inject.Default;
 import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Intercepted;
@@ -96,6 +95,7 @@ import org.jboss.weld.interceptor.reader.PlainInterceptorFactory;
 import org.jboss.weld.interceptor.spi.metadata.InterceptorClassMetadata;
 import org.jboss.weld.interceptor.spi.model.InterceptionModel;
 import org.jboss.weld.literal.DecoratedLiteral;
+import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.literal.InterceptedLiteral;
 import org.jboss.weld.logging.BeanLogger;
 import org.jboss.weld.logging.MessageCallback;
@@ -358,7 +358,7 @@ public class Validator implements Service {
     }
 
     public void validateEventMetadataInjectionPoint(InjectionPoint ip) {
-        if (EventMetadata.class.equals(ip.getType()) && ip.getQualifiers().contains(Default.Literal.INSTANCE)) {
+        if (EventMetadata.class.equals(ip.getType()) && ip.getQualifiers().contains(DefaultLiteral.INSTANCE)) {
             throw ValidatorLogger.LOG.eventMetadataInjectedOutsideOfObserver(ip, Formats.formatAsStackTraceElement(ip));
         }
     }
@@ -879,7 +879,7 @@ public class Validator implements Service {
                 throw ValidatorLogger.LOG.invalidBeanMetadataInjectionPointTypeArgument(typeArgument, ip, Formats.formatAsStackTraceElement(ip));
             }
         }
-        if (qualifiers.contains(Default.Literal.INSTANCE)) {
+        if (qualifiers.contains(DefaultLiteral.INSTANCE)) {
             /*
              * If the injection point is a field, an initializer method parameter or a bean constructor, with qualifier
              * @Default, then the type parameter of the injected Bean, Interceptor or Decorator must be the same as the type

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldRuntime.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldRuntime.java
@@ -20,9 +20,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.concurrent.ConcurrentMap;
 
-import javax.enterprise.context.BeforeDestroyed;
-import javax.enterprise.context.Destroyed;
-
 import org.jboss.weld.Container;
 import org.jboss.weld.ContainerState;
 import org.jboss.weld.bootstrap.events.BeforeShutdownImpl;
@@ -30,6 +27,8 @@ import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
 import org.jboss.weld.context.ApplicationContext;
 import org.jboss.weld.context.SingletonContext;
 import org.jboss.weld.event.ContextEvent;
+import org.jboss.weld.literal.BeforeDestroyedLiteral;
+import org.jboss.weld.literal.DestroyedLiteral;
 import org.jboss.weld.manager.BeanManagerImpl;
 
 /**
@@ -57,13 +56,13 @@ public class WeldRuntime {
         try {
             // The container must destroy all contexts.
             // For non-web modules, fire @BeforeDestroyed event
-            fireEventForNonWebModules(Object.class, ContextEvent.APPLICATION_BEFORE_DESTROYED, BeforeDestroyed.Literal.APPLICATION);
+            fireEventForNonWebModules(Object.class, ContextEvent.APPLICATION_BEFORE_DESTROYED, BeforeDestroyedLiteral.APPLICATION);
             deploymentManager.instance().select(ApplicationContext.class).get().invalidate();
             deploymentManager.instance().select(SingletonContext.class).get().invalidate();
 
         } finally {
             // fire @Destroyed(ApplicationScope.class) for non-web modules
-            fireEventForNonWebModules(Object.class, ContextEvent.APPLICATION_DESTROYED, Destroyed.Literal.APPLICATION);
+            fireEventForNonWebModules(Object.class, ContextEvent.APPLICATION_DESTROYED, DestroyedLiteral.APPLICATION);
             try {
                 // Finally, the container must fire an event of type BeforeShutdown.
                 BeforeShutdownImpl.fire(deploymentManager);

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
@@ -1,4 +1,4 @@
-/*
+    /*
  * JBoss, Home of Professional Open Source
  * Copyright 2013, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
@@ -28,7 +28,6 @@ import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.ConversationScoped;
 import javax.enterprise.context.Dependent;
-import javax.enterprise.context.Initialized;
 import javax.enterprise.context.NormalScope;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.context.SessionScoped;
@@ -98,6 +97,7 @@ import org.jboss.weld.executor.ExecutorServicesFactory;
 import org.jboss.weld.injection.CurrentInjectionPoint;
 import org.jboss.weld.injection.ResourceInjectionFactory;
 import org.jboss.weld.injection.producer.InjectionTargetService;
+import org.jboss.weld.literal.InitializedLiteral;
 import org.jboss.weld.logging.BootstrapLogger;
 import org.jboss.weld.logging.VersionLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
@@ -547,7 +547,7 @@ public class WeldStartup {
             // web modules are handled by HttpContextLifecycle
             for (BeanDeploymentModule module : modules) {
                 if (!module.isWebModule()) {
-                    module.fireEvent(Object.class, ContextEvent.APPLICATION_INITIALIZED, Initialized.Literal.APPLICATION);
+                    module.fireEvent(Object.class, ContextEvent.APPLICATION_INITIALIZED, InitializedLiteral.APPLICATION);
                 }
             }
         }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/ContainerLifecycleEvents.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/ContainerLifecycleEvents.java
@@ -200,7 +200,12 @@ public class ContainerLifecycleEvents extends AbstractBootstrapService {
             // FastProcessAnnotatedTypeResolver does not consider special scope inheritance rules (see CDI - section 4.1)
             if (checkScopeInheritanceRules(event.getOriginalAnnotatedType(), observer, beanManager)) {
                 try {
-                    observer.notify(event);
+                    //TODO: CDI 1.1 HACK remove once no longer required
+                    if(observer instanceof ObserverMethodImpl) {
+                        ((ObserverMethodImpl)observer).notify(event);
+                    } else {
+                        observer.notify(event);
+                    }
                 } catch (Throwable e) {
                     errors.add(e);
                 }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/ContainerLifecycleEvents.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/ContainerLifecycleEvents.java
@@ -200,12 +200,7 @@ public class ContainerLifecycleEvents extends AbstractBootstrapService {
             // FastProcessAnnotatedTypeResolver does not consider special scope inheritance rules (see CDI - section 4.1)
             if (checkScopeInheritanceRules(event.getOriginalAnnotatedType(), observer, beanManager)) {
                 try {
-                    //TODO: CDI 1.1 HACK remove once no longer required
-                    if(observer instanceof ObserverMethodImpl) {
-                        ((ObserverMethodImpl)observer).notify(event);
-                    } else {
-                        observer.notify(event);
-                    }
+                    observer.notify(event);
                 } catch (Throwable e) {
                     errors.add(e);
                 }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
@@ -38,6 +38,7 @@ import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.EventContext;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.inject.spi.Prioritized;
 import javax.enterprise.inject.spi.configurator.ObserverMethodConfigurator;
 
 import org.jboss.weld.event.SyntheticObserverMethod;
@@ -141,7 +142,10 @@ public class ObserverMethodConfiguratorImpl<T> implements ObserverMethodConfigur
         reception(observerMethod.getReception());
         transactionPhase(observerMethod.getTransactionPhase());
         priority(observerMethod.getPriority());
-        async(observerMethod.isAsync());
+        //TODO: CDI 1.1 HACK remove once no longer required
+        if(Prioritized.class.isAssignableFrom(ObserverMethod.class)) {
+            async(observerMethod.isAsync());
+        }
         return this;
     }
 

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
@@ -38,7 +38,6 @@ import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.EventContext;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ObserverMethod;
-import javax.enterprise.inject.spi.Prioritized;
 import javax.enterprise.inject.spi.configurator.ObserverMethodConfigurator;
 
 import org.jboss.weld.event.SyntheticObserverMethod;
@@ -142,10 +141,7 @@ public class ObserverMethodConfiguratorImpl<T> implements ObserverMethodConfigur
         reception(observerMethod.getReception());
         transactionPhase(observerMethod.getTransactionPhase());
         priority(observerMethod.getPriority());
-        //TODO: CDI 1.1 HACK remove once no longer required
-        if(Prioritized.class.isAssignableFrom(ObserverMethod.class)) {
-            async(observerMethod.isAsync());
-        }
+        async(observerMethod.isAsync());
         return this;
     }
 

--- a/impl/src/main/java/org/jboss/weld/contexts/AbstractConversationContext.java
+++ b/impl/src/main/java/org/jboss/weld/contexts/AbstractConversationContext.java
@@ -38,9 +38,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.enterprise.context.BeforeDestroyed;
 import javax.enterprise.context.ConversationScoped;
-import javax.enterprise.context.Destroyed;
 
 import org.jboss.weld.Container;
 import org.jboss.weld.bootstrap.api.ServiceRegistry;
@@ -55,6 +53,8 @@ import org.jboss.weld.contexts.beanstore.NamingScheme;
 import org.jboss.weld.contexts.conversation.ConversationIdGenerator;
 import org.jboss.weld.contexts.conversation.ConversationImpl;
 import org.jboss.weld.event.FastEvent;
+import org.jboss.weld.literal.BeforeDestroyedLiteral;
+import org.jboss.weld.literal.DestroyedLiteral;
 import org.jboss.weld.logging.ConversationLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.serialization.BeanIdentifierIndex;
@@ -89,13 +89,13 @@ public abstract class AbstractConversationContext<R, S> extends AbstractBoundCon
     private final LazyValueHolder<FastEvent<String>> conversationBeforeDestroyedEvent = new LazyValueHolder<FastEvent<String>>() {
         @Override
         protected FastEvent<String> computeValue() {
-            return FastEvent.of(String.class, manager, manager.getGlobalLenientObserverNotifier(), BeforeDestroyed.Literal.CONVERSATION);
+            return FastEvent.of(String.class, manager, manager.getGlobalLenientObserverNotifier(), BeforeDestroyedLiteral.CONVERSATION);
         }
     };
     private final LazyValueHolder<FastEvent<String>> conversationDestroyedEvent = new LazyValueHolder<FastEvent<String>>() {
         @Override
         protected FastEvent<String> computeValue() {
-            return FastEvent.of(String.class, manager, manager.getGlobalLenientObserverNotifier(), Destroyed.Literal.CONVERSATION);
+            return FastEvent.of(String.class, manager, manager.getGlobalLenientObserverNotifier(), DestroyedLiteral.CONVERSATION);
         }
     };
 

--- a/impl/src/main/java/org/jboss/weld/event/EventMetadataImpl.java
+++ b/impl/src/main/java/org/jboss/weld/event/EventMetadataImpl.java
@@ -20,10 +20,10 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Set;
 
-import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.EventMetadata;
 import javax.enterprise.inject.spi.InjectionPoint;
 
+import org.jboss.weld.literal.AnyLiteral;
 import org.jboss.weld.util.collections.ImmutableSet;
 
 /**
@@ -57,7 +57,7 @@ public final class EventMetadataImpl implements EventMetadata {
     @Override
     public Set<Annotation> getQualifiers() {
         ImmutableSet.Builder<Annotation> builder = ImmutableSet.<Annotation> builder();
-        builder.add(Any.Literal.INSTANCE);
+        builder.add(AnyLiteral.INSTANCE);
         if (qualifiers != null) {
             return builder.addAll(qualifiers).build();
         } else if (qualifierArray != null) {

--- a/impl/src/main/java/org/jboss/weld/event/FastEvent.java
+++ b/impl/src/main/java/org/jboss/weld/event/FastEvent.java
@@ -91,7 +91,12 @@ public class FastEvent<T> {
 
     public void fire(T event) {
         for (ObserverMethod<? super T> observer : resolvedObserverMethods.getImmediateSyncObservers()) {
-            observer.notify(event);
+            //TODO: CDI 1.1 HACK remove once no longer required
+            if(observer instanceof ObserverMethodImpl) {
+                ((ObserverMethodImpl)observer).notify(event);
+            } else {
+                observer.notify(event);
+            }
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/event/FastEvent.java
+++ b/impl/src/main/java/org/jboss/weld/event/FastEvent.java
@@ -91,12 +91,7 @@ public class FastEvent<T> {
 
     public void fire(T event) {
         for (ObserverMethod<? super T> observer : resolvedObserverMethods.getImmediateSyncObservers()) {
-            //TODO: CDI 1.1 HACK remove once no longer required
-            if(observer instanceof ObserverMethodImpl) {
-                ((ObserverMethodImpl)observer).notify(event);
-            } else {
-                observer.notify(event);
-            }
+            observer.notify(event);
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/event/ResolvedObservers.java
+++ b/impl/src/main/java/org/jboss/weld/event/ResolvedObservers.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.enterprise.event.TransactionPhase;
 import javax.enterprise.inject.spi.EventMetadata;
 import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.inject.spi.Prioritized;
 
 import org.jboss.weld.util.Observers;
 import org.jboss.weld.util.collections.ImmutableList;
@@ -54,7 +55,8 @@ public class ResolvedObservers<T> {
         List<ObserverMethod<? super T>> transactionObservers = new ArrayList<ObserverMethod<? super T>>();
         List<ObserverMethod<? super T>> asyncObservers = new ArrayList<ObserverMethod<? super T>>();
         for (ObserverMethod<? super T> observer : observers) {
-            if(observer.isAsync()) {
+            //TODO: CDI 1.1 HACK remove once no longer required
+            if(Prioritized.class.isAssignableFrom(ObserverMethod.class) && observer.isAsync()) {
                 asyncObservers.add(observer);
             } else if (TransactionPhase.IN_PROGRESS == observer.getTransactionPhase()) {
                 immediateSyncObservers.add(observer);

--- a/impl/src/main/java/org/jboss/weld/event/ResolvedObservers.java
+++ b/impl/src/main/java/org/jboss/weld/event/ResolvedObservers.java
@@ -55,7 +55,8 @@ public class ResolvedObservers<T> {
         List<ObserverMethod<? super T>> transactionObservers = new ArrayList<ObserverMethod<? super T>>();
         List<ObserverMethod<? super T>> asyncObservers = new ArrayList<ObserverMethod<? super T>>();
         for (ObserverMethod<? super T> observer : observers) {
-            //TODO: CDI 1.1 HACK remove once no longer required
+            //WELD-2452, remove once WFLY is fully EE 8 compatible
+            // temporary hack to determine what version of CDI library are we running against
             if(Prioritized.class.isAssignableFrom(ObserverMethod.class) && observer.isAsync()) {
                 asyncObservers.add(observer);
             } else if (TransactionPhase.IN_PROGRESS == observer.getTransactionPhase()) {

--- a/impl/src/main/java/org/jboss/weld/literal/AnyLiteral.java
+++ b/impl/src/main/java/org/jboss/weld/literal/AnyLiteral.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.literal;
+
+import javax.enterprise.inject.Any;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * Annotation literal for {@link Any}
+ *
+ * @author Pete Muir
+ */
+@SuppressWarnings("all")
+public class AnyLiteral extends AnnotationLiteral<Any> implements Any {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final Any INSTANCE = new AnyLiteral();
+
+    private AnyLiteral() {
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/literal/BeforeDestroyedLiteral.java
+++ b/impl/src/main/java/org/jboss/weld/literal/BeforeDestroyedLiteral.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.literal;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class BeforeDestroyedLiteral extends AnnotationLiteral<BeforeDestroyed> implements BeforeDestroyed {
+
+    public static final BeforeDestroyedLiteral REQUEST = of(RequestScoped.class);
+
+    public static final BeforeDestroyedLiteral CONVERSATION = of(ConversationScoped.class);
+
+    public static final BeforeDestroyedLiteral SESSION = of(SessionScoped.class);
+
+    public static final BeforeDestroyedLiteral APPLICATION = of(ApplicationScoped.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final Class<? extends Annotation> value;
+
+    public static BeforeDestroyedLiteral of(Class<? extends Annotation> value) {
+        return new BeforeDestroyedLiteral(value);
+    }
+
+    private BeforeDestroyedLiteral(Class<? extends Annotation> value) {
+        this.value = value;
+    }
+
+    public Class<? extends Annotation> value() {
+        return value;
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/literal/DefaultLiteral.java
+++ b/impl/src/main/java/org/jboss/weld/literal/DefaultLiteral.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.literal;
+
+import javax.enterprise.inject.Default;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * Annotation literal for {@link Default}
+ *
+ * @author Pete Muir
+ */
+@SuppressWarnings("all")
+public class DefaultLiteral extends AnnotationLiteral<Default> implements Default {
+
+    private static final long serialVersionUID = 5464062523108931731L;
+
+    public static final Default INSTANCE = new DefaultLiteral();
+
+    private DefaultLiteral() {
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/literal/DestroyedLiteral.java
+++ b/impl/src/main/java/org/jboss/weld/literal/DestroyedLiteral.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.literal;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.context.Destroyed;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class DestroyedLiteral extends AnnotationLiteral<Destroyed> implements Destroyed {
+
+    public static final DestroyedLiteral REQUEST = of(RequestScoped.class);
+
+    public static final DestroyedLiteral CONVERSATION = of(ConversationScoped.class);
+
+    public static final DestroyedLiteral SESSION = of(SessionScoped.class);
+
+    public static final DestroyedLiteral APPLICATION = of(ApplicationScoped.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final Class<? extends Annotation> value;
+
+    public static DestroyedLiteral of(Class<? extends Annotation> value) {
+        return new DestroyedLiteral(value);
+    }
+
+    private DestroyedLiteral(Class<? extends Annotation> value) {
+        this.value = value;
+    }
+
+    public Class<? extends Annotation> value() {
+        return value;
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/literal/InitializedLiteral.java
+++ b/impl/src/main/java/org/jboss/weld/literal/InitializedLiteral.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2017, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.literal;
+
+import java.lang.annotation.Annotation;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.ConversationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@SuppressWarnings("all")
+public class InitializedLiteral extends AnnotationLiteral<Initialized> implements Initialized {
+
+    public static final InitializedLiteral REQUEST = of(RequestScoped.class);
+
+    public static final InitializedLiteral CONVERSATION = of(ConversationScoped.class);
+
+    public static final InitializedLiteral SESSION = of(SessionScoped.class);
+
+    public static final InitializedLiteral APPLICATION = of(ApplicationScoped.class);
+
+    private static final long serialVersionUID = 1L;
+
+    private final Class<? extends Annotation> value;
+
+    public static InitializedLiteral of(Class<? extends Annotation> value) {
+        return new InitializedLiteral(value);
+    }
+
+    private InitializedLiteral(Class<? extends Annotation> value) {
+        this.value = value;
+    }
+
+    public Class<? extends Annotation> value() {
+        return value;
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/literal/NewLiteral.java
+++ b/impl/src/main/java/org/jboss/weld/literal/NewLiteral.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.literal;
+
+import javax.enterprise.inject.New;
+import javax.enterprise.util.AnnotationLiteral;
+
+/**
+ * Annotation literal for {@link New}
+ *
+ * @author Pete Muir
+ */
+@SuppressWarnings("all")
+public class NewLiteral extends AnnotationLiteral<New> implements New {
+
+    private static final long serialVersionUID = 5740797331347409678L;
+
+    public static final NewLiteral DEFAULT_INSTANCE = new NewLiteral(New.class);
+
+    private Class<?> value;
+
+    public NewLiteral(Class<?> value) {
+        this.value = value;
+    }
+
+    public Class<?> value() {
+        return value;
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -44,10 +44,7 @@ import java.util.function.Function;
 
 import javax.el.ELResolver;
 import javax.el.ExpressionFactory;
-import javax.enterprise.context.BeforeDestroyed;
 import javax.enterprise.context.Dependent;
-import javax.enterprise.context.Destroyed;
-import javax.enterprise.context.Initialized;
 import javax.enterprise.context.spi.Context;
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
@@ -133,6 +130,9 @@ import org.jboss.weld.injection.attributes.ParameterInjectionPointAttributes;
 import org.jboss.weld.injection.producer.WeldInjectionTargetBuilderImpl;
 import org.jboss.weld.interceptor.reader.InterceptorMetadataReader;
 import org.jboss.weld.interceptor.spi.model.InterceptionModel;
+import org.jboss.weld.literal.BeforeDestroyedLiteral;
+import org.jboss.weld.literal.DestroyedLiteral;
+import org.jboss.weld.literal.InitializedLiteral;
 import org.jboss.weld.logging.BeanManagerLogger;
 import org.jboss.weld.logging.BootstrapLogger;
 import org.jboss.weld.manager.api.WeldInjectionTargetBuilder;
@@ -362,9 +362,9 @@ public class BeanManagerImpl implements WeldManager, Serializable {
         this.registry = getServices().get(SpecializationAndEnablementRegistry.class);
         this.currentInjectionPoint = getServices().get(CurrentInjectionPoint.class);
         this.clientProxyOptimization = getServices().get(WeldConfiguration.class).getBooleanProperty(ConfigurationKey.INJECTABLE_REFERENCE_OPTIMIZATION);
-        this.requestInitializedEvent = LazyValueHolder.forSupplier(() -> FastEvent.of(Object.class, this, Initialized.Literal.REQUEST));
-        this.requestBeforeDestroyedEvent = LazyValueHolder.forSupplier(() -> FastEvent.of(Object.class, this, BeforeDestroyed.Literal.REQUEST));
-        this.requestDestroyedEvent = LazyValueHolder.forSupplier(() -> FastEvent.of(Object.class, this, Destroyed.Literal.REQUEST));
+        this.requestInitializedEvent = LazyValueHolder.forSupplier(() -> FastEvent.of(Object.class, this, InitializedLiteral.REQUEST));
+        this.requestBeforeDestroyedEvent = LazyValueHolder.forSupplier(() -> FastEvent.of(Object.class, this, BeforeDestroyedLiteral.REQUEST));
+        this.requestDestroyedEvent = LazyValueHolder.forSupplier(() -> FastEvent.of(Object.class, this, DestroyedLiteral.REQUEST));
         this.validationFailureCallbacks = new CopyOnWriteArrayList<>();
     }
 

--- a/impl/src/main/java/org/jboss/weld/resolution/ResolvableBuilder.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/ResolvableBuilder.java
@@ -43,6 +43,7 @@ import javax.inject.Provider;
 import org.jboss.weld.events.WeldEvent;
 import org.jboss.weld.inject.WeldInstance;
 import org.jboss.weld.literal.NamedLiteral;
+import org.jboss.weld.literal.NewLiteral;
 import org.jboss.weld.logging.BeanManagerLogger;
 import org.jboss.weld.logging.ResolutionLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
@@ -158,7 +159,7 @@ public class ResolvableBuilder {
             if (newQualifier.value().equals(New.class) && rawType == null) {
                 throw new IllegalStateException("Cannot transform @New when there is no known raw type");
             } else if (newQualifier.value().equals(New.class)) {
-                qualifier = New.Literal.of(rawType);
+                qualifier = new NewLiteral(rawType);
                 qualifierInstance = QualifierInstance.of(qualifier, store);
             }
         } else if (injectionPoint != null && annotationType.equals(Named.class)) {

--- a/impl/src/main/java/org/jboss/weld/resolution/TypeSafeObserverResolver.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/TypeSafeObserverResolver.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Set;
 
 import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.inject.spi.Prioritized;
 
 import org.jboss.weld.bootstrap.events.ProcessAnnotatedTypeEventResolvable;
 import org.jboss.weld.config.WeldConfiguration;
@@ -103,7 +104,10 @@ public class TypeSafeObserverResolver extends TypeSafeResolver<Resolvable, Obser
     @Override
     protected List<ObserverMethod<?>> sortResult(Set<ObserverMethod<?>> matched) {
         List<ObserverMethod<?>> observers = new ArrayList<>(matched);
-        Collections.sort(observers, ObserverMethodComparator.INSTANCE);
+        //TODO: CDI 1.1 HACK remove once no longer required
+        if(Prioritized.class.isAssignableFrom(ObserverMethod.class)) {
+            Collections.sort(observers, ObserverMethodComparator.INSTANCE);
+        }
         return observers;
     }
 

--- a/impl/src/main/java/org/jboss/weld/resolution/TypeSafeObserverResolver.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/TypeSafeObserverResolver.java
@@ -104,7 +104,8 @@ public class TypeSafeObserverResolver extends TypeSafeResolver<Resolvable, Obser
     @Override
     protected List<ObserverMethod<?>> sortResult(Set<ObserverMethod<?>> matched) {
         List<ObserverMethod<?>> observers = new ArrayList<>(matched);
-        //TODO: CDI 1.1 HACK remove once no longer required
+        //WELD-2452, remove once WFLY is fully EE 8 compatible
+        // temporary hack to determine what version of CDI library are we running against
         if(Prioritized.class.isAssignableFrom(ObserverMethod.class)) {
             Collections.sort(observers, ObserverMethodComparator.INSTANCE);
         }

--- a/impl/src/main/java/org/jboss/weld/util/Bindings.java
+++ b/impl/src/main/java/org/jboss/weld/util/Bindings.java
@@ -19,10 +19,10 @@ package org.jboss.weld.util;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
-import javax.enterprise.inject.Any;
-import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.BeanManager;
 
+import org.jboss.weld.literal.AnyLiteral;
+import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.logging.BeanManagerLogger;
 import org.jboss.weld.logging.MetadataLogger;
 import org.jboss.weld.metadata.cache.InterceptorBindingModel;
@@ -39,7 +39,7 @@ import org.jboss.weld.util.collections.ImmutableSet;
  */
 public class Bindings {
 
-    public static final Set<Annotation> DEFAULT_QUALIFIERS = ImmutableSet.of(Any.Literal.INSTANCE, Default.Literal.INSTANCE);
+    public static final Set<Annotation> DEFAULT_QUALIFIERS = ImmutableSet.of(AnyLiteral.INSTANCE, DefaultLiteral.INSTANCE);
 
     private Bindings() {
     }

--- a/impl/src/main/java/org/jboss/weld/util/InjectionPoints.java
+++ b/impl/src/main/java/org/jboss/weld/util/InjectionPoints.java
@@ -22,20 +22,20 @@ import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.AnnotatedField;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionPoint;
 
 import org.jboss.weld.bootstrap.MissingDependenciesRegistry;
-import org.jboss.weld.injection.FieldInjectionPoint;
 import org.jboss.weld.injection.MethodInjectionPoint;
+import org.jboss.weld.injection.FieldInjectionPoint;
 import org.jboss.weld.injection.ParameterInjectionPoint;
 import org.jboss.weld.injection.ParameterInjectionPointImpl;
 import org.jboss.weld.injection.attributes.ForwardingFieldInjectionPointAttributes;
 import org.jboss.weld.injection.attributes.ForwardingParameterInjectionPointAttributes;
 import org.jboss.weld.injection.attributes.SpecialParameterInjectionPoint;
 import org.jboss.weld.injection.attributes.WeldInjectionPointAttributes;
+import org.jboss.weld.literal.AnyLiteral;
 import org.jboss.weld.logging.ValidatorLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.util.collections.ImmutableSet;
@@ -109,7 +109,7 @@ public class InjectionPoints {
     }
 
     public static String getUnsatisfiedDependenciesAdditionalInfo(InjectionPoint ij, BeanManagerImpl beanManager) {
-        Set<Bean<?>> beansMatchedByType = beanManager.getBeans(ij.getType(), Any.Literal.INSTANCE);
+        Set<Bean<?>> beansMatchedByType = beanManager.getBeans(ij.getType(), AnyLiteral.INSTANCE);
         if (beansMatchedByType.isEmpty()) {
             Class<?> rawType = Reflections.getRawType(ij.getType());
             if (rawType != null) {

--- a/impl/src/main/java/org/jboss/weld/util/Observers.java
+++ b/impl/src/main/java/org/jboss/weld/util/Observers.java
@@ -163,7 +163,12 @@ public class Observers {
      * @param metadata May be null
      */
     public static <T> void notify(ObserverMethod<? super T> observerMethod, T event, EventMetadata metadata) {
-        observerMethod.notify(new EventContextImpl<>(event, metadata));
+        //TODO: CDI 1.1 HACK remove once no longer required 
+        if(observerMethod instanceof ObserverMethodImpl) {
+            ((ObserverMethodImpl)observerMethod).notify(event);
+        } else {
+            observerMethod.notify(new EventContextImpl<>(event, metadata));
+        }
     }
 
     private static boolean hasNotifyOverriden(Class<?> clazz, ObserverMethod<?> observerMethod) {

--- a/impl/src/main/java/org/jboss/weld/util/Observers.java
+++ b/impl/src/main/java/org/jboss/weld/util/Observers.java
@@ -32,6 +32,7 @@ import javax.enterprise.inject.spi.BeforeShutdown;
 import javax.enterprise.inject.spi.EventContext;
 import javax.enterprise.inject.spi.EventMetadata;
 import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.inject.spi.Prioritized;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.ProcessBean;
 import javax.enterprise.inject.spi.ProcessBeanAttributes;
@@ -163,11 +164,12 @@ public class Observers {
      * @param metadata May be null
      */
     public static <T> void notify(ObserverMethod<? super T> observerMethod, T event, EventMetadata metadata) {
-        //TODO: CDI 1.1 HACK remove once no longer required 
-        if(observerMethod instanceof ObserverMethodImpl) {
-            ((ObserverMethodImpl)observerMethod).notify(event);
-        } else {
+        //WELD-2452, remove once WFLY is fully EE 8 compatible
+        // temporary hack to determine what version of CDI library are we running against
+        if (Prioritized.class.isAssignableFrom(ObserverMethod.class)) {
             observerMethod.notify(new EventContextImpl<>(event, metadata));
+        } else {
+            observerMethod.notify(event);
         }
     }
 

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -245,6 +245,10 @@
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/tck12/tck-tests.xml</suiteXmlFile>
                             </suiteXmlFiles>
+                            <systemPropertyVariables>
+                                <!--Temporary for WFLY 12 and EE 8 mode, automatically disabled for TCK 1.2-->
+                                <ee8.preview.mode>false</ee8.preview.mode>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -271,6 +275,10 @@
                             <suiteXmlFiles>
                                 <suiteXmlFile>src/test/tck20/tck-tests.xml</suiteXmlFile>
                             </suiteXmlFiles>
+                            <systemPropertyVariables>
+                                <!--Temporary for WFLY 12 and EE 8 mode, automatically enabled for TCK 2.0-->
+                                <ee8.preview.mode>true</ee8.preview.mode>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/jboss-tck-runner/src/test/wildfly8/arquillian.xml
+++ b/jboss-tck-runner/src/test/wildfly8/arquillian.xml
@@ -11,7 +11,7 @@
     <container qualifier="wildfly-8" default="true">
         <configuration>
             <property name="serverConfig">standalone-full.xml</property>
-            <property name="javaVmArguments">-Xms128m -Xmx1g -XX:MaxPermSize=512m -ea -DcdiTckExcludeDummy=true ${additional.vm.args} ${jacoco.agent}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx1g -XX:MaxPermSize=512m -ea -DcdiTckExcludeDummy=true -Dee8.preview.mode=${ee8.preview.mode} ${additional.vm.args} ${jacoco.agent}</property>
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>

--- a/modules/ejb/src/main/java/org/jboss/weld/module/ejb/AbstractEJBRequestScopeActivationInterceptor.java
+++ b/modules/ejb/src/main/java/org/jboss/weld/module/ejb/AbstractEJBRequestScopeActivationInterceptor.java
@@ -18,15 +18,15 @@ package org.jboss.weld.module.ejb;
 
 import java.io.Serializable;
 
-import javax.enterprise.context.BeforeDestroyed;
-import javax.enterprise.context.Destroyed;
-import javax.enterprise.context.Initialized;
 import javax.enterprise.context.RequestScoped;
 import javax.interceptor.InvocationContext;
 
 import org.jboss.weld.context.ejb.EjbRequestContext;
 import org.jboss.weld.event.ContextEvent;
 import org.jboss.weld.event.FastEvent;
+import org.jboss.weld.literal.BeforeDestroyedLiteral;
+import org.jboss.weld.literal.DestroyedLiteral;
+import org.jboss.weld.literal.InitializedLiteral;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.util.LazyValueHolder;
 
@@ -48,21 +48,21 @@ public abstract class AbstractEJBRequestScopeActivationInterceptor implements Se
         private static final long serialVersionUID = 1L;
         @Override
         protected FastEvent<Object> computeValue() {
-            return FastEvent.of(Object.class, getBeanManager(), getBeanManager().getGlobalLenientObserverNotifier(), Initialized.Literal.REQUEST);
+            return FastEvent.of(Object.class, getBeanManager(), getBeanManager().getGlobalLenientObserverNotifier(), InitializedLiteral.REQUEST);
         }
     };
     private final LazyValueHolder<FastEvent<Object>> requestBeforeDestroyedEvent = new LazyValueHolder.Serializable<FastEvent<Object>>() {
         private static final long serialVersionUID = 1L;
         @Override
         protected FastEvent<Object> computeValue() {
-            return FastEvent.of(Object.class, getBeanManager(), getBeanManager().getGlobalLenientObserverNotifier(), BeforeDestroyed.Literal.REQUEST);
+            return FastEvent.of(Object.class, getBeanManager(), getBeanManager().getGlobalLenientObserverNotifier(), BeforeDestroyedLiteral.REQUEST);
         }
     };
     private final LazyValueHolder<FastEvent<Object>> requestDestroyedEvent = new LazyValueHolder.Serializable<FastEvent<Object>>() {
         private static final long serialVersionUID = 1L;
         @Override
         protected FastEvent<Object> computeValue() {
-            return FastEvent.of(Object.class, getBeanManager(), getBeanManager().getGlobalLenientObserverNotifier(), Destroyed.Literal.REQUEST);
+            return FastEvent.of(Object.class, getBeanManager(), getBeanManager().getGlobalLenientObserverNotifier(), DestroyedLiteral.REQUEST);
         }
     };
 

--- a/modules/ejb/src/main/java/org/jboss/weld/module/ejb/WeldEjbValidator.java
+++ b/modules/ejb/src/main/java/org/jboss/weld/module/ejb/WeldEjbValidator.java
@@ -18,12 +18,12 @@ package org.jboss.weld.module.ejb;
 
 import javax.ejb.TransactionManagement;
 import javax.ejb.TransactionManagementType;
-import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.transaction.UserTransaction;
 
 import org.jboss.weld.bean.SessionBean;
+import org.jboss.weld.literal.DefaultLiteral;
 import org.jboss.weld.logging.ValidatorLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.module.PlugableValidator;
@@ -35,7 +35,7 @@ class WeldEjbValidator implements PlugableValidator {
         // check that UserTransaction is not injected into a SessionBean with container-managed transactions
         if (bean instanceof SessionBean<?>) {
             SessionBean<?> sessionBean = (SessionBean<?>) bean;
-            if (UserTransaction.class.equals(ij.getType()) && (ij.getQualifiers().isEmpty() || ij.getQualifiers().contains(Default.Literal.INSTANCE))
+            if (UserTransaction.class.equals(ij.getType()) && (ij.getQualifiers().isEmpty() || ij.getQualifiers().contains(DefaultLiteral.INSTANCE))
                     && hasContainerManagedTransactions(sessionBean)) {
                 throw ValidatorLogger.LOG.userTransactionInjectionIntoBeanWithContainerManagedTransactions(ij, Formats.formatAsStackTraceElement(ij));
             }

--- a/modules/web/src/main/java/org/jboss/weld/module/web/servlet/ConversationContextActivator.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/servlet/ConversationContextActivator.java
@@ -25,9 +25,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.function.Consumer;
 
-import javax.enterprise.context.BeforeDestroyed;
-import javax.enterprise.context.Destroyed;
-import javax.enterprise.context.Initialized;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
@@ -37,6 +34,9 @@ import org.jboss.weld.context.api.ContextualInstance;
 import org.jboss.weld.context.http.HttpConversationContext;
 import org.jboss.weld.module.web.context.http.LazyHttpConversationContextImpl;
 import org.jboss.weld.event.FastEvent;
+import org.jboss.weld.literal.BeforeDestroyedLiteral;
+import org.jboss.weld.literal.DestroyedLiteral;
+import org.jboss.weld.literal.InitializedLiteral;
 import org.jboss.weld.logging.ContextLogger;
 import org.jboss.weld.logging.ConversationLogger;
 import org.jboss.weld.module.web.logging.ServletLogger;
@@ -73,9 +73,9 @@ public class ConversationContextActivator {
 
     protected ConversationContextActivator(BeanManagerImpl beanManager, boolean lazy) {
         this.beanManager = beanManager;
-        conversationInitializedEvent = FastEvent.of(HttpServletRequest.class, beanManager, Initialized.Literal.CONVERSATION);
-        conversationBeforeDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, BeforeDestroyed.Literal.CONVERSATION);
-        conversationDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, Destroyed.Literal.CONVERSATION);
+        conversationInitializedEvent = FastEvent.of(HttpServletRequest.class, beanManager, InitializedLiteral.CONVERSATION);
+        conversationBeforeDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, BeforeDestroyedLiteral.CONVERSATION);
+        conversationDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, DestroyedLiteral.CONVERSATION);
         lazyInitializationCallback = lazy ? conversationInitializedEvent::fire : null;
         this.lazy = lazy;
     }
@@ -195,8 +195,8 @@ public class ConversationContextActivator {
         if (contextsAttribute instanceof Map) {
             Map<String, List<ContextualInstance<?>>> contexts = cast(contextsAttribute);
             synchronized (contexts) {
-                FastEvent<String> beforeDestroyedEvent = FastEvent.of(String.class, beanManager, BeforeDestroyed.Literal.CONVERSATION);
-                FastEvent<String> destroyedEvent = FastEvent.of(String.class, beanManager, Destroyed.Literal.CONVERSATION);
+                FastEvent<String> beforeDestroyedEvent = FastEvent.of(String.class, beanManager, BeforeDestroyedLiteral.CONVERSATION);
+                FastEvent<String> destroyedEvent = FastEvent.of(String.class, beanManager, DestroyedLiteral.CONVERSATION);
                 for (Iterator<Entry<String, List<ContextualInstance<?>>>> iterator = contexts.entrySet().iterator(); iterator.hasNext();) {
                     Entry<String, List<ContextualInstance<?>>> entry = iterator.next();
                     beforeDestroyedEvent.fire(entry.getKey());

--- a/modules/web/src/main/java/org/jboss/weld/module/web/servlet/HttpContextLifecycle.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/servlet/HttpContextLifecycle.java
@@ -19,9 +19,6 @@ package org.jboss.weld.module.web.servlet;
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 
-import javax.enterprise.context.BeforeDestroyed;
-import javax.enterprise.context.Destroyed;
-import javax.enterprise.context.Initialized;
 import javax.enterprise.inject.spi.EventMetadata;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequestListener;
@@ -39,6 +36,9 @@ import org.jboss.weld.context.http.HttpSessionContext;
 import org.jboss.weld.contexts.cache.RequestScopedCache;
 import org.jboss.weld.event.EventMetadataImpl;
 import org.jboss.weld.event.FastEvent;
+import org.jboss.weld.literal.BeforeDestroyedLiteral;
+import org.jboss.weld.literal.DestroyedLiteral;
+import org.jboss.weld.literal.InitializedLiteral;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.module.web.context.http.HttpRequestContextImpl;
 import org.jboss.weld.module.web.context.http.HttpSessionDestructionContext;
@@ -107,12 +107,12 @@ public class HttpContextLifecycle implements Service {
         this.ignoreForwards = ignoreForwards;
         this.ignoreIncludes = ignoreIncludes;
         this.contextActivationFilter = contextActivationFilter;
-        this.requestInitializedEvent = FastEvent.of(HttpServletRequest.class, beanManager, Initialized.Literal.REQUEST);
-        this.requestBeforeDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, BeforeDestroyed.Literal.REQUEST);
-        this.requestDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, Destroyed.Literal.REQUEST);
-        this.sessionInitializedEvent = FastEvent.of(HttpSession.class, beanManager, Initialized.Literal.SESSION);
-        this.sessionBeforeDestroyedEvent = FastEvent.of(HttpSession.class, beanManager, BeforeDestroyed.Literal.SESSION);
-        this.sessionDestroyedEvent = FastEvent.of(HttpSession.class, beanManager, Destroyed.Literal.SESSION);
+        this.requestInitializedEvent = FastEvent.of(HttpServletRequest.class, beanManager, InitializedLiteral.REQUEST);
+        this.requestBeforeDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, BeforeDestroyedLiteral.REQUEST);
+        this.requestDestroyedEvent = FastEvent.of(HttpServletRequest.class, beanManager, DestroyedLiteral.REQUEST);
+        this.sessionInitializedEvent = FastEvent.of(HttpSession.class, beanManager, InitializedLiteral.SESSION);
+        this.sessionBeforeDestroyedEvent = FastEvent.of(HttpSession.class, beanManager, BeforeDestroyedLiteral.SESSION);
+        this.sessionDestroyedEvent = FastEvent.of(HttpSession.class, beanManager, DestroyedLiteral.SESSION);
         this.servletApi = beanManager.getServices().get(ServletApiAbstraction.class);
         this.servletContextService = beanManager.getServices().get(ServletContextService.class);
         this.nestedInvocationGuardEnabled = nestedInvocationGuardEnabled;
@@ -144,13 +144,13 @@ public class HttpContextLifecycle implements Service {
 
     public void contextInitialized(ServletContext ctx) {
         servletContextService.contextInitialized(ctx);
-        fireEventForApplicationScope(ctx, Initialized.Literal.APPLICATION);
+        fireEventForApplicationScope(ctx, InitializedLiteral.APPLICATION);
     }
 
     public void contextDestroyed(ServletContext ctx) {
         // TODO WELD-2282 Firing these two right after each other does not really make sense
-        fireEventForApplicationScope(ctx, BeforeDestroyed.Literal.APPLICATION);
-        fireEventForApplicationScope(ctx, Destroyed.Literal.APPLICATION);
+        fireEventForApplicationScope(ctx, BeforeDestroyedLiteral.APPLICATION);
+        fireEventForApplicationScope(ctx, DestroyedLiteral.APPLICATION);
     }
 
     private void fireEventForApplicationScope(ServletContext ctx, Annotation qualifier) {

--- a/probe/core/src/main/java/org/jboss/weld/probe/JsonObjects.java
+++ b/probe/core/src/main/java/org/jboss/weld/probe/JsonObjects.java
@@ -1026,6 +1026,7 @@ final class JsonObjects {
         return observerBuilder;
     }
 
+    @SuppressFBWarnings(value = "BC_VACUOUS_INSTANCEOF", justification = "WELD-2452, with CDI 1.2 API, this doesn't need to be true.")
     static JsonObjectBuilder createBasicObserverJson(ObserverMethod<?> observerMethod, Probe probe) {
         JsonObjectBuilder observerBuilder = createSimpleObserverJson(observerMethod, probe);
         observerBuilder.add(RECEPTION, observerMethod.getReception().toString());
@@ -1044,10 +1045,13 @@ final class JsonObjects {
         if(isUnrestrictedProcessAnnotatedTypeObserver(observerMethod)) {
             observerBuilder.add(DESCRIPTION, WARNING_UNRESTRICTED_PAT_OBSERVER);
         }
-        // Every OM is now instance of Prioritized
-        final int priority = Prioritized.class.cast(observerMethod).getPriority();
-        observerBuilder.add(PRIORITY, priority);
-        observerBuilder.add(PRIORITY_RANGE, Components.PriorityRange.of(priority).toString());
+        // WELD-2452 to be removed once WFLY is EE 8 certified
+        if (observerMethod instanceof Prioritized) {
+            // Every OM is now instance of Prioritized
+            final int priority = Prioritized.class.cast(observerMethod).getPriority();
+            observerBuilder.add(PRIORITY, priority);
+            observerBuilder.add(PRIORITY_RANGE, Components.PriorityRange.of(priority).toString());
+        }
 
         return observerBuilder;
     }

--- a/probe/tests/src/ftest/resources/arquillian-ftest.xml
+++ b/probe/tests/src/ftest/resources/arquillian-ftest.xml
@@ -14,7 +14,7 @@
             <!-- ARQ-649 workaround -->
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m ${jacoco.agent} ${additional.vm.args}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m -Dee8.preview.mode=true ${jacoco.agent} ${additional.vm.args}</property>
         </configuration>
     </container>
 

--- a/probe/tests/src/test/resources/arquillian.xml
+++ b/probe/tests/src/test/resources/arquillian.xml
@@ -16,7 +16,7 @@
             <!-- ARQ-649 workaround -->
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m ${jacoco.agent} ${additional.vm.args}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m -Dee8.preview.mode=true ${jacoco.agent} ${additional.vm.args}</property>
         </configuration>
     </container>
 

--- a/tests-arquillian/src/test/resources/wildfly-arquillian.xml
+++ b/tests-arquillian/src/test/resources/wildfly-arquillian.xml
@@ -16,7 +16,7 @@
             <!-- ARQ-649 workaround -->
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m ${jacoco.agent} ${additional.vm.args}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m -Dee8.preview.mode=true ${jacoco.agent} ${additional.vm.args}</property>
             <property name="jbossArguments">${additional.jboss.args}</property>
             <property name="managementAddress">${node.address}</property>
         </configuration>


### PR DESCRIPTION
This is a temporary re-introduction of some literals and code construct we need to support two CDI versions in WildFly. Once WFLY fully transfers to CDI 2.0 this PR is to be **reverted**.