### PR TITLE
Ignores .factorypath files in all project modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .project
 .classpath
 .settings
+.factorypath
 *.ipr
 .idea
 *.iws

--- a/environments/se/core/.gitignore
+++ b/environments/se/core/.gitignore
@@ -1,1 +1,0 @@
-/.factorypath

--- a/environments/se/tests/.gitignore
+++ b/environments/se/tests/.gitignore
@@ -1,4 +1,3 @@
-/.factorypath
 .project
 .settings
 .classpath


### PR DESCRIPTION
These files seem to be commonly generated in projects that are edited in VS Code (which uses headless Eclipse under the covers).