### PR TITLE
WELD-2479 Allow to modify lists of alternatives/interceptors/decorato…

### DIFF
--- a/impl/src/test/java/org/jboss/weld/bootstrap/enablement/EnablementListViewTest.java
+++ b/impl/src/test/java/org/jboss/weld/bootstrap/enablement/EnablementListViewTest.java
@@ -1,0 +1,179 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.bootstrap.enablement;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.ListIterator;
+
+import javax.enterprise.inject.spi.Extension;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class EnablementListViewTest {
+
+    @Test
+    public void testBasicOperations() {
+        final List<Item> list = new ArrayList<>();
+        EnablementListView view = new EnablementListView() {
+            @Override
+            protected ViewType getViewType() {
+                return null;
+            }
+
+            @Override
+            protected Extension getExtension() {
+                return null;
+            }
+
+            @Override
+            protected List<Item> getDelegate() {
+                return list;
+            }
+        };
+
+        list.add(new Item(Integer.class, 20));
+        list.add(new Item(String.class, 1));
+        list.add(new Item(Double.class, 300));
+
+        // test contains(), index() and lastIndexOf(), note that list is *not* sorted
+        assertTrue(view.contains(Integer.class));
+        assertEquals(2, view.indexOf(Double.class));
+        assertEquals(0, view.lastIndexOf(Integer.class));
+
+        assertEquals(3, view.size());
+        assertEquals(Integer.class, view.get(0));
+        list.add(new Item(BigInteger.class, 301));
+        assertEquals(4, view.size());
+
+        view.add(BigDecimal.class);
+        assertEquals(5, view.size());
+        assertEquals(BigDecimal.class, view.get(view.size() - 1));
+
+        // remove via List.remove(Object)
+        view.remove(Double.class);
+        assertEquals(4, list.size());
+    }
+
+    @Test
+    public void testListIterator() {
+
+        final List<Item> list = new ArrayList<>();
+        EnablementListView view = new EnablementListView() {
+            @Override
+            protected ViewType getViewType() {
+                return null;
+            }
+
+            @Override
+            protected Extension getExtension() {
+                return null;
+            }
+
+            @Override
+            protected List<Item> getDelegate() {
+                return list;
+            }
+        };
+        list.add(new Item(Integer.class, 10));
+        list.add(new Item(String.class, 20));
+        list.add(new Item(Double.class, 30));
+
+        ListIterator<Class<?>> iterator = view.listIterator();
+        // -> Integer, String, Double
+        assertEquals(Integer.class, iterator.next());
+        // Integer, -> String, Double
+        iterator.remove();
+        // -> String, Double
+        iterator.add(Float.class);
+        assertEquals(Float.class, iterator.previous());
+        // -> Float, String, Double
+        assertFalse(iterator.hasPrevious());
+        assertTrue(iterator.hasNext());
+        assertEquals(Float.class, iterator.next());
+        assertEquals(String.class, iterator.next());
+        // Float, -> String, Double
+        iterator.set(StringBuilder.class);
+        assertEquals(3, list.size());
+        assertEquals(StringBuilder.class, view.get(1));
+    }
+
+    @Test
+    public void testMassListOperations() {
+        final List<Item> list = new ArrayList<>();
+        EnablementListView view = new EnablementListView() {
+            @Override
+            protected EnablementListView.ViewType getViewType() {
+                return null;
+            }
+
+            @Override
+            protected Extension getExtension() {
+                return null;
+            }
+
+            @Override
+            protected List<Item> getDelegate() {
+                return list;
+            }
+        };
+        list.add(new Item(Integer.class, 10));
+        list.add(new Item(String.class, 20));
+        list.add(new Item(Double.class, 30));
+        list.add(new Item(Float.class, 50));
+
+        // note that these operations indirectly test List.contains()
+        // try removeAll()
+        Collection<Object> testList = new ArrayList<Object>();
+        testList.add(Integer.class);
+        testList.add(Float.class);
+
+        view.removeAll(testList);
+
+        assertEquals(2, list.size());
+        assertEquals(String.class, list.get(0).getJavaClass());
+        assertEquals(Double.class, list.get(1).getJavaClass());
+
+        // re-add missing items
+        list.add(new Item(Integer.class, 10));
+        list.add(new Item(Float.class, 50));
+
+        // try retainAll()
+        view.retainAll(testList);
+        assertEquals(2, list.size());
+        assertEquals(Integer.class, list.get(0).getJavaClass());
+        assertEquals(Float.class, list.get(1).getJavaClass());
+
+        // re-add missing items
+        list.add(new Item(String.class, 20));
+        list.add(new Item(Double.class, 30));
+
+        // try containsAll()
+        assertTrue(view.containsAll(testList));
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/AfterTypeDiscoveryObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/AfterTypeDiscoveryObserver.java
@@ -65,6 +65,11 @@ public class AfterTypeDiscoveryObserver implements Extension {
         }
         // Enable CharlieAlternative globally
         event.getAlternatives().add(0, CharlieAlternative.class);
+        
+        // Remove alternative, interceptor and decorator via List.remove(Object)
+        event.getAlternatives().remove(EchoAlternative.class);
+        event.getDecorators().remove(EchoDecorator.class);
+        event.getInterceptors().remove(EchoInterceptor.class);
     }
 
     public List<Class<?>> getInitialInterceptors() {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/AfterTypeDiscoveryTest.java
@@ -59,15 +59,18 @@ public class AfterTypeDiscoveryTest {
 
     @Test
     public void testInitialAlternatives() {
-        assertEquals(extension.getInitialAlternatives().size(), 2);
+        assertEquals(extension.getInitialAlternatives().size(), 3);
         assertEquals(extension.getInitialAlternatives().get(0), AlphaAlternative.class);
         assertEquals(extension.getInitialAlternatives().get(1), BravoAlternative.class);
+        assertEquals(extension.getInitialAlternatives().get(2), EchoAlternative.class);
     }
 
     @Test
     public void testFinalAlternatives() {
         // AlphaAlternative was removed from the list
         assertTrue(beanManager.getBeans(AlphaAlternative.class).isEmpty());
+        // EchoAlternative was removed from the list
+        assertTrue(beanManager.getBeans(EchoAlternative.class).isEmpty());
         // CharlieAlternative was enabled
         assertEquals(1, beanManager.getBeans(CharlieAlternative.class).size());
     }
@@ -76,6 +79,7 @@ public class AfterTypeDiscoveryTest {
     public void testInitialInterceptors() {
         assertTrue(extension.getInitialInterceptors().contains(BravoInterceptor.class));
         assertTrue(extension.getInitialInterceptors().contains(AlphaInterceptor.class));
+        assertTrue(extension.getInitialInterceptors().contains(EchoInterceptor.class));
     }
 
     @Test
@@ -90,9 +94,10 @@ public class AfterTypeDiscoveryTest {
 
     @Test
     public void testInitialDecorators() {
-        assertEquals(extension.getInitialDecorators().size(), 2);
+        assertEquals(extension.getInitialDecorators().size(), 3);
         assertEquals(extension.getInitialDecorators().get(0), AlphaDecorator.class);
         assertEquals(extension.getInitialDecorators().get(1), BravoDecorator.class);
+        assertEquals(extension.getInitialDecorators().get(2), EchoDecorator.class);
     }
 
     @Test

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/EchoAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/EchoAlternative.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.lifecycle.atd;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Alternative
+@Priority(2700)
+public class EchoAlternative {
+    
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/EchoDecorator.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/EchoDecorator.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.lifecycle.atd;
+
+import javax.annotation.Priority;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.inject.Inject;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Decorator
+@Priority(2017)
+public class EchoDecorator implements Logger {
+
+    @Inject
+    @Delegate
+    Logger logger;
+
+    @Override
+    public String log(String msg) {
+        return logger.log(msg + "echo");
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/EchoInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/EchoInterceptor.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.lifecycle.atd;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.jboss.weld.test.util.ActionSequence;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@Interceptor
+@Priority(2017)
+@Monitored
+public class EchoInterceptor {
+
+    @AroundInvoke
+    public Object monitor(InvocationContext ctx) throws Exception {
+        ActionSequence.addAction(EchoInterceptor.class.getName());
+        return ctx.proceed();
+    }
+}


### PR DESCRIPTION
…rs via List.remove(Object). Add test case for this.

Backporting to 2.4.
Added unit tests for this, a simplified version of what is on master (does not contain assertions on priority as `Item` does not expose this on 2.4).