### PR TITLE
Allow usage of InterceptionFactory  on interfaces

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -903,6 +903,10 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
         return true;
     }
 
+    protected Class<?> getProxiedBeanType() {
+        return proxiedBeanType;
+    }
+
     /**
      * @return {@code true} if {@link #CONSTRUCTED_FLAG_NAME} should be used
      */

--- a/impl/src/main/java/org/jboss/weld/injection/InterceptionFactoryImpl.java
+++ b/impl/src/main/java/org/jboss/weld/injection/InterceptionFactoryImpl.java
@@ -112,10 +112,6 @@ public class InterceptionFactoryImpl<T> implements InterceptionFactory<T> {
         }
         used = true;
 
-        if (annotatedType.getJavaClass().isInterface()) {
-            throw InterceptorLogger.LOG.interceptionFactoryNotOnInstance(annotatedType.getJavaClass().getCanonicalName());
-        }
-
         Optional<InterceptionFactoryData<T>> cached = beanManager.getServices().get(InterceptionFactoryDataCache.class)
                 .getInterceptionFactoryData(configurator != null ? configurator.complete() : annotatedType);
 

--- a/impl/src/main/java/org/jboss/weld/logging/InterceptorLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/InterceptorLogger.java
@@ -78,7 +78,4 @@ public interface InterceptorLogger extends WeldLogger {
     @Message(id = 1710, value = "InterceptionFactory skipped wrapper creation for an internal container construct of type {0}", format = Format.MESSAGE_FORMAT)
     void interceptionFactoryInternalContainerConstruct(Object type);
 
-    @Message(id = 1711, value = "InterceptionFactory is not supported on interfaces. Check InterceptionFactory<{0}>", format= Format.MESSAGE_FORMAT)
-    IllegalStateException interceptionFactoryNotOnInstance(Object param1);
-
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/InterceptionFactoryTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/InterceptionFactoryTest.java
@@ -31,7 +31,6 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.weld.exceptions.IllegalStateException;
 import org.jboss.weld.test.util.Utils;
 import org.jboss.weld.tests.interceptors.producer.Producer.Bar;
 import org.jboss.weld.tests.interceptors.producer.Producer.Foo;
@@ -93,17 +92,13 @@ public class InterceptionFactoryTest {
     }
 
     @Test
-    public void testListAdd(@Produced Instance<List<Object>> lists) {
-        // resolving via Instance just to make the NPE exception human-readable (direct method injection will blow up with Arq. stack)
-        // Invalid producer using an InterceptionFactory for List (interface) and applying it to ArrayList
-        try {
-            lists.get();
-            fail();
-        } catch (IllegalStateException e) {
-            //Expected
-        }
+    public void testListAdd(@Produced List<Object> list) {
+    	list.add("pang");
+        assertEquals(1, Producer.INVOCATIONS.size());
+        assertEquals(Arrays.toString(new String[] { "pang" }), Producer.INVOCATIONS.get(0));
+        assertEquals(3, list.size());
+        assertEquals(1, Producer.INVOCATIONS.size()); // list.size() should not be intercepted
     }
-
 
     @Test
     public void testParent(@Produced Producer.FooParent foo) {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/Producer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/producer/Producer.java
@@ -18,6 +18,7 @@
 package org.jboss.weld.tests.interceptors.producer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +100,7 @@ public class Producer {
             }
             return false;
         }).findFirst().get().add(Monitor.Literal.INSTANCE);
-        return interceptionFactory.createInterceptedInstance(new ArrayList<>());
+        return interceptionFactory.createInterceptedInstance(new ArrayList<>(Arrays.asList("ping", "pong")));
     }
 
 


### PR DESCRIPTION
In case you change your mind about [CDI-686](https://issues.jboss.org/browse/CDI-686), I modified `InterceptedProxyFactory` to proxy methods even if the proxied bean type is an interface.