### PR TITLE
Few fixes and exclusions for Weld examples on JDK 9.

### DIFF
--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -14,12 +14,6 @@
 
     <description>Weld support for Java SE</description>
 
-    <properties>
-        <groovy.version>2.4.7</groovy.version>
-        <groovy.eclipse.compiler.version>2.9.2-01</groovy.eclipse.compiler.version>
-        <groovy.eclipse.batch.version>2.4.3-01</groovy.eclipse.batch.version>
-    </properties>
-
     <url>http://weld.cdi-spec.org</url>
     <licenses>
         <license>
@@ -106,13 +100,11 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jboss.classfilewriter</groupId>
             <artifactId>jboss-classfilewriter</artifactId>
-            <version>${classfilewriter.version}</version>
         </dependency>
 
     </dependencies>
@@ -130,10 +122,35 @@
                     </archive>
                 </configuration>
             </plugin>
+            <!--This plugin adds Groovy test sources to Maven and makes sure it compiles and runs as tests-->
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addTestSources</goal>
+                            <goal>generateTestStubs</goal>
+                            <goal>compileTests</goal>
+                            <goal>removeTestStubs</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <testSources>
+                        <testSource>
+                            <directory>${project.basedir}/src/test/groovy</directory>
+                            <includes>
+                                <include>**/*.groovy</include>
+                            </includes>
+                        </testSource>
+                    </testSources>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <executions>
                     <execution>
                         <id>compile</id>
@@ -159,51 +176,6 @@
     </build>
 
     <profiles>
-        <profile>
-            <!--Groovy compilation is disabled for JDK 1.9+-->
-            <id>weld-groovy-compilation</id>
-            <activation>
-                <jdk>(,9)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <!-- There is a problem compiling WeldSELogger with a groovy compiler and there also can't be
-                        2 compilers specified for one pom.xml, so the compilation is splitted: javac for main,groovyc for tests. -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.1</version>
-                        <executions>
-                            <execution>
-                                <id>test-compile</id>
-                                <phase>process-test-sources</phase>
-                                <goals>
-                                    <goal>testCompile</goal>
-                                </goals>
-                                <configuration>
-                                    <compilerId>groovy-eclipse-compiler</compilerId>
-                                    <source>${maven.compiler.source}</source>
-                                    <target>${maven.compiler.target}</target>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-eclipse-compiler</artifactId>
-                                <version>${groovy.eclipse.compiler.version}</version>
-                            </dependency>
-                            <dependency>
-                                <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-eclipse-batch</artifactId>
-                                <version>${groovy.eclipse.batch.version}</version>
-                            </dependency>
-                        </dependencies>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
         <profile>
             <id>jacoco</id>
             <activation>

--- a/examples/jsf/pastecode/pom.xml
+++ b/examples/jsf/pastecode/pom.xml
@@ -210,6 +210,37 @@
         <profile>
             <id>arquillian-wildfly-remote-8</id>
         </profile>
+
+        <profile>
+            <!-- auto-activated profile for any JDK 9+ -->
+            <id>jdk9+</id>
+            <activation>
+                <jdk>[9,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.ws</groupId>
+                    <artifactId>jaxws-api</artifactId>
+                    <version>${jax.artifacts.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.ws</groupId>
+                    <artifactId>jaxws-ri</artifactId>
+                    <version>${jax.artifacts.version}</version>
+                    <type>zip</type>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-ri</artifactId>
+                    <version>${jax.artifacts.version}</version>
+                    <type>zip</type>
+                </dependency>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <scm>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -98,15 +98,17 @@
         <module>jsf/pastecode</module>
         <module>se/numberguess</module>
         <module>se/hello-world</module>
-        <module>se/groovy-numberguess</module>
+        <!-- Disabled because in JDK 9+, Groovy doesn't work yet - TODO -->
+        <!--<module>se/groovy-numberguess</module>-->
         <module>osgi</module>
-        <module>webstart</module>
+        <!-- Disabled because in JDK 9+, the signing process fails - TODO -->
+        <!--<module>webstart</module>-->
     </modules>
 
     <properties>
         <jsf.version>2.1</jsf.version>
         <facelets.version>1.1.15</facelets.version>
-        <wildfly.plugin.version>1.1.0.Final</wildfly.plugin.version>
+        <wildfly.plugin.version>1.2.1.Final</wildfly.plugin.version>
         <uel.version>2.2</uel.version>
         <ftest.sources.directory>src/ftest/java</ftest.sources.directory>
         <ftest.resources.directory>src/ftest/resources</ftest.resources.directory>
@@ -176,6 +178,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-ejb-plugin</artifactId>
+                    <version>3.0.0</version>
                     <configuration>
                         <ejbVersion>3.2</ejbVersion>
                     </configuration>
@@ -183,13 +186,14 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-ear-plugin</artifactId>
-                    <version>2.9</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <!-- Work around issues encountered with http://jira.codehaus.org/browse/MWAR-187
                     during release -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
+                    <version>3.2.0</version>
                     <configuration>
                         <useCache>false</useCache>
                     </configuration>

--- a/examples/se/groovy-numberguess/pom.xml
+++ b/examples/se/groovy-numberguess/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-   <parent>
+    <parent>
         <artifactId>weld-examples-parent</artifactId>
         <groupId>org.jboss.weld.examples</groupId>
         <version>3.0.5-SNAPSHOT</version>
@@ -22,63 +22,71 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
-        <groovy.version>2.3.9</groovy.version>         
-        <groovy-eclipse-compiler.version>2.9.1-01</groovy-eclipse-compiler.version>
-        <groovy-eclipse-batch.version>2.3.7-01</groovy-eclipse-batch.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.jboss.weld.se</groupId>
-            <artifactId>weld-se-core</artifactId>
+            <artifactId>weld-se-shaded</artifactId>
         </dependency>
         
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
         </dependency>
     </dependencies>
 
     <build>
-         <pluginManagement>
-             <plugins>
+        <pluginManagement>
+            <plugins>
                 <plugin>
-                   <artifactId>maven-compiler-plugin</artifactId>
-                   <version>${maven-compiler-plugin.version}</version>
-                   <configuration>
-                    <compilerId>groovy-eclipse-compiler</compilerId>
-                   </configuration>
-                   <dependencies>
-                    <dependency>
-                      <groupId>org.codehaus.groovy</groupId>
-                      <artifactId>groovy-eclipse-compiler</artifactId>
-                      <version>${groovy-eclipse-compiler.version}</version>
-                    </dependency>
-     
-                    <dependency>
-                      <groupId>org.codehaus.groovy</groupId>
-                      <artifactId>groovy-eclipse-batch</artifactId>
-                      <version>${groovy-eclipse-batch.version}</version>
-                    </dependency>
-                   </dependencies>
-                 </plugin>
-        
-        
-                <plugin>
-                 <groupId>org.apache.maven.plugins</groupId>
-                 <artifactId>maven-jar-plugin</artifactId>
-                 <configuration>
-                    <archive>
-                        <manifest>
-                            <mainClass>org.jboss.weld.environment.se.StartMain</mainClass>
-                        </manifest>
-                    </archive>
-                 </configuration>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifest>
+                                <mainClass>org.jboss.weld.environment.se.StartMain</mainClass>
+                            </manifest>
+                        </archive>
+                    </configuration>
                 </plugin>
-             </plugins>
+            </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.gmavenplus</groupId>
+                <artifactId>gmavenplus-plugin</artifactId>
+                <version>1.6</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>addSources</goal>
+                            <goal>addTestSources</goal>
+                            <goal>generateStubs</goal>
+                            <goal>compile</goal>
+                            <goal>generateTestStubs</goal>
+                            <goal>compileTests</goal>
+                            <goal>removeStubs</goal>
+                            <goal>removeTestStubs</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sources>
+                        <source>
+                            <directory>${project.basedir}/src/main/java</directory>
+                            <includes>
+                                <include>**/*.groovy</include>
+                            </includes>
+                        </source>
+                    </sources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>
@@ -103,6 +111,7 @@
                         </executions>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
                         <configuration>
                             <mainClass>org.jboss.weld.environment.se.StartMain</mainClass>
                         </configuration>
@@ -110,6 +119,6 @@
                 </plugins>
             </build>
         </profile>
-     </profiles>
+    </profiles>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <spotbugs-maven-plugin.version>3.1.1</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>3.1.1</spotbugs-annotations-version>
         <glassfish.el.version>2.1.2-b04</glassfish.el.version>
+        <groovy.version>2.4.15</groovy.version>
         <htmlunit.version>2.20</htmlunit.version>
         <jacoco.version>0.7.9</jacoco.version>
         <jandex.version>2.0.3.Final</jandex.version>
@@ -114,6 +115,12 @@
                 <artifactId>bcel</artifactId>
                 <version>${apache.bcel.version}</version>
                 <optional>true</optional>
+            </dependency>
+
+            <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${groovy.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
**Not to be merged**, this is a tracking PR for changes needed in Weld examples for JDK 9+

Some of the dep updates should go to parent.
Groovy + webstart are disabled altogether as I am not sure how to fix and if it's worth fixing in the first place.