### PR TITLE
WELD-2484 Configurators should override toString()

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/AnnotatedTypeBuilderImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/AnnotatedTypeBuilderImpl.java
@@ -37,6 +37,7 @@ import org.jboss.weld.util.annotated.ForwardingAnnotatedType;
 import org.jboss.weld.util.collections.ImmutableList;
 import org.jboss.weld.util.collections.ImmutableMap;
 import org.jboss.weld.util.collections.ImmutableSet;
+import org.jboss.weld.util.reflection.Formats;
 
 /**
  *
@@ -125,6 +126,11 @@ class AnnotatedTypeBuilderImpl<T> {
             return constructors;
         }
 
+        @Override
+        public String toString() {
+            return Formats.formatAnnotatedType(delegate);
+        }
+
     }
 
     static class AnnotatedMethodImpl<X> extends ForwardingAnnotatedMethod<X> {
@@ -166,6 +172,11 @@ class AnnotatedTypeBuilderImpl<T> {
             return annotations.isAnnotationPresent(annotationType);
         }
 
+        @Override
+        public String toString() {
+            return Formats.formatAnnotatedMethod(delegate);
+        }
+
     }
 
     static class AnnotatedFieldImpl<X> extends ForwardingAnnotatedField<X> {
@@ -199,6 +210,10 @@ class AnnotatedTypeBuilderImpl<T> {
             return annotations.isAnnotationPresent(annotationType);
         }
 
+        @Override
+        public String toString() {
+            return Formats.formatAnnotatedField(delegate);
+        }
     }
 
     static class AnnotatedConstructorImpl<X> extends ForwardingAnnotatedConstructor<X> {
@@ -240,6 +255,10 @@ class AnnotatedTypeBuilderImpl<T> {
             return annotations.isAnnotationPresent(annotationType);
         }
 
+        @Override
+        public String toString() {
+            return Formats.formatAnnotatedConstructor(delegate);
+        }
     }
 
     static class AnnotatedParameterImpl<X> extends ForwardingAnnotatedParameter<X> {
@@ -271,6 +290,11 @@ class AnnotatedTypeBuilderImpl<T> {
         @Override
         public boolean isAnnotationPresent(Class<? extends Annotation> annotationType) {
             return annotations.isAnnotationPresent(annotationType);
+        }
+
+        @Override
+        public String toString() {
+            return Formats.formatAnnotatedParameter(delegate);
         }
 
     }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/InjectionPointConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/InjectionPointConfiguratorImpl.java
@@ -210,6 +210,10 @@ public class InjectionPointConfiguratorImpl implements InjectionPointConfigurato
            return isTransient;
        }
 
+       @Override
+       public String toString() {
+           return "InjectionPoint with type=" + requiredType + ", qualifiers=" + qualifiers +
+               ", delegate=" + isDelegate + ", transient=" + isTransient + ".";
+       }
    }
-
 }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
@@ -330,6 +330,14 @@ public class ObserverMethodConfiguratorImpl<T> implements ObserverMethodConfigur
            return true;
        }
 
-   }
+       @Override
+       public String toString() {
+           return "Configurator observer method [Bean class = " + getBeanClass()
+               + ", type = " + getObservedType()
+               + ", qualifiers =" + Formats.formatAnnotations(getObservedQualifiers())
+               + ", priority =" + getPriority() + ", async =" + isAsync()
+               + ", reception =" + getReception() + ", transaction phase =" + getTransactionPhase() + "]";
+       }
 
+   }
 }


### PR DESCRIPTION
Not sure this is 'sensible enough'. It can blow up (and call toString()) from many scenarios so amount of useful information may vary.