### PR TITLE
WELD-2502 Do not force quit SE applications with success code, defaul…

### DIFF
--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/StartMain.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/StartMain.java
@@ -55,7 +55,6 @@ public class StartMain {
     public static void main(String[] args) {
         try {
             new StartMain(args).go();
-            System.exit(0);
         } catch(Throwable t) {
             WeldSELogger.LOG.error("Application exited with an exception", t);
             System.exit(1);


### PR DESCRIPTION
…t behaviour should take care of that.

This change breaks any app which hooks into container lifecycle and then runs in another thread (e.g. Swing app) - for instance our Groovy SE sample.
Removing the line should not affect the exit code as Java always returns 0 unless killed as a process.