### PR TITLE
WELD-1130: Prevent setting a null instance as an attribute

### DIFF
--- a/impl/src/main/java/org/jboss/weld/context/beanstore/http/AbstractSessionBeanStore.java
+++ b/impl/src/main/java/org/jboss/weld/context/beanstore/http/AbstractSessionBeanStore.java
@@ -87,7 +87,7 @@ public abstract class AbstractSessionBeanStore extends AttributeBeanStore {
             String prefixedId = getNamingScheme().prefix(id);
             instance = cast(getAttribute(prefixedId));
         }
-        if (resetHttpSessionAttributeOnBeanAccess){
+        if (resetHttpSessionAttributeOnBeanAccess && instance != null){
             put(id, instance);
         }
         return instance;


### PR DESCRIPTION
I had a report of an NPE being thrown when resetHttpSessionAttributeOnBeanAccess is enabled. I was able to recreate locally and it looks like a simple null check to prevent AbstractSessionBeanStore from trying to set the attribute before it is created is sufficient. 