### PR TITLE
Upgrade SpotBugs versions, Suppress false positives on JDK 11

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/reflection/Formats.java
+++ b/impl/src/main/java/org/jboss/weld/util/reflection/Formats.java
@@ -668,6 +668,8 @@ public class Formats {
         return typeVariable.getName() + UPPER_BOUND + formatType(bounds[0], simpleNames);
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE",
+            justification = "False positive, getBuildPropertiesResource() can return null in various situations")
     private static Properties getBuildProperties() {
         Properties buildProperties = null;
         try (InputStream in = getBuildPropertiesResource()) {

--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
@@ -39,6 +39,7 @@ import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.bootstrap.spi.ClassAvailableActivation;
@@ -121,6 +122,8 @@ public class BeansXmlStreamParser {
         this.interpolator = interpolator;
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "False positive, see https://github.com/spotbugs/spotbugs/issues/259")
     public BeansXml parse() {
         if (beansXml == null) {
             throw XmlLogger.LOG.loadError("unknown", null);

--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlValidator.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlValidator.java
@@ -34,6 +34,7 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jboss.weld.logging.XmlLogger;
 import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
@@ -61,6 +62,8 @@ public class BeansXmlValidator implements ErrorHandler {
         cdi20Schema = initSchema(factory, XmlSchema.CDI20_SCHEMAS);
     }
 
+    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
+            justification = "False positive, see https://github.com/spotbugs/spotbugs/issues/259")
     public void validate(URL beansXml, ErrorHandler errorHandler) {
         if (beansXml == null) {
             throw XmlLogger.LOG.loadError("unknown", null);

--- a/pom.xml
+++ b/pom.xml
@@ -61,8 +61,8 @@
         <cdi.tck-2-0.version>2.0.5.SP1</cdi.tck-2-0.version>
         <classfilewriter.version>1.2.3.Final</classfilewriter.version>
         <contiperf.version>1.06</contiperf.version>
-        <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
-        <spotbugs-annotations-version>3.1.8</spotbugs-annotations-version>
+        <spotbugs-maven-plugin.version>3.1.10</spotbugs-maven-plugin.version>
+        <spotbugs-annotations-version>3.1.11</spotbugs-annotations-version>
         <glassfish.el.version>2.1.2-b04</glassfish.el.version>
         <groovy.version>2.4.15</groovy.version>
         <htmlunit.version>2.20</htmlunit.version>


### PR DESCRIPTION
We have had SpotBugs disabled for JDK 10+ as the project wasn't running there.
This is now fixed so I re-enabled our CI jobs to run spotbugs with higher JDKs.

This PR bumps version of SpotBugs to latest and also adds supression for three false positives that only pop-up on JDK 11 for some reason. As justification I linked their GH issue which I think is the cause.