### PR TITLE
Revert "Uncommented test reproducing WFLY-11125"

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/Consumer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/Consumer.java
@@ -17,7 +17,6 @@
 package org.jboss.weld.tests.builtinBeans;
 
 import java.io.Serializable;
-import java.security.Principal;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.SessionScoped;
@@ -33,8 +32,8 @@ import org.junit.Assert;
 @SuppressWarnings("serial")
 public class Consumer implements Serializable {
 
-    @Inject
-    Principal principal;
+    // Not working incontainer as there is no principal
+    //@Inject Principal principal;
     @Inject
     UserTransaction userTransaction;
     @Inject
@@ -61,7 +60,9 @@ public class Consumer implements Serializable {
 
     public void check() {
         Assert.assertTrue(Checker.checkBeanManager(beanManager));
-        Assert.assertTrue(Checker.checkPrincipal(principal));
+
+        // Not working incontainer as there is no principal
+        //assert Checker.checkPrincipal(principal);
         Assert.assertTrue(Checker.checkUserTransaction(userTransaction));
         Assert.assertTrue(Checker.checkInstance(cow));
         Assert.assertTrue(Checker.checkEvent(event, observer));


### PR DESCRIPTION
This is to be able to test Weld against latest released final version of WFLY.