### PR TITLE
WELD-2528 Updated version of Jetty to 9.4

### DIFF
--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -166,7 +166,7 @@ public class Main {
 
 ==== Jetty
 
-Jetty 9.3.6 and newer are supported. Context activation/deactivation and dependency
+Jetty 9.4.14 and newer are supported. Context activation/deactivation and dependency
 injection into Servlets and Filters works out of the box. Injection into Servlet listeners works on
 Jetty 9.1.1 and newer.
 

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -28,8 +28,8 @@
     <properties>
         <jsf.version>2.3</jsf.version>
         <tomcat.version>9.0.12</tomcat.version>
-        <jetty.version>9.3.6.v20151106</jetty.version>
-        <jetty9.asm.version>5.0.3</jetty9.asm.version>
+        <jetty.version>9.4.14.v20181114</jetty.version>
+        <jetty9.asm.version>7.0</jetty9.asm.version>
         <!-- Jetty 6 API is used for GWT support only -->
         <jetty6.version>6.1.26</jetty6.version>
         <uel.glassfish.version>2.2</uel.glassfish.version>


### PR DESCRIPTION
Just updated versions to latest. There's no newer version of arquillian adapter, but it seems the current one works fine.