### PR TITLE
WELD-2508 Give Weld-specific methods on proxies prefixed names to avo…

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/builtin/InstanceImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/InstanceImpl.java
@@ -172,8 +172,8 @@ public class InstanceImpl<T> extends AbstractFacade<T, Instance<T>> implements W
         // Attempt to destroy instance which is either a client proxy or a dependent session bean proxy
         if (instance instanceof ProxyObject) {
             ProxyObject proxy = (ProxyObject) instance;
-            if (proxy.getHandler() instanceof ProxyMethodHandler) {
-                ProxyMethodHandler handler = (ProxyMethodHandler) proxy.getHandler();
+            if (proxy.weld_getHandler() instanceof ProxyMethodHandler) {
+                ProxyMethodHandler handler = (ProxyMethodHandler) proxy.weld_getHandler();
                 Bean<?> bean = handler.getBean();
                 if (isSessionBeanProxy(instance) && Dependent.class.equals(bean.getScope())) {
                     // Destroy internal reference to a dependent session bean

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/DecoratorProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/DecoratorProxyFactory.java
@@ -263,7 +263,7 @@ public class DecoratorProxyFactory<T> extends ProxyFactory<T> {
 
         public void getDeclaredMethod(ClassMethod classMethod, String declaringClass, String methodName, String[] parameterTypes, ClassMethod staticConstructor) {
             // get the correct class type to use to resolve the method
-            MethodInformation methodInfo = new StaticMethodInformation("getTargetClass", new String[0], LJAVA_LANG_CLASS, TargetInstanceProxy.class.getName());
+            MethodInformation methodInfo = new StaticMethodInformation("weld_getTargetClass", new String[0], LJAVA_LANG_CLASS, TargetInstanceProxy.class.getName());
             invokeMethodHandler(classMethod, methodInfo, false, DEFAULT_METHOD_RESOLVER, staticConstructor);
             CodeAttribute code = classMethod.getCodeAttribute();
             code.checkcast("java/lang/Class");

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
@@ -477,15 +477,15 @@ public class InterceptedSubclassFactory<T> extends ProxyFactory<T> {
                 MethodInformation methodInfo = new RuntimeMethodInformation(method);
                 createInterceptorBody(proxyClassType.addMethod(method), methodInfo, false, staticConstructor);
             }
-            Method getInstanceMethod = TargetInstanceProxy.class.getMethod("getTargetInstance");
-            Method getInstanceClassMethod = TargetInstanceProxy.class.getMethod("getTargetClass");
+            Method getInstanceMethod = TargetInstanceProxy.class.getMethod("weld_getTargetInstance");
+            Method getInstanceClassMethod = TargetInstanceProxy.class.getMethod("weld_getTargetClass");
             generateGetTargetInstanceBody(proxyClassType.addMethod(getInstanceMethod));
             generateGetTargetClassBody(proxyClassType.addMethod(getInstanceClassMethod));
 
-            Method setMethodHandlerMethod = ProxyObject.class.getMethod("setHandler", MethodHandler.class);
+            Method setMethodHandlerMethod = ProxyObject.class.getMethod("weld_setHandler", MethodHandler.class);
             generateSetMethodHandlerBody(proxyClassType.addMethod(setMethodHandlerMethod));
 
-            Method getMethodHandlerMethod = ProxyObject.class.getMethod("getHandler");
+            Method getMethodHandlerMethod = ProxyObject.class.getMethod("weld_getHandler");
             generateGetMethodHandlerBody(proxyClassType.addMethod(getMethodHandlerMethod));
        } catch (Exception e) {
             throw new WeldException(e);

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -314,7 +314,7 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
      */
     public T create(BeanInstance beanInstance) {
         final T proxy = (System.getSecurityManager() == null) ? run() : AccessController.doPrivileged(this);
-        ((ProxyObject) proxy).setHandler(new ProxyMethodHandler(contextId, beanInstance, bean));
+        ((ProxyObject) proxy).weld_setHandler(new ProxyMethodHandler(contextId, beanInstance, bean));
         return proxy;
     }
 
@@ -392,7 +392,7 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
     public static <T> void setBeanInstance(String contextId, T proxy, BeanInstance beanInstance, Bean<?> bean) {
         if (proxy instanceof ProxyObject) {
             ProxyObject proxyView = (ProxyObject) proxy;
-            proxyView.setHandler(new ProxyMethodHandler(contextId, beanInstance, bean));
+            proxyView.weld_setHandler(new ProxyMethodHandler(contextId, beanInstance, bean));
         }
     }
 
@@ -796,8 +796,8 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
                 final ClassMethod classMethod = proxyClassType.addMethod(method);
                 createInterceptorBody(classMethod, methodInfo, staticConstructor);
             }
-            Method getInstanceMethod = TargetInstanceProxy.class.getMethod("getTargetInstance");
-            Method getInstanceClassMethod = TargetInstanceProxy.class.getMethod("getTargetClass");
+            Method getInstanceMethod = TargetInstanceProxy.class.getMethod("weld_getTargetInstance");
+            Method getInstanceClassMethod = TargetInstanceProxy.class.getMethod("weld_getTargetClass");
 
             MethodInformation getInstanceMethodInfo = new RuntimeMethodInformation(getInstanceMethod);
             createInterceptorBody(proxyClassType.addMethod(getInstanceMethod), getInstanceMethodInfo, staticConstructor);
@@ -806,10 +806,10 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
             MethodInformation getInstanceClassMethodInfo = new RuntimeMethodInformation(getInstanceClassMethod);
             createInterceptorBody(proxyClassType.addMethod(getInstanceClassMethod), getInstanceClassMethodInfo, staticConstructor);
 
-            Method setMethodHandlerMethod = ProxyObject.class.getMethod("setHandler", MethodHandler.class);
+            Method setMethodHandlerMethod = ProxyObject.class.getMethod("weld_setHandler", MethodHandler.class);
             generateSetMethodHandlerBody(proxyClassType.addMethod(setMethodHandlerMethod));
 
-            Method getMethodHandlerMethod = ProxyObject.class.getMethod("getHandler");
+            Method getMethodHandlerMethod = ProxyObject.class.getMethod("weld_getHandler");
             generateGetMethodHandlerBody(proxyClassType.addMethod(getMethodHandlerMethod));
         } catch (Exception e) {
             throw new WeldException(e);

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyMethodHandler.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyMethodHandler.java
@@ -88,9 +88,9 @@ public class ProxyMethodHandler implements MethodHandler, Serializable, Metadata
             if (beanInstance == null) {
                 throw BeanLogger.LOG.beanInstanceNotSetOnProxy(getBean());
             }
-            if (thisMethod.getName().equals("getTargetInstance")) {
+            if (thisMethod.getName().equals("weld_getTargetInstance")) {
                 return beanInstance.getInstance();
-            } else if (thisMethod.getName().equals("getTargetClass")) {
+            } else if (thisMethod.getName().equals("weld_getTargetClass")) {
                 return beanInstance.getInstanceType();
             } else {
                 return null;

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyObject.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyObject.java
@@ -10,12 +10,12 @@ public interface ProxyObject {
      * Sets a handler.  It can be used for changing handlers
      * during runtime.
      */
-    void setHandler(MethodHandler mi);
+    void weld_setHandler(MethodHandler mi);
 
     /**
      * Get the handler.
      * This can be used to access values of the underlying MethodHandler
      * or to serialize it properly.
      */
-    MethodHandler getHandler();
+    MethodHandler weld_getHandler();
 }

--- a/impl/src/main/java/org/jboss/weld/injection/FieldInjectionPoint.java
+++ b/impl/src/main/java/org/jboss/weld/injection/FieldInjectionPoint.java
@@ -79,7 +79,7 @@ public class FieldInjectionPoint<T, X> extends ForwardingInjectionPointAttribute
             if (!(instanceToInject instanceof DecoratorProxy)) {
                 // if declaringInstance is a proxy, unwrap it
                 if (declaringInstance instanceof TargetInstanceProxy) {
-                    instanceToInject = Reflections.<TargetInstanceProxy<T>> cast(declaringInstance).getTargetInstance();
+                    instanceToInject = Reflections.<TargetInstanceProxy<T>> cast(declaringInstance).weld_getTargetInstance();
                 }
             }
             Object objectToInject;

--- a/impl/src/main/java/org/jboss/weld/injection/FieldResourceInjection.java
+++ b/impl/src/main/java/org/jboss/weld/injection/FieldResourceInjection.java
@@ -56,7 +56,7 @@ class FieldResourceInjection<T, X> extends AbstractResourceInjection<T> {
             if (!(instanceToInject instanceof DecoratorProxy)) {
                 // if declaringInstance is a proxy, unwrap it
                 if (instanceToInject instanceof TargetInstanceProxy) {
-                    instanceToInject = Reflections.<TargetInstanceProxy<T>> cast(declaringInstance).getTargetInstance();
+                    instanceToInject = Reflections.<TargetInstanceProxy<T>> cast(declaringInstance).weld_getTargetInstance();
                 }
             }
             accessibleField.set(instanceToInject, reference);

--- a/impl/src/main/java/org/jboss/weld/injection/InterceptionFactoryImpl.java
+++ b/impl/src/main/java/org/jboss/weld/injection/InterceptionFactoryImpl.java
@@ -173,7 +173,7 @@ public class InterceptionFactoryImpl<T> implements InterceptionFactory<T> {
 
         T proxy = (System.getSecurityManager() == null) ? data.getInterceptedProxyFactory().run()
             : AccessController.doPrivileged(data.getInterceptedProxyFactory());
-        ((ProxyObject) proxy).setHandler(methodHandler);
+        ((ProxyObject) proxy).weld_setHandler(methodHandler);
 
         return proxy;
     }

--- a/impl/src/main/java/org/jboss/weld/injection/ProxyClassConstructorInjectionPointWrapper.java
+++ b/impl/src/main/java/org/jboss/weld/injection/ProxyClassConstructorInjectionPointWrapper.java
@@ -90,7 +90,7 @@ public class ProxyClassConstructorInjectionPointWrapper<T> extends ConstructorIn
             ProxyFactory.setBeanInstance(contextId, instance, beanInstance, bean);
         } else {
             if (instance instanceof ProxyObject) {
-                ((ProxyObject) instance).setHandler(new CombinedInterceptorAndDecoratorStackMethodHandler());
+                ((ProxyObject) instance).weld_setHandler(new CombinedInterceptorAndDecoratorStackMethodHandler());
                 // Set method handler for private methods if necessary
                 InterceptedSubclassFactory.setPrivateMethodHandler(instance);
             }

--- a/impl/src/main/java/org/jboss/weld/injection/SetterResourceInjection.java
+++ b/impl/src/main/java/org/jboss/weld/injection/SetterResourceInjection.java
@@ -60,7 +60,7 @@ class SetterResourceInjection<T, X> extends AbstractResourceInjection<T> {
             if (!(instanceToInject instanceof DecoratorProxy)) {
                 // if declaringInstance is a proxy, unwrap it
                 if (instanceToInject instanceof TargetInstanceProxy) {
-                    instanceToInject = Reflections.<TargetInstanceProxy<T>> cast(declaringInstance).getTargetInstance();
+                    instanceToInject = Reflections.<TargetInstanceProxy<T>> cast(declaringInstance).weld_getTargetInstance();
                 }
             }
             accessibleMethod.invoke(instanceToInject, reference);

--- a/impl/src/main/java/org/jboss/weld/injection/producer/AbstractDecoratorApplyingInstantiator.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/AbstractDecoratorApplyingInstantiator.java
@@ -81,7 +81,7 @@ public abstract class AbstractDecoratorApplyingInstantiator<T> extends Forwardin
     }
 
     protected void registerOuterDecorator(ProxyObject instance, T outerDelegate) {
-        CombinedInterceptorAndDecoratorStackMethodHandler wrapperMethodHandler = (CombinedInterceptorAndDecoratorStackMethodHandler) instance.getHandler();
+        CombinedInterceptorAndDecoratorStackMethodHandler wrapperMethodHandler = (CombinedInterceptorAndDecoratorStackMethodHandler) instance.weld_getHandler();
         wrapperMethodHandler.setOuterDecorator(outerDelegate);
     }
 

--- a/impl/src/main/java/org/jboss/weld/injection/producer/DecoratorInjectionTarget.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/DecoratorInjectionTarget.java
@@ -109,7 +109,7 @@ public class DecoratorInjectionTarget<T> extends BeanInjectionTarget<T> {
                 throw UtilLogger.LOG.accessErrorOnField(accessibleField.getName(), accessibleField.getDeclaringClass(), e);
             }
             final ProxyMethodHandler handler = new ProxyMethodHandler(beanManager.getContextId(), new TargetBeanInstance(delegate), getBean());
-            ((ProxyObject) instance).setHandler(handler);
+            ((ProxyObject) instance).weld_setHandler(handler);
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/injection/producer/InterceptorApplyingInstantiator.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/InterceptorApplyingInstantiator.java
@@ -67,7 +67,7 @@ public class InterceptorApplyingInstantiator<T> extends ForwardingInstantiator<T
     protected T applyInterceptors(T instance, InterceptionContext interceptionContext) {
         try {
             InterceptorMethodHandler methodHandler = new InterceptorMethodHandler(interceptionContext);
-            CombinedInterceptorAndDecoratorStackMethodHandler wrapperMethodHandler = (CombinedInterceptorAndDecoratorStackMethodHandler) ((ProxyObject) instance).getHandler();
+            CombinedInterceptorAndDecoratorStackMethodHandler wrapperMethodHandler = (CombinedInterceptorAndDecoratorStackMethodHandler) ((ProxyObject) instance).weld_getHandler();
             wrapperMethodHandler.setInterceptorMethodHandler(methodHandler);
         } catch (Exception e) {
             throw new DeploymentException(e);

--- a/impl/src/main/java/org/jboss/weld/injection/producer/ProducerFieldProducer.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/ProducerFieldProducer.java
@@ -82,7 +82,7 @@ public abstract class ProducerFieldProducer<X, T> extends AbstractMemberProducer
     public T produce(Object receiver, CreationalContext<T> creationalContext) {
         // unwrap if we have a proxy
         if (receiver instanceof TargetInstanceProxy) {
-            receiver = Reflections.<TargetInstanceProxy<T>> cast(receiver).getTargetInstance();
+            receiver = Reflections.<TargetInstanceProxy<T>> cast(receiver).weld_getTargetInstance();
         }
         try {
             return cast(accessibleField.get(receiver));

--- a/impl/src/main/java/org/jboss/weld/interceptor/util/proxy/TargetInstanceProxy.java
+++ b/impl/src/main/java/org/jboss/weld/interceptor/util/proxy/TargetInstanceProxy.java
@@ -4,7 +4,7 @@ package org.jboss.weld.interceptor.util.proxy;
  * @author <a href="mailto:mariusb@redhat.com">Marius Bogoevici</a>
  */
 public interface TargetInstanceProxy<T> {
-    T getTargetInstance();
+    T weld_getTargetInstance();
 
-    Class<? extends T> getTargetClass();
+    Class<? extends T> weld_getTargetClass();
 }

--- a/modules/ejb/src/main/java/org/jboss/weld/module/ejb/SessionBeanInjectionTarget.java
+++ b/modules/ejb/src/main/java/org/jboss/weld/module/ejb/SessionBeanInjectionTarget.java
@@ -126,7 +126,7 @@ class SessionBeanInjectionTarget<T> extends BeanInjectionTarget<T> {
         if (result instanceof ProxyObject) {
             // if decorators are applied, use SessionBeanViewMethodHandler
             ProxyObject proxy = (ProxyObject) result;
-            proxy.setHandler(new SessionBeanViewMethodHandler(bean.getTypes(), (CombinedInterceptorAndDecoratorStackMethodHandler) proxy.getHandler()));
+            proxy.weld_setHandler(new SessionBeanViewMethodHandler(bean.getTypes(), (CombinedInterceptorAndDecoratorStackMethodHandler) proxy.weld_getHandler()));
         }
         return result;
     }


### PR DESCRIPTION
…id collision with user code.

@mkouba @nziakova I took a result of a test with decorator, interceptor and client proxy in place, decompiled proxies and came up with methods from - `TargetInstanceProxy` interface, `ProxyObject` interface and `LifecycleMixin`.
`LifecycleMixin` already uses obscure names, so I left that one untouched and only altered the other two.

I also left methods on `WeldClientProxy` untouched as those are part of API and have specific return type to avoid these kinds of problems. Not to mention backward compatibility.