### PR TITLE
WELD-2457: Make it possible to drop unused beans metadata 

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/ConcurrentValidator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/ConcurrentValidator.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.enterprise.inject.spi.Bean;
@@ -48,8 +49,8 @@ public class ConcurrentValidator extends Validator {
 
     private final ExecutorServices executor;
 
-    public ConcurrentValidator(Set<PlugableValidator> plugableValidators, ExecutorServices executor) {
-        super(plugableValidators);
+    public ConcurrentValidator(Set<PlugableValidator> plugableValidators, ExecutorServices executor, ConcurrentMap<Bean<?>, Boolean> resolvedInjectionPoints) {
+        super(plugableValidators, resolvedInjectionPoints);
         this.executor = executor;
     }
 

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldUnusedMetadataExtension.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldUnusedMetadataExtension.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.bootstrap;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Initialized;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.ProcessInjectionPoint;
+
+import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.resolution.Resolvable;
+import org.jboss.weld.resolution.ResolvableBuilder;
+import org.jboss.weld.util.reflection.Reflections;
+
+/**
+ * This optional extension collects all injection points
+ * <ul>
+ * <li>of Java EE components,</li>
+ * <li>with {@link Instance} required type,</li>
+ * </ul>
+ * so that Weld is able to identify unused beans better.
+ *
+ * @author Martin Kouba
+ */
+public class WeldUnusedMetadataExtension implements Extension {
+
+    private Set<InjectionPoint> componentInjectionPoints;
+
+    private Set<InjectionPoint> instanceInjectionPoints;
+
+    WeldUnusedMetadataExtension() {
+        this.componentInjectionPoints = new HashSet<>();
+        this.instanceInjectionPoints = new HashSet<>();
+    }
+
+    void processInjectionPoints(@Observes ProcessInjectionPoint<?, ?> event) {
+        if (event.getInjectionPoint().getBean() == null) {
+            componentInjectionPoints.add(event.getInjectionPoint());
+        }
+        if (Instance.class.equals(Reflections.getRawType(event.getInjectionPoint().getType()))) {
+            instanceInjectionPoints.add(event.getInjectionPoint());
+        }
+    }
+
+    void clear(@Observes @Initialized(ApplicationScoped.class) Object obj) {
+        componentInjectionPoints.clear();
+        instanceInjectionPoints.clear();
+    }
+
+    public boolean isInjectedByEEComponent(Bean<?> bean, BeanManagerImpl beanManager) {
+        if (componentInjectionPoints.isEmpty()) {
+            return false;
+        }
+        for (InjectionPoint injectionPoint : componentInjectionPoints) {
+            if (beanManager.getBeanResolver().resolve(new ResolvableBuilder(injectionPoint, beanManager).create(), false).contains(bean)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public boolean isInstanceResolvedBean(Bean<?> bean, BeanManagerImpl beanManager) {
+        if (instanceInjectionPoints.isEmpty()) {
+            return false;
+        }
+        for (InjectionPoint injectionPoint : instanceInjectionPoints) {
+            Type facadeType = getFacadeType(injectionPoint);
+            if (facadeType != null) {
+                Resolvable resolvable = new ResolvableBuilder(facadeType, beanManager).addQualifiers(injectionPoint.getQualifiers())
+                        .setDeclaringBean(injectionPoint.getBean()).create();
+                if (beanManager.getBeanResolver().resolve(resolvable, false).contains(bean)) {
+                    return true;
+                }
+            }
+
+        }
+        return false;
+    }
+
+    private Type getFacadeType(InjectionPoint injectionPoint) {
+        Type genericType = injectionPoint.getType();
+        if (genericType instanceof ParameterizedType) {
+            return ((ParameterizedType) genericType).getActualTypeArguments()[0];
+        }
+        return null;
+    }
+
+}

--- a/impl/src/main/java/org/jboss/weld/config/ConfigurationKey.java
+++ b/impl/src/main/java/org/jboss/weld/config/ConfigurationKey.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.weld.config;
 
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.ProcessInjectionTarget;
 
 import org.jboss.weld.bean.proxy.ProxyInstantiator;
@@ -271,6 +274,54 @@ public enum ConfigurationKey {
      */
     ALLOW_OPTIMIZED_CLEANUP("org.jboss.weld.bootstrap.allowOptimizedCleanup", false, true),
 
+    /**
+     * A regular expression. If {@link #ALLOW_OPTIMIZED_CLEANUP} is set to true this property can be used to extend the set of beans which should never be
+     * considered <strong>unused</strong>. {@link Bean#getBeanClass()} is used to match the pattern.
+     *
+     * <p>
+     * Two special values are considered. {@link UnusedBeans#ALL} (default value) means that all beans are excluded. If set to {@link UnusedBeans#NONE}, no
+     * beans are excluded.
+     * </p>
+     *
+     * An unused bean:
+     * <ul>
+     * <li>is not excluded by this property or {@link #UNUSED_BEANS_EXCLUDE_ANNOTATION}</li>
+     * <li>is not a built-in bean, session bean, extension, interceptor or decorator,</li>
+     * <li>does not have a name</li>
+     * <li>does not declare an observer</li>
+     * <li>is not eligible for injection to any injection point</li>
+     * <li>does not declare a producer which is eligible for injection to any injection point</li>
+     * <li>is not eligible for injection into any {@link Instance} injection point</li>
+     * </ul>
+     *
+     * @see ConfigurationKey#UNUSED_BEANS_EXCLUDE_ANNOTATION
+     */
+    UNUSED_BEANS_EXCLUDE_TYPE("org.jboss.weld.bootstrap.unusedBeans.excludeType", UnusedBeans.ALL),
+
+    /**
+     * A regular expression. If {@link #ALLOW_OPTIMIZED_CLEANUP} is set to true this property can be used to extend the set of beans which should never be
+     * considered <strong>unused</strong>. A bean is excluded if the corresponding {@link AnnotatedType}, or any member, is annotated with an annotation which
+     * matches this pattern.
+     *
+     * <p>
+     * By default, JAX-RS annotations are considered. If undefined (an empty string), no annotations are considered.
+     * </p>
+     *
+     * An unused bean:
+     * <ul>
+     * <li>is not excluded by this property or {@link #UNUSED_BEANS_EXCLUDE_ANNOTATION}</li>
+     * <li>is not a built-in bean, session bean, extension, interceptor or decorator,</li>
+     * <li>does not have a name</li>
+     * <li>does not declare an observer</li>
+     * <li>is not eligible for injection to any injection point</li>
+     * <li>does not declare a producer which is eligible for injection to any injection point</li>
+     * <li>is not eligible for injection into any {@link Instance} injection point</li>
+     * </ul>
+     *
+     * @see #UNUSED_BEANS_EXCLUDE_TYPE
+     */
+    UNUSED_BEANS_EXCLUDE_ANNOTATION("org.jboss.weld.bootstrap.unusedBeans.excludeAnnotation", "javax\\.ws\\.rs.*"),
+
     ;
 
     /**
@@ -296,6 +347,24 @@ public enum ConfigurationKey {
         }
         this.defaultValue = defaultValue;
         this.integratorOnly = integratorOnly;
+    }
+
+    public static final class UnusedBeans {
+
+        public static final String ALL = "ALL";
+        public static final String NONE = "NONE";
+
+        public static final boolean isEnabled(WeldConfiguration configuration) {
+            return isEnabled(configuration.getStringProperty(UNUSED_BEANS_EXCLUDE_TYPE));
+        }
+
+        public static final boolean isEnabled(String value) {
+            return !ALL.equals(value) && !".*".equals(value);
+        }
+
+        public static final boolean excludeNone(String value) {
+            return NONE.equals(value);
+        }
     }
 
     private final String key;
@@ -383,5 +452,6 @@ public enum ConfigurationKey {
         }
         return null;
     }
+
 
 }

--- a/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
@@ -330,4 +330,8 @@ public interface BootstrapLogger extends WeldLogger {
     @Message(id = 179, value = "{0} created by {1} cannot be processed", format = Format.MESSAGE_FORMAT)
     DeploymentException unableToProcessConfigurator(Object configurator, Object extensionName, @Cause Throwable cause);
 
+    @LogMessage(level = Logger.Level.DEBUG)
+    @Message(id = 180, value = "Drop unused bean metadata: {0}", format = Format.MESSAGE_FORMAT)
+    void dropUnusedBeanMetadata(Object bean);
+
 }

--- a/impl/src/main/java/org/jboss/weld/resources/ClassTransformer.java
+++ b/impl/src/main/java/org/jboss/weld/resources/ClassTransformer.java
@@ -21,11 +21,13 @@ import static org.jboss.weld.util.reflection.Reflections.cast;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
 
 import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.Bean;
 
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedType;
 import org.jboss.weld.annotated.enhanced.EnhancedAnnotation;
@@ -35,6 +37,7 @@ import org.jboss.weld.annotated.slim.AnnotatedTypeIdentifier;
 import org.jboss.weld.annotated.slim.SlimAnnotatedType;
 import org.jboss.weld.annotated.slim.backed.BackedAnnotatedType;
 import org.jboss.weld.annotated.slim.unbacked.UnbackedAnnotatedType;
+import org.jboss.weld.bean.AbstractClassBean;
 import org.jboss.weld.bootstrap.api.BootstrapService;
 import org.jboss.weld.logging.BootstrapLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
@@ -301,5 +304,13 @@ public class ClassTransformer implements BootstrapService {
         cleanupAfterBoot();
         slimAnnotatedTypesById.clear();
         syntheticAnnotationsAnnotatedTypes.clear();
+    }
+
+    public void removeAll(Set<Bean<?>> removable) {
+        for (Bean<?> bean : removable) {
+            if (bean instanceof AbstractClassBean) {
+                slimAnnotatedTypesById.remove(((AbstractClassBean<?>) bean).getAnnotated().getIdentifier());
+            }
+        }
     }
 }

--- a/impl/src/main/java/org/jboss/weld/serialization/ContextualStoreImpl.java
+++ b/impl/src/main/java/org/jboss/weld/serialization/ContextualStoreImpl.java
@@ -24,9 +24,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.enterprise.context.spi.Contextual;
 import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.PassivationCapable;
 
 import org.jboss.weld.bean.CommonBean;
+import org.jboss.weld.bean.RIBean;
 import org.jboss.weld.bean.StringBeanIdentifier;
 import org.jboss.weld.contexts.SerializableContextualFactory;
 import org.jboss.weld.contexts.SerializableContextualInstanceImpl;
@@ -148,5 +150,18 @@ public class ContextualStoreImpl implements ContextualStore {
         contextuals.clear();
         contextualsInverse.clear();
         passivationCapableContextuals.clear();
+    }
+
+    public void removeAll(Iterable<Bean<?>> removable) {
+        for (Bean<?> bean : removable) {
+            BeanIdentifier beanIdentifier = contextuals.remove(bean);
+            if (beanIdentifier == null && bean instanceof RIBean) {
+                beanIdentifier = ((RIBean<?>) bean).getIdentifier();
+            }
+            if (beanIdentifier != null) {
+                contextualsInverse.remove(beanIdentifier);
+                passivationCapableContextuals.remove(beanIdentifier);
+            }
+        }
     }
 }

--- a/impl/src/main/java/org/jboss/weld/util/Beans.java
+++ b/impl/src/main/java/org/jboss/weld/util/Beans.java
@@ -67,6 +67,7 @@ import org.jboss.weld.annotated.enhanced.EnhancedAnnotatedType;
 import org.jboss.weld.bean.AbstractBean;
 import org.jboss.weld.bean.AbstractProducerBean;
 import org.jboss.weld.bean.DecoratorImpl;
+import org.jboss.weld.bean.ForwardingBean;
 import org.jboss.weld.bean.InterceptorImpl;
 import org.jboss.weld.bean.RIBean;
 import org.jboss.weld.bootstrap.api.ServiceRegistry;
@@ -664,6 +665,14 @@ public class Beans {
             return abstractBean.isIgnoreFinalMethods();
         }
         return false;
+    }
+
+    public static Bean<?> unwrap(Bean<?> bean) {
+        if (bean instanceof ForwardingBean) {
+            ForwardingBean<?> forwarding = (ForwardingBean<?>) bean;
+            return forwarding.delegate();
+        }
+        return bean;
     }
 
     /**

--- a/probe/tests/src/main/java/org/jboss/weld/probe/tests/integration/JSONTestUtil.java
+++ b/probe/tests/src/main/java/org/jboss/weld/probe/tests/integration/JSONTestUtil.java
@@ -40,7 +40,7 @@ public class JSONTestUtil {
     public static final String DEPLOYMENT_PATH = "weld-probe/deployment";
     public static final String INVOCATIONS_PATH = "weld-probe/invocations";
     public static final String EVENTS_PATH = "weld-probe/events";
-    public static final String OBSERVERS_PATH = "weld-probe/observers";
+    public static final String OBSERVERS_PATH_ALL = "weld-probe/observers?pageSize=0";
     public static final String BEANS_PATH = "weld-probe/beans";
     public static final String SESSION_CONTEXTS_PATH = "weld-probe/contexts/session";
     public static final String APPLICATION_CONTEXTS_PATH = "weld-probe/contexts/application";

--- a/probe/tests/src/test/java/org/jboss/weld/probe/tests/integration/ProbeObserversTest.java
+++ b/probe/tests/src/test/java/org/jboss/weld/probe/tests/integration/ProbeObserversTest.java
@@ -79,7 +79,7 @@ public class ProbeObserversTest extends ProbeIntegrationTest {
     @Test
     public void testObserversEndpoint() throws IOException {
         WebClient client = invokeSimpleAction(url);
-        JsonObject observers = getPageAsJSONObject(JSONTestUtil.OBSERVERS_PATH, url, client);
+        JsonObject observers = getPageAsJSONObject(JSONTestUtil.OBSERVERS_PATH_ALL, url, client);
         ReadContext ctx = JsonPath.parse(observers.toString());
         List<String> beanClasses = ctx.read("$." + DATA + "[*]." + BEAN_CLASS, List.class);
         List<String> txPhases = ctx.read("$." + DATA + "[*]." + TX_PHASE, List.class);

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/ExcludedUnused.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/ExcludedUnused.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ExcludedUnused {
+
+    public boolean ping() {
+        return true;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/TestExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/TestExtension.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+public class TestExtension implements Extension {
+
+    private AtomicBoolean used = new AtomicBoolean(false);
+
+    void afterBeanDiscovery(@Observes AfterBeanDiscovery event) {
+        used.set(true);
+    }
+
+    public boolean isInitialized() {
+        return used.get();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/TestExternalConfiguration.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/TestExternalConfiguration.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.jboss.weld.config.ConfigurationKey;
+import org.jboss.weld.configuration.spi.ExternalConfiguration;
+
+public class TestExternalConfiguration implements ExternalConfiguration {
+
+    @Override
+    public void cleanup() {
+    }
+
+    @Override
+    public Map<String, Object> getConfigurationProperties() {
+        return Collections.singletonMap(ConfigurationKey.ALLOW_OPTIMIZED_CLEANUP.get(), true);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/Unused.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/Unused.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Unused {
+
+    public boolean ping() {
+        return true;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedBeanRemovalTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedBeanRemovalTest.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InterceptionType;
+import javax.enterprise.util.AnnotationLiteral;
+import javax.enterprise.util.TypeLiteral;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.bootstrap.api.Service;
+import org.jboss.weld.config.ConfigurationKey;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.util.PropertiesBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * See also WELD-2457.
+ *
+ * @author Martin Kouba
+ */
+@RunWith(Arquillian.class)
+public class UnusedBeanRemovalTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ShrinkWrap
+                .create(BeanArchive.class,
+                        Utils.getDeploymentNameAsHash(UnusedBeanRemovalTest.class))
+                .addPackage(UnusedBeanRemovalTest.class.getPackage())
+                .addAsServiceProvider(Extension.class, TestExtension.class)
+                .addAsServiceProvider(Service.class, TestExternalConfiguration.class)
+                .addAsResource(PropertiesBuilder.newBuilder()
+                        .set(ConfigurationKey.UNUSED_BEANS_EXCLUDE_TYPE.get(),
+                                "org\\.jboss\\.weld\\.tests\\.bootstrap\\.unusedbeans\\.Excluded.*")
+                        .set(ConfigurationKey.UNUSED_BEANS_EXCLUDE_ANNOTATION.get(),
+                                ".*UnusedExcludeAnnotation")
+                        .build(), "weld.properties");
+    }
+
+    @Inject
+    BeanManager beanManager;
+
+    @Test
+    public void testExtensionNotRemoved() {
+        assertEquals(1, beanManager.getBeans(TestExtension.class).size());
+    }
+
+    @Test
+    public void testUnusedRemoved() {
+        assertEquals(0, beanManager.getBeans(Unused.class).size());
+    }
+
+    @Test
+    public void testExcludedUnusedNotRemoved() {
+        assertEquals(1, beanManager.getBeans(ExcludedUnused.class).size());
+    }
+
+    @Test
+    public void testUnusedWithObserverNotRemoved() {
+        assertEquals(1, beanManager.getBeans(UnusedWithObserver.class).size());
+    }
+
+    @Test
+    public void testUnusedWithNameNotRemoved() {
+        assertEquals(1, beanManager.getBeans(UnusedWithName.class).size());
+    }
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testUnusedWithProducerNotRemoved() {
+        assertEquals(1, beanManager.getBeans(UnusedWithProducer.class).size());
+        assertEquals(1, beanManager.getBeans(new TypeLiteral<List<ExcludedUnused>>() {
+        }.getType()).size());
+    }
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testUnusedWithUnusedProducerRemoved() {
+        assertEquals(0, beanManager.getBeans(UnusedWithUnusedProducer.class).size());
+        assertEquals(0, beanManager.getBeans(new TypeLiteral<List<Unused>>() {
+        }.getType()).size());
+    }
+
+    @Test
+    public void testUnusedResolvableToInstanceNotRemoved() {
+        assertEquals(1, beanManager.getBeans(UnusedResolvableToInstance.class).size());
+    }
+
+    @SuppressWarnings("serial")
+    @Test
+    public void testUnusedInterceptorNotRemoved() {
+        assertEquals(1, beanManager.resolveInterceptors(InterceptionType.AROUND_INVOKE,
+                new AnnotationLiteral<UnusedBinding>() {
+                }).size());
+    }
+
+    @Test
+    public void testUnusedWithExcludeAnnotationNotRemoved() {
+        assertEquals(1, beanManager.getBeans(UnusedWithExcludeAnnotation.class).size());
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedBinding.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedBinding.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE })
+@Retention(RUNTIME)
+public @interface UnusedBinding {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedExcludeAnnotation.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedExcludeAnnotation.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.interceptor.InterceptorBinding;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface UnusedExcludeAnnotation {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedInterceptor.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@UnusedBinding
+@Priority(1)
+@Interceptor
+public class UnusedInterceptor {
+
+    @AroundInvoke
+    Object aroundInvoke(InvocationContext context) throws Exception {
+        return context.proceed();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedResolvableToInstance.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedResolvableToInstance.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import javax.enterprise.context.Dependent;
+
+@Dependent
+public class UnusedResolvableToInstance extends UnusedResolvableToInstanceBase {
+
+    public boolean ping() {
+        return true;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedResolvableToInstanceBase.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedResolvableToInstanceBase.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+public class UnusedResolvableToInstanceBase {
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithExcludeAnnotation.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithExcludeAnnotation.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import javax.enterprise.context.RequestScoped;
+
+@RequestScoped
+public class UnusedWithExcludeAnnotation {
+
+    @UnusedExcludeAnnotation
+    public void ping() {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithName.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithName.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Named
+@ApplicationScoped
+public class UnusedWithName {
+
+    @Inject
+    Instance<UnusedResolvableToInstanceBase> instance;
+
+    @Inject
+    List<ExcludedUnused> list;
+
+    void pong() {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithObserver.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+
+@ApplicationScoped
+public class UnusedWithObserver {
+
+    public void observe(@Observes String event) {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithProducer.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class UnusedWithProducer {
+
+    /**
+     * See {@link UnusedWithName}
+     */
+    @Dependent
+    @Produces
+    public List<ExcludedUnused> produce() {
+        return Collections.emptyList();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithUnusedProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/bootstrap/unusedbeans/UnusedWithUnusedProducer.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.bootstrap.unusedbeans;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class UnusedWithUnusedProducer {
+
+    @Dependent
+    @Produces
+    public List<Unused> produce() {
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
This is a POC for ideas around [WELD-2457](https://issues.jboss.org/browse/WELD-2457).

I've tested the changes with a small application (slightly modified [JSF numberguess](https://github.com/weld/core/tree/master/examples/jsf/numberguess) example with DeltaSpike core dependency) deployed to WildFly 12. When measuring the cold start of the app server the memory consumption was reduced by ~ 10% (~ 300 KB) at the cost of increasing the bootstrap time by ~ 5% (~ 60ms).