### PR TITLE
WELD-2474 Use Weld's internal literals.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/Observers.java
+++ b/impl/src/main/java/org/jboss/weld/util/Observers.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.util.Set;
 
-import javax.enterprise.inject.Any;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.AfterDeploymentValidation;
 import javax.enterprise.inject.spi.AfterTypeDiscovery;
@@ -54,6 +53,7 @@ import org.jboss.weld.event.ContainerLifecycleEventObserverMethod;
 import org.jboss.weld.event.EventMetadataAwareObserverMethod;
 import org.jboss.weld.event.ObserverMethodImpl;
 import org.jboss.weld.event.SyntheticObserverMethod;
+import org.jboss.weld.literal.AnyLiteral;
 import org.jboss.weld.logging.EventLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.security.GetDeclaredMethodsAction;
@@ -99,7 +99,7 @@ public class Observers {
             }
 
             // public void observe (@Observes @Any Object ob){...} - this IS container event observer
-            if (method.getObservedQualifiers().size() == 1 && method.getObservedQualifiers().contains(Any.Literal.INSTANCE)) {
+            if (method.getObservedQualifiers().size() == 1 && method.getObservedQualifiers().contains(AnyLiteral.INSTANCE)) {
                 return true;
             }
         }


### PR DESCRIPTION
I did grep our codebase for these and I think this is the sole problematic case.

There were other occurrences of course, but:
* those in tests can be ignored (SE or integration)
* those is SE impl too as they are not relevant for WFLY
* those in core but related to `Configurators` API can only be used with CDI 2.0, so we are safe there as well