### PR TITLE
WELD-2572 Updated classfilewriter version for JDK12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <bundle.plugin.version>2.5.3</bundle.plugin.version>
         <cdi.tck-1-2.version>1.2.10.Final</cdi.tck-1-2.version>
         <cdi.tck-2-0.version>2.0.5.SP1</cdi.tck-2-0.version>
-        <classfilewriter.version>1.2.3.Final</classfilewriter.version>
+        <classfilewriter.version>1.2.4.Final</classfilewriter.version>
         <contiperf.version>1.06</contiperf.version>
         <spotbugs-maven-plugin.version>3.1.10</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>3.1.11</spotbugs-annotations-version>


### PR DESCRIPTION
CI does not run on JDK12 yet so the results might not be relevant, but at least will run regression tests with JDK8 and 11.