### PR TITLE
Make RequestScopeEventMessageDeliveryTest use CountDownLatch.

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/AbstractMessageListener.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/AbstractMessageListener.java
@@ -32,12 +32,16 @@ public class AbstractMessageListener implements MessageListener {
     @Inject
     private RequestScopedObserver observer;
 
+    @Inject
+    private Controller controller;
+
     @Override
     public void onMessage(Message message) {
 
         if (message instanceof TextMessage) {
             processedMessages.incrementAndGet();
             initializedEventObserver.set(observer.isInitializedObserved());
+            controller.getMsgDeliveredLatch().countDown();
         } else {
             throw new IllegalArgumentException("Unsupported message type");
         }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/ApplicationScopedObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/ApplicationScopedObserver.java
@@ -22,14 +22,20 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.context.Destroyed;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.event.Observes;
+import javax.inject.Inject;
 
 @ApplicationScoped
 public class ApplicationScopedObserver {
 
     private final AtomicBoolean destroyedCalled = new AtomicBoolean();
 
+    @Inject
+    private Controller controller;
+
     void observeRequestDestroyed(@Observes @Destroyed(RequestScoped.class) Object event) {
         destroyedCalled.set(true);
+        controller.getContextDestroyedLatch().countDown();
+
     }
 
     boolean isDestroyedCalled() {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/Controller.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/Controller.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.resources.proxy.weld1782;
+
+import java.util.concurrent.CountDownLatch;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class Controller {
+
+    private CountDownLatch msgDeliveredLatch = new CountDownLatch(1);
+    private CountDownLatch contextDestroyedLatch = new CountDownLatch(1);
+
+    public CountDownLatch getMsgDeliveredLatch() {
+        return msgDeliveredLatch;
+    }
+
+    public CountDownLatch getContextDestroyedLatch() {
+        return contextDestroyedLatch;
+    }
+
+    public void resetLatches() {
+        msgDeliveredLatch = new CountDownLatch(1);
+        contextDestroyedLatch = new CountDownLatch(1);
+    }
+}


### PR DESCRIPTION
Not sure this is actually useful - I've seen some weird intermittent failures on Jenkins with previous solution using `Timer`. Maybe countdown latch will help a bit...