### PR TITLE
Tomcat versions prior to 9.0.12 have known security vulnerability, bu…

### DIFF
--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <jsf.version>2.3</jsf.version>
-        <tomcat.version>9.0.11</tomcat.version>
+        <tomcat.version>9.0.12</tomcat.version>
         <jetty.version>9.3.6.v20151106</jetty.version>
         <jetty9.asm.version>5.0.3</jetty9.asm.version>
         <!-- Jetty 6 API is used for GWT support only -->

--- a/probe/tests/pom.xml
+++ b/probe/tests/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <json.version>1.1.2</json.version>
         <json.path.version>2.4.0</json.path.version>
-        <tomcat.version>9.0.11</tomcat.version>
+        <tomcat.version>9.0.12</tomcat.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
…mp versions.

We only use this for testing, but GH bot keep complaining about sec. vulnerability of older versions.
So long as tests pass, we might as well bump it.