### PR TITLE
WELD-2464: Prevent NPE in ProtectionDomainCache (2.4)

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProtectionDomainCache.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProtectionDomainCache.java
@@ -73,11 +73,16 @@ public class ProtectionDomainCache extends AbstractBootstrapService {
         if (domain.implies(ACCESS_DECLARED_MEMBERS_PERMISSION)) {
             return domain;
         }
-        Enumeration<Permission> permissions = domain.getPermissions().elements();
+        PermissionCollection permissions = domain.getPermissions();
         PermissionCollection proxyPermissions = new Permissions();
-        while (permissions.hasMoreElements()) {
-            proxyPermissions.add(permissions.nextElement());
+
+        if (permissions != null) {
+            Enumeration<Permission> permissionElements = permissions.elements();
+            while (permissionElements.hasMoreElements()) {
+                proxyPermissions.add(permissionElements.nextElement());
+            }
         }
+
         proxyPermissions.add(ACCESS_DECLARED_MEMBERS_PERMISSION);
         return new ProtectionDomain(domain.getCodeSource(), proxyPermissions);
     }


### PR DESCRIPTION
Prevent NullPointerException in ProtectionDomainCache if
ProtectionDomain.getPermissions() returns null.