### PR TITLE
Based on CDITCK-624 we need to update our 1.2 TCK exclude list.

### DIFF
--- a/jboss-tck-runner/src/test/tck12/tck-tests.xml
+++ b/jboss-tck-runner/src/test/tck12/tck-tests.xml
@@ -39,6 +39,15 @@
                 </methods>
             </class>
 
+            <!-- CDITCK-624 -->
+            <class name="org.jboss.cdi.tck.tests.lookup.injection.non.contextual.ContainerEventTest">
+                <methods>
+                    <exclude name="testProcessAnnotatedTypeEventFiredForTagLibraryListener"/>
+                    <exclude name="testProcessAnnotatedTypeEventFiredForServletListener"/>
+                    <exclude name="testProcessAnnotatedTypeEventFiredForFilter"/>
+                </methods>
+            </class>
+
             <!-- Issues in the TCK -->
 
             <!-- changes in Weld 3 which were not reflected in TCK yet -->


### PR DESCRIPTION
TCK issue - https://issues.jboss.org/browse/CDITCK-624
TCK PR - https://github.com/cdi-spec/cdi-tck/pull/178