### PR TITLE
WELD-2497 Context propagation for built-in scopes.

### DIFF
--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/AbstractBeanWithState.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/AbstractBeanWithState.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.se.test.context.propagation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A template for beans of all scopes which makes sure they have some state on which to assert propagation. AtomicInteger is
+ * used to assure concurrent access isn't skewed.
+ *
+ * The bean also provides a plain ping() method just to be able to trigger lazy creation.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public abstract class AbstractBeanWithState {
+
+    private AtomicInteger counter = new AtomicInteger(0);
+
+    public AtomicInteger getCounter() {
+        return counter;
+    }
+
+    public int getValue() {
+        return counter.get();
+    }
+
+    public void incrementCounter() {
+        counter.incrementAndGet();
+    }
+
+    public void ping() {
+        // no-op
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/AppScopedBean.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/AppScopedBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.se.test.context.propagation;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class AppScopedBean extends AbstractBeanWithState {
+
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/ContextPropagationSEService.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/ContextPropagationSEService.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.se.test.context.propagation;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.jboss.weld.context.WeldAlterableContext;
+import org.jboss.weld.context.api.ContextualInstance;
+import org.jboss.weld.context.bound.BoundLiteral;
+import org.jboss.weld.context.bound.BoundRequestContext;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.manager.api.WeldManager;
+
+/**
+ * Util class allowing to offload tasks to another thread. Takes case of context activation/propagation for req. scope (in SE).
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class ContextPropagationSEService {
+
+    private static final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+    public static <T> Future<T> propagateContextsAndSubmitTask(Callable<T> task) {
+        // gather all the contexts we want to propagate and the instances in them
+        Map<Class<? extends Annotation>, Collection<ContextualInstance<?>>> scopeToContextualInstances = new HashMap<>();
+        for (WeldAlterableContext context : WeldContainer.current().select(WeldManager.class).get().getActiveWeldAlterableContexts()) {
+            scopeToContextualInstances.put(context.getScope(), context.getAllContextualInstances());
+        }
+        // We create a task wrapper which will make sure we have contexts propagated
+        Callable<T> wrappedTask = new Callable<T>() {
+
+            @Override
+            public T call() throws Exception {
+                WeldContainer container = WeldContainer.current();
+                WeldManager weldManager = container.select(WeldManager.class).get();
+                BoundRequestContext requestContext = weldManager.instance().select(BoundRequestContext.class, BoundLiteral.INSTANCE).get();
+
+                // we will be using bound context, prepare backing map
+                Map<String, Object> requestMap = new HashMap<>();
+
+                // activate request context
+                requestContext.associate(requestMap);
+                requestContext.activate();
+
+                // propagate req. context
+                if (scopeToContextualInstances.get(requestContext.getScope()) != null) {
+                    requestContext.clearAndSet(scopeToContextualInstances.get(requestContext.getScope()));
+                }
+                // now execute the actual original task
+                T result = task.call();
+
+                // cleanup, context deactivation
+                // requestContext.invalidate(); is deliberately left out so that pre destroy callbacks are not invoked
+                requestContext.deactivate();
+
+                // all done, return
+                return result;
+            }
+        };
+        return executor.submit(wrappedTask);
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/ContextPropagationSETest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/ContextPropagationSETest.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.se.test.context.propagation;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.enterprise.context.control.RequestContextController;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Since this test runs in SE, we can only test Application and Request scopes
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RunWith(Arquillian.class)
+public class ContextPropagationSETest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ClassPath.builder()
+            .add(ShrinkWrap.create(BeanArchive.class)
+                .addPackage(ContextPropagationSETest.class.getPackage())).build();
+    }
+
+    @Test
+    public void testRequestScopedBean() {
+        try (WeldContainer container = new Weld().initialize()) {
+            // in SE we need to controll req context activation/deactivation
+            RequestContextController controller = container.select(RequestContextController.class).get();
+            controller.activate();
+
+            Future<Integer> futureResult = pingBeanAndOffloadTask(container, ReqScopedBean.class);
+            // block until we have result
+            try {
+                Integer result = futureResult.get();
+                controller.deactivate();
+                Assert.assertEquals(2, result.intValue());
+            } catch (InterruptedException e) {
+                Assert.fail("Encountered InterruptedException while waiting for result from a different thread!");
+            } catch (ExecutionException e) {
+                Assert.fail(e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void testApplicationScopedBean() {
+        try (WeldContainer container = new Weld().initialize()) {
+            // with app scope, no propagation is needed, it all works out of the box
+            Future<Integer> futureResult = pingBeanAndOffloadTask(container, AppScopedBean.class);
+            // block until we have result
+            try {
+                Integer result = futureResult.get();
+                Assert.assertEquals(2, result.intValue());
+            } catch (InterruptedException e) {
+                Assert.fail("Encountered InterruptedException while waiting for result from a different thread!");
+            } catch (ExecutionException e) {
+                Assert.fail(e.toString());
+            }
+        }
+    }
+
+    private Future<Integer> pingBeanAndOffloadTask(WeldContainer container, Class<? extends AbstractBeanWithState> beanClazz) {
+        // use the bean in this thread first - set counter to one
+        AbstractBeanWithState bean = container.select(beanClazz).get();
+        Assert.assertEquals(0, bean.getValue());
+        bean.incrementCounter();
+        Assert.assertEquals(1, bean.getValue());
+
+        // prepare a callable which will further increase the counter and return the value we gave there
+        Callable<Integer> callableTask = () -> {
+            WeldContainer weldContainer = WeldContainer.current();
+            // app context is always active and there is no need to propagate it - works out of the box
+            AbstractBeanWithState beanInCallable = weldContainer.select(beanClazz).get();
+            beanInCallable.incrementCounter();
+            return beanInCallable.getValue();
+        };
+        return ContextPropagationSEService.propagateContextsAndSubmitTask(callableTask);
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/ReqScopedBean.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/context/propagation/ReqScopedBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.se.test.context.propagation;
+
+import javax.enterprise.context.RequestScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RequestScoped
+public class ReqScopedBean extends AbstractBeanWithState {
+
+}

--- a/impl/src/main/java/org/jboss/weld/contexts/AbstractContext.java
+++ b/impl/src/main/java/org/jboss/weld/contexts/AbstractContext.java
@@ -195,4 +195,8 @@ public abstract class AbstractContext implements AlterableContext {
     protected void checkContextInitialized() {
     }
 
+    protected boolean isMultithreaded() {
+        return multithreaded;
+    }
+
 }

--- a/impl/src/main/java/org/jboss/weld/contexts/unbound/RequestContextImpl.java
+++ b/impl/src/main/java/org/jboss/weld/contexts/unbound/RequestContextImpl.java
@@ -7,6 +7,12 @@ import org.jboss.weld.contexts.beanstore.HashMapBeanStore;
 import javax.enterprise.context.RequestScoped;
 
 import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.weld.context.api.ContextualInstance;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
 
 public class RequestContextImpl extends AbstractUnboundContext implements RequestContext {
 
@@ -32,4 +38,20 @@ public class RequestContextImpl extends AbstractUnboundContext implements Reques
         cleanup();
     }
 
+    @Override
+    public Collection<ContextualInstance<?>> getAllContextualInstances() {
+        Set<ContextualInstance<?>> result = new HashSet<>();
+        getBeanStore().iterator().forEachRemaining((BeanIdentifier beanId) -> {
+            result.add(getBeanStore().get(beanId));
+        });
+        return result;
+    }
+
+    @Override
+    public void clearAndSet(Collection<ContextualInstance<?>> setOfInstances) {
+        getBeanStore().clear();
+        for (ContextualInstance<?> contextualInstance : setOfInstances) {
+            getBeanStore().put(getId(contextualInstance.getContextual()), contextualInstance);
+        }
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <shrinkwrap.resolver.version>2.2.6</shrinkwrap.resolver.version>
         <testng.version>6.14.3</testng.version>
         <testng.jcommander.version>1.74</testng.jcommander.version>
-        <weld.api.version>3.1.Alpha1</weld.api.version>
+        <weld.api.version>3.1.Beta1</weld.api.version>
         <weld.logging.tools.version>1.0.2.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>2.1.1.Final</wildfly.arquillian.version>
         <!--Temportary version override, once alligned in WFLY-Arq adapter, we can remove this-->

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/AbstractBeanWithState.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/AbstractBeanWithState.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.propagation;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A template for beans of all scopes which makes sure they have some state on which to assert propagation. AtomicInteger is
+ * used to assure concurrent access isn't skewed.
+ *
+ * The bean also provides a plain ping() method just to be able to trigger lazy creation.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public abstract class AbstractBeanWithState {
+
+    private AtomicInteger counter = new AtomicInteger(0);
+
+    public AtomicInteger getCounter() {
+        return counter;
+    }
+
+    public int getValue() {
+        return counter.get();
+    }
+
+    public void incrementCounter() {
+        counter.incrementAndGet();
+    }
+
+    public void ping() {
+        // no-op
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/AppScopedBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/AppScopedBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.propagation;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ApplicationScoped
+public class AppScopedBean extends AbstractBeanWithState {
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ContextPropagationService.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ContextPropagationService.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.propagation;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import javax.enterprise.inject.spi.CDI;
+
+import org.jboss.weld.context.WeldAlterableContext;
+import org.jboss.weld.context.api.ContextualInstance;
+import org.jboss.weld.context.bound.BoundConversationContext;
+import org.jboss.weld.context.bound.BoundLiteral;
+import org.jboss.weld.context.bound.BoundRequest;
+import org.jboss.weld.context.bound.BoundRequestContext;
+import org.jboss.weld.context.bound.BoundSessionContext;
+import org.jboss.weld.context.bound.MutableBoundRequest;
+import org.jboss.weld.manager.api.WeldManager;
+
+/**
+ * Util class allowing to offload tasks to another thread. Takes care of context activation/propagation.
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+public class ContextPropagationService {
+
+    private static final ExecutorService executor = Executors.newFixedThreadPool(1);
+
+    public static <T> Future<T> propagateContextsAndSubmitTask(Callable<T> task) {
+        // gather all the contexts we want to propagate and the instances in them
+        Map<Class<? extends Annotation>, Collection<ContextualInstance<?>>> scopeToContextualInstances = new HashMap<>();
+        for (WeldAlterableContext context : CDI.current().select(WeldManager.class).get().getActiveWeldAlterableContexts()) {
+            scopeToContextualInstances.put(context.getScope(), context.getAllContextualInstances());
+        }
+        // We create a task wrapper which will make sure we have contexts propagated
+        Callable<T> wrappedTask = new Callable<T>() {
+
+            @Override
+            public T call() throws Exception {
+                WeldManager weldManager = CDI.current().select(WeldManager.class).get();
+                BoundRequestContext requestContext = weldManager.instance().select(BoundRequestContext.class, BoundLiteral.INSTANCE).get();
+                BoundSessionContext sessionContext = weldManager.instance().select(BoundSessionContext.class, BoundLiteral.INSTANCE).get();
+                BoundConversationContext conversationContext = weldManager.instance().select(BoundConversationContext.class, BoundLiteral.INSTANCE).get();
+
+                // we will be using bound contexts, prepare backing structures for contexts
+                Map<String, Object> sessionMap = new HashMap<>();
+                Map<String, Object> requestMap = new HashMap<>();
+                BoundRequest boundRequest = new MutableBoundRequest(requestMap, sessionMap);
+
+                // activate contexts
+                requestContext.associate(requestMap);
+                requestContext.activate();
+                sessionContext.associate(sessionMap);
+                sessionContext.activate();
+                conversationContext.associate(boundRequest);
+                conversationContext.activate();
+
+                // propagate all contexts that have some bean in them
+                if (scopeToContextualInstances.get(requestContext.getScope()) != null) {
+                    requestContext.clearAndSet(scopeToContextualInstances.get(requestContext.getScope()));
+                }
+                if (scopeToContextualInstances.get(sessionContext.getScope()) != null) {
+                    sessionContext.clearAndSet(scopeToContextualInstances.get(sessionContext.getScope()));
+                }
+                if (scopeToContextualInstances.get(conversationContext.getScope()) != null) {
+                    conversationContext.clearAndSet(scopeToContextualInstances.get(conversationContext.getScope()));
+                }
+
+                // now execute the actual original task
+                T result = task.call();
+
+                // cleanup, context deactivation
+                // context.invalidate() is deliberately left out so as to avoid calling all pre destroy/disposer callbacks
+                // propagators might choose to invoke them but it could lead to these methods being invoked multiple times
+                // while the bean is still 'alive' in yet another thread into which it was propagated
+                requestContext.deactivate();
+                conversationContext.deactivate();
+                sessionContext.deactivate();
+
+                // all done, return
+                return result;
+            }
+        };
+        return executor.submit(wrappedTask);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ContextPropagationTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ContextPropagationTest.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.propagation;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.weld.manager.api.WeldManager;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test verifies context propagation using an executor service with one thread to which we offload some Callable. Callable is
+ * wrapped and automatically handles context activation and propagation. Propagation uses bound contexts.
+ *
+ * NOTE: Arquillian JMX protocol (default) means that request, session and conversation contexts that will be active will be
+ * {@code @Bound} contexts (for instance {@code BoundRequestContextImpl}). Switching this protocol to Servlet will force the use
+ * of respective HTTP variant of contexts. To do that, edit {@code wildfly-arquillian.xml} with
+ * {@code <defaultProtocol type="Servlet 3.0" />}
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RunWith(Arquillian.class)
+public class ContextPropagationTest {
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        return ShrinkWrap.create(WebArchive.class, Utils.getDeploymentNameAsHash(ContextPropagationTest.class, Utils.ARCHIVE_TYPE.WAR))
+            .addPackage(ContextPropagationTest.class.getPackage())
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    WeldManager manager;
+
+    @Test
+    public void testRequestScopedBean() {
+        pingBeanAndOffloadTask(manager, ReqScopedBean.class);
+    }
+
+    @Test
+    public void testApplicationScopedBean() {
+        // with app scope, no propagation is needed, it all works out of the box
+        pingBeanAndOffloadTask(manager, AppScopedBean.class);
+    }
+
+    @Test
+    public void testSessionScopedBean() {
+        pingBeanAndOffloadTask(manager, SessionScopedBean.class);
+    }
+
+    @Test
+    public void testConversationScopedBean() {
+        pingBeanAndOffloadTask(manager, ConversationScopedBean.class);
+    }
+
+    private void pingBeanAndOffloadTask(WeldManager manager, Class<? extends AbstractBeanWithState> beanClazz) {
+        // use the bean in this thread first - set counter to one
+        AbstractBeanWithState bean = manager.instance().select(beanClazz).get();
+        Assert.assertEquals(0, bean.getValue());
+        bean.incrementCounter();
+        Assert.assertEquals(1, bean.getValue());
+
+        // prepare a callable which will further increase the counter and return the value we gave there
+        Callable<Integer> callableTask = () -> {
+            // app context is always active and there is no need to propagate it - works out of the box
+            AbstractBeanWithState beanInCallable = CDI.current().select(beanClazz).get();
+            beanInCallable.incrementCounter();
+            return beanInCallable.getValue();
+        };
+        Future<Integer> futureResult = ContextPropagationService.propagateContextsAndSubmitTask(callableTask);
+        // block until we have result
+        try {
+            Integer result = futureResult.get();
+            Assert.assertEquals(2, result.intValue());
+        } catch (InterruptedException e) {
+            Assert.fail("Encountered InterruptedException while waiting for result from a different thread!");
+        } catch (ExecutionException e) {
+            Assert.fail(e.toString());
+        }
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ConversationScopedBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ConversationScopedBean.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.propagation;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.ConversationScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@ConversationScoped
+public class ConversationScopedBean extends AbstractBeanWithState implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ReqScopedBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/ReqScopedBean.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.propagation;
+
+import javax.enterprise.context.RequestScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@RequestScoped
+public class ReqScopedBean extends AbstractBeanWithState {
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/SessionScopedBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation/SessionScopedBean.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.propagation;
+
+import java.io.Serializable;
+
+import javax.enterprise.context.SessionScoped;
+
+/**
+ *
+ * @author <a href="mailto:manovotn@redhat.com">Matej Novotny</a>
+ */
+@SessionScoped
+public class SessionScopedBean extends AbstractBeanWithState implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+}


### PR DESCRIPTION
A basis PR for discussions around context propagation in Weld (WELD-2497)

Shows propagation for buillt-in contexts (req., session, conversation + application).
There are two very similar tests, in SE and in EE.
Both test the same thing however note that for instance `RequestContext` implementation in SE differs versus that in EE (unbound versus bound versus HTTP). Also only subset of scopes can be used in SE.