### PR TITLE
WELD-2498 Fix test deployments which fail because of this issue.

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/conversation/timeout/concurrent/ConversationLockTimeoutTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/conversation/timeout/concurrent/ConversationLockTimeoutTest.java
@@ -85,12 +85,7 @@ public class ConversationLockTimeoutTest {
         final Future<String> longTaskFuture = executorService.submit(longTask);
         Timer timer = Timer.startNew(1000l);
         final Future<String> busyRequestFuture = executorService.submit(busyRequest);
-        timer.setSleepInterval(100l).setDelay(2, TimeUnit.SECONDS).addStopCondition(new Timer.StopCondition() {
-            @Override
-            public boolean isSatisfied() {
-                return longTaskFuture.isDone() || busyRequestFuture.isDone();
-            }
-        }).start();
+        timer.setSleepInterval(100l).setDelay(2, TimeUnit.SECONDS).addStopCondition(() -> longTaskFuture.isDone() || busyRequestFuture.isDone()).start();
 
         Assert.assertEquals("OK", longTaskFuture.get());
         Assert.assertEquals("Conversation locked", busyRequestFuture.get());

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanConfiguratorFailureTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanConfiguratorFailureTest.java
@@ -41,7 +41,8 @@ public class BeanConfiguratorFailureTest {
     @Deployment
     public static WebArchive createTestArchive() {
         return ShrinkWrap.create(WebArchive.class, Utils.getDeploymentNameAsHash(BeanConfiguratorFailureTest.class, Utils.ARCHIVE_TYPE.WAR))
-                .addPackage(BeanConfiguratorFailureTest.class.getPackage()).addAsServiceProvider(Extension.class, BrokenExtension.class)
+                .addClasses(BeanConfiguratorFailureTest.class, VetoedBean.class, BrokenExtension.class, CoolStereotype.class)
+                .addAsServiceProvider(Extension.class, BrokenExtension.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanConfiguratorWithNoCallbackTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanConfiguratorWithNoCallbackTest.java
@@ -40,7 +40,8 @@ public class BeanConfiguratorWithNoCallbackTest {
     @ShouldThrowException(DeploymentException.class)
     public static WebArchive createTestArchive() {
         return ShrinkWrap.create(WebArchive.class, Utils.getDeploymentNameAsHash(BeanConfiguratorWithNoCallbackTest.class, Utils.ARCHIVE_TYPE.WAR))
-            .addPackage(BeanConfiguratorFailureTest.class.getPackage()).addAsServiceProvider(Extension.class, IncorrectCustomBeanExtension.class)
+            .addClasses(BeanConfiguratorWithNoCallbackTest.class, IncorrectCustomBeanExtension.class, Charlie.class)
+            .addAsServiceProvider(Extension.class, IncorrectCustomBeanExtension.class)
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
     


### PR DESCRIPTION
This basically puts those three tests back into a state where they are unaffected by WELD-2498 (no anonymous class deployed to server) so that their failures don't hinder our CI test results.

Fix and test for the issue itself will be in a separate PR.