### PR TITLE
Fix for weld-2567

### DIFF
--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/WeldSEProvider.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/WeldSEProvider.java
@@ -59,7 +59,7 @@ public class WeldSEProvider implements CDIProvider {
     public CDI<Object> getCDI() {
         List<String> ids = WeldContainer.getRunningContainerIds();
         if (ids.isEmpty()) {
-            return null;
+            throw new IllegalStateException("Unable to access CDI");
         }
         if (ids.size() == 1) {
             return WeldContainer.instance(ids.get(0));

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/container/provider/WeldSEProviderTest.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/container/provider/WeldSEProviderTest.java
@@ -16,12 +16,6 @@
  */
 package org.jboss.weld.environment.se.test.container.provider;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.CDI;
@@ -29,6 +23,8 @@ import javax.enterprise.inject.spi.CDI;
 import org.jboss.weld.environment.se.Weld;
 import org.jboss.weld.environment.se.WeldContainer;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -38,7 +34,11 @@ public class WeldSEProviderTest {
 
     @Test
     public void testNoContainer() {
-        assertNull(CDI.current());
+        try {
+            CDI.current();
+            fail();
+        } catch (IllegalStateException ignored) {
+        }
     }
 
     @Test


### PR DESCRIPTION
As described in the bug report getCDI method should not return null. Instead it should throw IllegalStateException