### PR TITLE
Improved beans.xml parsing performance

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
@@ -97,7 +97,6 @@ public class WeldBootstrap implements CDI11Bootstrap {
             weldStartup.endInitialization();
             weldStartup = null;
         }
-        this.beansXmlParser.reset();
         return this;
     }
 

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
@@ -97,6 +97,7 @@ public class WeldBootstrap implements CDI11Bootstrap {
             weldStartup.endInitialization();
             weldStartup = null;
         }
+        this.beansXmlParser.reset();
         return this;
     }
 

--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlParser.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlParser.java
@@ -73,8 +73,6 @@ public class BeansXmlParser {
 
     private Function<URL, BeansXml> URL_TO_BEANS_XML_FUNCTION = BeansXmlParser.this::parse;
 
-    private SAXParser parser;
-
     private static Function<BeanDeploymentArchive, BeansXml> BEAN_ARCHIVE_TO_BEANS_XML_FUNCTION = archive -> {
         if (archive == null) {
             return null;
@@ -84,26 +82,19 @@ public class BeansXmlParser {
 
     private static Function<BeansXml, BeansXml> BEANS_XML_IDENTITY_FUNCTION = beansXml -> beansXml;
 
-    public void reset() {
-        this.parser = null;
-    }
-
     public BeansXml parse(final URL beansXml) {
         if (beansXml == null) {
             throw XmlLogger.LOG.loadError("unknown", null);
         }
-        SAXParser parser = this.parser;
-        if (parser == null) {
-            try {
-                synchronized (PARSER_FACTORY) {
-                    parser = PARSER_FACTORY.newSAXParser();
-                }
-            } catch (SAXException e) {
-                throw XmlLogger.LOG.configurationError(e);
-            } catch (ParserConfigurationException e) {
-                throw XmlLogger.LOG.configurationError(e);
-            }
-            this.parser = parser;
+        SAXParser parser = null;
+        try {
+          synchronized (PARSER_FACTORY) {
+            parser = PARSER_FACTORY.newSAXParser();
+          }
+        } catch (SAXException e) {
+          throw XmlLogger.LOG.configurationError(e);
+        } catch (ParserConfigurationException e) {
+          throw XmlLogger.LOG.configurationError(e);
         }
 
         // quick check of beans.xml to find out version


### PR DESCRIPTION
Hello; thanks as always for your work on Weld.

(I am something of a Github rookie when it comes to pull requests and such so I hope I've done this right.)

This pull request improves the performance of parsing `beans.xml` files.  The general approach is to share the `SAXParserFactory` (carefully!) and to buffer certain reads to avoid too many method invocations.  All edits were performed after profiling to make sure they had some kind of measurable effect.

Happy to make edits etc. but might require some hand-holding where git is concerned.  😄 