### PR TITLE
Re-introduce property allowing us to pass WFLY-specific args via Arqu…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,10 @@
         <surefire.plugin.jdk9.args />
         <jax.artifacts.version>2.3.0</jax.artifacts.version>
 
-        <!-- A property which is handed over to WFLY container through Arquillian, allows for easy container configuration -->
+        <!-- A property which is handed over to WFLY container through Arquillian, allows to pass on JVM options -->
         <additional.vm.args />
+        <!-- A property which is handed over to WFLY container through Arquillian, allows to configure server-specific options -->
+        <additional.jboss.args></additional.jboss.args>
 
         <manifest.specification.title>JSR-365 Contexts and Dependency Injection for Java</manifest.specification.title>
         <manifest.specification.version>2.0</manifest.specification.version>

--- a/tests-arquillian/pom.xml
+++ b/tests-arquillian/pom.xml
@@ -282,6 +282,7 @@
                                 <jacoco.agent>${jacoco.agent}</jacoco.agent>
                                 <node.address>${node.address}</node.address>
                                 <additional.vm.args>${additional.vm.args}</additional.vm.args>
+                                <additional.jboss.args>${additional.jboss.args}</additional.jboss.args>
                                 <illegal.access.option>${surefire.plugin.jdk9.args}</illegal.access.option>
                                 <org.jboss.remoting-jmx.timeout>360</org.jboss.remoting-jmx.timeout>
                             </systemProperties>

--- a/tests-arquillian/src/test/resources/wildfly-arquillian.xml
+++ b/tests-arquillian/src/test/resources/wildfly-arquillian.xml
@@ -17,6 +17,7 @@
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m -Dee8.preview.mode=true ${illegal.access.option} ${jacoco.agent} ${additional.vm.args}</property>
+            <property name="jbossArguments">${additional.jboss.args}</property>
             <property name="managementAddress">${node.address}</property>
         </configuration>
     </container>


### PR DESCRIPTION
…illian.

Removing this was a mistake, we need this when we want, for instance, to boot WFLY with security manager.