### PR TITLE
WELD-2462 Migrate from FindBugs to SpotBugs.

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -81,8 +81,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
             <optional>true</optional>
         </dependency>
 
@@ -105,15 +105,15 @@
     <build>
         <plugins>
             <plugin>
-               <groupId>org.apache.maven.plugins</groupId>
-               <artifactId>maven-compiler-plugin</artifactId>
-               <configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
                     <!-- This path is not used for default properties files yet -->
                     <!-- https://issues.jboss.org/browse/LOGTOOL-65 -->
                     <compilerArguments>
                         <AgeneratedTranslationFilesPath>${project.build.directory}/generated-translation-files</AgeneratedTranslationFilesPath>
                     </compilerArguments>
-               </configuration>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -143,7 +143,7 @@
                         </goals>
                     </execution>
                 </executions>
-             </plugin>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -191,8 +191,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                         <configuration>
                             <effort>Max</effort>
                             <xmlOutput>true</xmlOutput>
@@ -200,7 +200,7 @@
                             <failOnError>${findbugs.failOnError}</failOnError>
                             <excludeFilterFile>${project.basedir}/findbugsfilter.xml</excludeFilterFile>
                         </configuration>
-                        <executions>
+                         <executions>
                             <execution>
                                 <goals>
                                     <goal>check</goal>

