### PR TITLE
WELD-2535 correct Weld.handleJar behaviour.

### DIFF
--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
@@ -1166,7 +1166,7 @@ public class Weld extends SeContainerInitializer implements ContainerInstanceFac
                     if (!entry.getName().endsWith(Files.CLASS_FILE_EXTENSION)) {
                         continue;
                     }
-                    if (entry.getName().startsWith(packNamePath)) {
+                    if (entry.getName().startsWith(packNamePath + '/')) {
                         if (scanRecursively) {
                             foundClasses.add(Files.filenameToClassname(entry.getName()));
                         } else {

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/SomeInterface.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/SomeInterface.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.synthethic.jarHandling;
+
+public interface SomeInterface {
+    String ping();
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/SyntheticArchiveWithPackageFromJarTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/SyntheticArchiveWithPackageFromJarTest.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.environment.se.test.synthethic.jarHandling;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.impl.BeansXml;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.environment.se.test.synthethic.jarHandling.foo.ImplOne;
+import org.jboss.weld.environment.se.test.synthethic.jarHandling.foobar.ImplTwo;
+import org.jboss.weld.inject.WeldInstance;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(Arquillian.class)
+public class SyntheticArchiveWithPackageFromJarTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        // create JAR on CP that includes two beans with packages names starting with same characters
+        JavaArchive library = ShrinkWrap.create(JavaArchive.class).addClasses(ImplOne.class, ImplTwo.class);
+        JavaArchive testLib = ShrinkWrap.create(JavaArchive.class)
+                .addClasses(SyntheticArchiveWithPackageFromJarTest.class, SomeInterface.class)
+                .addAsManifestResource(new BeansXml(), "beans.xml");
+        return ClassPath.builder().add(library).add(testLib).build();
+    }
+
+    @Test
+    public void testCorrectImplementationAdded() {
+        try (WeldContainer container = new Weld().disableDiscovery()
+                .addPackages(ImplOne.class.getPackage()).initialize()) {
+            WeldInstance<SomeInterface> someInterfaceInstance = container.select(SomeInterface.class);
+            assertTrue(someInterfaceInstance.isResolvable());
+            SomeInterface bean = someInterfaceInstance.get();
+            assertEquals(ImplOne.class.getSimpleName(), bean.ping());
+        }
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/foo/ImplOne.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/foo/ImplOne.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.synthethic.jarHandling.foo;
+
+import org.jboss.weld.environment.se.test.synthethic.jarHandling.SomeInterface;
+
+public class ImplOne implements SomeInterface {
+    @Override
+    public String ping() {
+        return ImplOne.class.getSimpleName();
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/foobar/ImplTwo.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/synthethic/jarHandling/foobar/ImplTwo.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.synthethic.jarHandling.foobar;
+
+import org.jboss.weld.environment.se.test.synthethic.jarHandling.SomeInterface;
+
+public class ImplTwo implements SomeInterface {
+    @Override
+    public String ping() {
+        return ImplTwo.class.getSimpleName();
+    }
+}


### PR DESCRIPTION

Prevents a problem of picking multiple packages from a JAR that has two or more package starting with the same String (e.g. `org.mine.foo`, `org.mine.foobar`).