### PR TITLE
WELD-2477: Optimize string representation of AnnotatedTypeIdentifier

### DIFF
--- a/impl/src/main/java/org/jboss/weld/annotated/slim/AnnotatedTypeIdentifier.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/slim/AnnotatedTypeIdentifier.java
@@ -141,13 +141,15 @@ public class AnnotatedTypeIdentifier implements Identifier {
         StringBuilder builder = new StringBuilder();
         builder.append(contextId);
         builder.append(ID_SEPARATOR);
-        builder.append(bdaId);
+        // Bean deployment archive id very often starts with context id
+        builder.append(bdaId != null ? (bdaId.startsWith(contextId) ? bdaId.substring(contextId.length()) : bdaId) : bdaId);
         builder.append(ID_SEPARATOR);
         builder.append(className);
         builder.append(ID_SEPARATOR);
-        builder.append(suffix);
+        // AnnodatedType added by an extension often has suffix starting with class FQCN
+        builder.append(suffix != null ? (suffix.startsWith(className) ? suffix.substring(className.length()) : suffix) : suffix);
         builder.append(ID_SEPARATOR);
-        builder.append(modified);
+        builder.append(modified ? 1 : 0);
         return builder.toString();
     }
 
@@ -156,6 +158,5 @@ public class AnnotatedTypeIdentifier implements Identifier {
         return "AnnotatedTypeIdentifier [contextId=" + contextId + ", bdaId=" + bdaId + ", className=" + className + ", suffix=" + suffix + ", modified="
                 + modified + "]";
     }
-
 
 }

--- a/jboss-tck-runner/src/test/tck20/tck-tests.xml
+++ b/jboss-tck-runner/src/test/tck20/tck-tests.xml
@@ -26,7 +26,13 @@
             <!-- Issues in the spec -->
 
             <!-- Issues in the TCK -->
-            
+            <!-- CDITCK-614 -->
+            <class name="org.jboss.cdi.tck.tests.extensions.configurators.invalid.ConfiguratorAndSetMethodTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+
             <!-- Issues in Weld (the RI) -->
 
             <!-- Issues in WildFly -->

--- a/tests/src/test/java/org/jboss/weld/tests/unit/util/AnnotatedTypesTest.java
+++ b/tests/src/test/java/org/jboss/weld/tests/unit/util/AnnotatedTypesTest.java
@@ -141,18 +141,18 @@ public class AnnotatedTypesTest {
         builder.addToMethod(Chair.class.getMethod("sit"), new ProducesLiteral());
         AnnotatedType<Chair> chair3 = builder.create();
         String id = AnnotatedTypes.createTypeId(chair3);
-        Assert.assertEquals("org.jboss.weld.tests.unit.util.Chair{org.jboss.weld.tests.unit.util.Chair.sit[@javax.enterprise.inject.Produces()]();}", id, "wrong id for type :" + id);
+        Assert.assertEquals(id, AnnotatedTypes.hash("org.jboss.weld.tests.unit.util.Chair{org.jboss.weld.tests.unit.util.Chair.sit[@javax.enterprise.inject.Produces()]();}"), "wrong id for type :" + id);
 
         builder = new TestAnnotatedTypeBuilder<Chair>(Chair.class);
         chair3 = builder.create();
         id = AnnotatedTypes.createTypeId(chair3);
-        Assert.assertEquals("org.jboss.weld.tests.unit.util.Chair{}", id, "wrong id for type :" + id);
+        Assert.assertEquals(id, AnnotatedTypes.hash("org.jboss.weld.tests.unit.util.Chair{}"), "wrong id for type :" + id);
 
         builder = new TestAnnotatedTypeBuilder<Chair>(Chair.class);
         builder.addToMethod(Chair.class.getMethod("sit"), new ComfyChairLiteral());
         chair3 = builder.create();
         id = AnnotatedTypes.createTypeId(chair3);
-        Assert.assertEquals("org.jboss.weld.tests.unit.util.Chair{org.jboss.weld.tests.unit.util.Chair.sit[@org.jboss.weld.tests.unit.util.ComfyChair(softness=1)]();}", id, "wrong id for type :" + id);
+        Assert.assertEquals(id, AnnotatedTypes.hash("org.jboss.weld.tests.unit.util.Chair{org.jboss.weld.tests.unit.util.Chair.sit[@org.jboss.weld.tests.unit.util.ComfyChair(softness=1)]();}"), "wrong id for type :" + id);
     }
 
     private static class DefaultLiteral extends AnnotationLiteral<Default> implements Default {


### PR DESCRIPTION
- use SHA-1 hash for generated ids for synthetic types
- shorten bdaId - bean deployment archive id very often starts with context id
- shorten suffix - AnnodatedType added by an extension often has suffix starting with class FQCN
- shorten modified - use 0 and 1