--- a/impl/src/main/java/org/jboss/weld/config/WeldConfiguration.java
+++ b/impl/src/main/java/org/jboss/weld/config/WeldConfiguration.java
@@ -123,8 +123,8 @@ public class WeldConfiguration implements Service {
         this.proxyDumpFilePath = initProxyDumpFilePath();
         this.proxyIgnoreFinalMethodsPattern = initProxyIgnoreFinalMethodsPattern();
         StringJoiner logOutputBuilder = new StringJoiner(", ", "{", "}");
-        for (ConfigurationKey key : properties.keySet()) {
-            logOutputBuilder.add(key.get() + "=" + properties.get(key));
+        for (Entry<ConfigurationKey, Object> entry : properties.entrySet()) {
+            logOutputBuilder.add(entry.getKey().get() + "=" + entry.getValue());
         }
         ConfigurationLogger.LOG.configurationInitialized(logOutputBuilder.toString());
     }

--- a/impl/src/main/java/org/jboss/weld/util/reflection/Formats.java
+++ b/impl/src/main/java/org/jboss/weld/util/reflection/Formats.java
@@ -536,7 +536,7 @@ public class Formats {
     public static String getSimpleVersion() {
         Properties buildProperties = getBuildProperties();
         if(buildProperties != null) {
-            buildProperties.getProperty(BUILD_PROPERTIES_VERSION);
+            return buildProperties.getProperty(BUILD_PROPERTIES_VERSION);
         }
         return getManifestImplementationVersion();
     }

--- a/modules/ejb/pom.xml
+++ b/modules/ejb/pom.xml
@@ -52,6 +52,13 @@
             <groupId>org.jboss.spec.javax.ejb</groupId>
             <artifactId>jboss-ejb-api_3.2_spec</artifactId>
         </dependency>
+        
+        <!-- spotbugs dependency -->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>
@@ -59,8 +66,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                         <configuration>
                             <effort>Max</effort>
                             <xmlOutput>true</xmlOutput>

--- a/modules/jsf/pom.xml
+++ b/modules/jsf/pom.xml
@@ -62,6 +62,13 @@
             <classifier>jdk15</classifier>
             <scope>test</scope>
         </dependency>
+        
+        <!-- spotbugs dependency -->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     
     <profiles>
@@ -70,8 +77,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                         <configuration>
                             <effort>Max</effort>
                             <xmlOutput>true</xmlOutput>

--- a/modules/jta/pom.xml
+++ b/modules/jta/pom.xml
@@ -47,6 +47,13 @@
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-spi</artifactId>
         </dependency>
+        
+        <!-- spotbugs dependency -->
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     
     <profiles>
@@ -55,8 +62,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                         <configuration>
                             <effort>Max</effort>
                             <xmlOutput>true</xmlOutput>

--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -72,10 +72,10 @@
             <scope>test</scope>
         </dependency>
         
-        <!-- findbugs dependency -->
+        <!-- spotbugs dependency -->
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>
@@ -86,8 +86,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                         <configuration>
                             <effort>Max</effort>
                             <xmlOutput>true</xmlOutput>

--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
         <cdi.tck-2-0.version>2.0.3.Final</cdi.tck-2-0.version>
         <classfilewriter.version>1.1.2.Final</classfilewriter.version>
         <contiperf.version>1.06</contiperf.version>
-        <findbugs-maven-plugin.version>3.0.0</findbugs-maven-plugin.version>
-        <findbugs-annotations-version>3.0.1</findbugs-annotations-version>
+        <spotbugs-maven-plugin.version>3.1.1</spotbugs-maven-plugin.version>
+        <spotbugs-annotations-version>3.1.1</spotbugs-annotations-version>
         <glassfish.el.version>2.1.2-b04</glassfish.el.version>
         <htmlunit.version>2.20</htmlunit.version>
         <jacoco.version>0.7.9</jacoco.version>
@@ -126,8 +126,8 @@
             </dependency>
 
             <dependency>
-               <groupId>org.jboss.spec.javax.el</groupId>
-               <artifactId>jboss-el-api_3.0_spec</artifactId>
+                <groupId>org.jboss.spec.javax.el</groupId>
+                <artifactId>jboss-el-api_3.0_spec</artifactId>
                 <version>${jboss.spec.el-api.version}</version>
             </dependency>
 
@@ -144,22 +144,22 @@
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.logging</groupId>
-              <artifactId>jboss-logging-processor</artifactId>
-              <version>${jboss.logging.processor.version}</version>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging-processor</artifactId>
+                <version>${jboss.logging.processor.version}</version>
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.logging</groupId>
-              <artifactId>jboss-logging</artifactId>
-              <version>${jboss.logging.version}</version>
+                <groupId>org.jboss.logging</groupId>
+                <artifactId>jboss-logging</artifactId>
+                <version>${jboss.logging.version}</version>
             </dependency>
 
             <dependency>
-              <groupId>org.jboss.logmanager</groupId>
-              <artifactId>jboss-logmanager</artifactId>
-              <version>${jboss.logmanager.version}</version>
-              <scope>test</scope>
+                <groupId>org.jboss.logmanager</groupId>
+                <artifactId>jboss-logmanager</artifactId>
+                <version>${jboss.logmanager.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>
@@ -482,11 +482,12 @@
                 <version>${jsf.impl.version}</version>
             </dependency>
 
-            <!-- findbugs annotations -->
+            <!-- spotbugs annotations -->
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${findbugs-annotations-version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-annotations</artifactId>
+                <version>${spotbugs-annotations-version}</version>
+                <optional>true</optional>
             </dependency>
         </dependencies>
 
@@ -502,9 +503,9 @@
                     <version>${cargo.maven2.plugin.version}</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>findbugs-maven-plugin</artifactId>
-                    <version>${findbugs-maven-plugin.version}</version>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -518,7 +519,7 @@
                     <version>${selenium.maven.plugin.version}</version>
                 </plugin>
                 <!-- So m2e doesn't throw errors for features it doesn't
-                    support in the POM -->
+                support in the POM -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
                     <artifactId>lifecycle-mapping</artifactId>
@@ -566,8 +567,8 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-      <tag>3.0.0-SNAPSHOT</tag>
-  </scm>
+        <tag>3.0.0-SNAPSHOT</tag>
+    </scm>
 
 
     <profiles>

--- a/probe/core/pom.xml
+++ b/probe/core/pom.xml
@@ -41,10 +41,10 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- findbugs dependency -->
+        <!-- spotbugs dependency -->
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
             <optional>true</optional>
         </dependency>
     </dependencies>
@@ -230,8 +230,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>findbugs-maven-plugin</artifactId>
+                        <groupId>com.github.spotbugs</groupId>
+                        <artifactId>spotbugs-maven-plugin</artifactId>
                         <configuration>
                             <effort>Max</effort>
                             <xmlOutput>true</xmlOutput>

--- a/probe/core/src/main/java/org/jboss/weld/probe/InvocationMonitor.java
+++ b/probe/core/src/main/java/org/jboss/weld/probe/InvocationMonitor.java
@@ -143,10 +143,11 @@ public class InvocationMonitor implements Serializable {
         if (probe == null) {
             synchronized (this) {
                 if (probe == null) {
-                    probe = beanManager.getExtension(ProbeExtension.class).getProbe();
-                    if (!probe.isInitialized()) {
+                    Probe probeExt = beanManager.getExtension(ProbeExtension.class).getProbe();
+                    if (!probeExt.isInitialized()) {
                         throw ProbeLogger.LOG.probeNotInitialized();
                     }
+                    probe = probeExt;
                     skipJavaBeanProperties = beanManager.getServices().get(WeldConfiguration.class)
                             .getBooleanProperty(ConfigurationKey.PROBE_INVOCATION_MONITOR_SKIP_JAVABEAN_PROPERTIES);
                 }


### PR DESCRIPTION
Replace FindBugs with SpotBugs.

SpotBugs found few more details in code which I adapted as part of this PR, feel free to disagree.

I will keep the profile name and threshold properties (etc.) named "findbugs" as it is well-known and many CI jobs use it.