### PR TITLE
[WELD-2435] Moved WeldProvider to Servlet Core module

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/WeldProvider.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/WeldProvider.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.weld.environment;
+package org.jboss.weld.environment.servlet;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/environments/servlet/core/src/main/resources/META-INF/services/javax.enterprise.inject.spi.CDIProvider
+++ b/environments/servlet/core/src/main/resources/META-INF/services/javax.enterprise.inject.spi.CDIProvider
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-org.jboss.weld.environment.WeldProvider
+org.jboss.weld.environment.servlet.WeldProvider


### PR DESCRIPTION
WeldProvider is only used and referenced by Servlet Core it doesn't make sense to keep it into commons anymore.

Note: SE already has its own provider implementation.