### PR TITLE
WELD-2573 Make sure TCCL is preserved within async observer notificat…

### DIFF
--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/AsyncEventNotificationPreservesTCCLTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/AsyncEventNotificationPreservesTCCLTest.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.event.async.classLoader;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.event.Event;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests that async observer notification preserves TCCL that the original application had.
+ * Test runs in SE where we use different executor than in EE.
+ * CDI.current() is used to enforce lookup of Weld container from within the thread pool.
+ *
+ * @author Matej Novotny
+ */
+@RunWith(Arquillian.class)
+public class AsyncEventNotificationPreservesTCCLTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ClassPath.builder().add(ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(AsyncEventNotificationPreservesTCCLTest.class))
+                .addPackage(AsyncEventNotificationPreservesTCCLTest.class.getPackage())).build();
+    }
+
+    @Test
+    public void testAsyncEventHasSameTccl() {
+        try (WeldContainer container = new Weld().initialize()) {
+            Event<Message> event = container.event().select(Message.class);
+            final CountDownLatch latch = new CountDownLatch(1);
+            ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
+            event.fireAsync(() -> latch.countDown());
+            boolean latchWait = false;
+            try {
+                latchWait = latch.await(3, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Assert.fail("Interrupted while waiting for latch countdown.");
+            }
+            if (!latchWait) {
+                Assert.fail("CountDownLatch didn't reach 0 in time limit.");
+            }
+            Observer observer = container.select(Observer.class).get();
+            // assert both TCCL are the same
+            Assert.assertEquals(originalCl, observer.getTccl());
+        }
+
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/Foo.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/Foo.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.event.async.classLoader;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Foo {
+
+    public ClassLoader getTccl() {
+        return Thread.currentThread().getContextClassLoader();
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/Message.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/Message.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.event.async.classLoader;
+
+public interface Message {
+    void receive();
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/Observer.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/async/classLoader/Observer.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.event.async.classLoader;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.ObservesAsync;
+import javax.enterprise.inject.spi.CDI;
+
+@ApplicationScoped
+public class Observer {
+
+    private ClassLoader tccl = null;
+
+    public void observe(@ObservesAsync Message msg) {
+        // using CDI.current() means we will have to look up correct Weld container
+        this.tccl = CDI.current().select(Foo.class).get().getTccl();
+        msg.receive();
+    }
+
+    public ClassLoader getTccl() {
+        return tccl;
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/event/SecurityActions.java
+++ b/impl/src/main/java/org/jboss/weld/event/SecurityActions.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.event;
+
+import org.jboss.weld.security.GetContextClassLoaderAction;
+import org.jboss.weld.security.SetContextClassLoaderAction;
+
+import java.security.AccessController;
+
+/**
+ * @author Matej Novotny
+ */
+final class SecurityActions {
+
+    private SecurityActions() {
+    }
+
+    static ClassLoader getContextClassLoader() {
+        if (System.getSecurityManager() != null) {
+            return AccessController.doPrivileged(GetContextClassLoaderAction.INSTANCE);
+        } else {
+            return Thread.currentThread().getContextClassLoader();
+        }
+    }
+
+    static void setContextClassLoader(ClassLoader classLoader) {
+        if (System.getSecurityManager() != null) {
+            AccessController.doPrivileged(new SetContextClassLoaderAction(classLoader));
+        } else {
+            Thread.currentThread().setContextClassLoader(classLoader);
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/security/SetContextClassLoaderAction.java
+++ b/impl/src/main/java/org/jboss/weld/security/SetContextClassLoaderAction.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.security;
+
+import java.security.PrivilegedAction;
+
+/**
+ * Privileged action that sets the TCCL.
+ *
+ * @author Matej Novotny
+ *
+ */
+public class SetContextClassLoaderAction implements PrivilegedAction<Void> {
+
+    private ClassLoader tccl;
+
+    public SetContextClassLoaderAction(ClassLoader tccl) {
+        this.tccl = tccl;
+    }
+
+    @Override
+    public Void run() {
+        Thread.currentThread().setContextClassLoader(tccl);
+        return null;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/AsyncEventNotificationPreservesTCCLTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/AsyncEventNotificationPreservesTCCLTest.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.event.async.contextClassLoader;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests that async observer notification preserves TCCL that the original application had.
+ * Test is mainly aimed at WFLY as there the TCCL means you can use CDI.current() from within the observer method (which
+ * is what this test does as well). However, it makes sense to be sure this doesn't break anything in SE either.
+ *
+ * @author Matej Novotny
+ */
+@RunWith(Arquillian.class)
+public class AsyncEventNotificationPreservesTCCLTest {
+
+    @Inject
+    Event<Message> event;
+
+    @Inject
+    Observer observer;
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(AsyncEventNotificationPreservesTCCLTest.class))
+                .addPackage(AsyncEventNotificationPreservesTCCLTest.class.getPackage());
+    }
+
+    @Test
+    public void testAsyncEventHasSameTccl() {
+        final CountDownLatch latch = new CountDownLatch(1);
+        ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
+        event.fireAsync(() -> latch.countDown());
+        boolean latchWait = false;
+        try {
+            latchWait = latch.await(3, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Assert.fail("Interrupted while waiting for latch countdown.");
+        }
+        if (!latchWait) {
+            Assert.fail("CountDownLatch didn't reach 0 in time limit.");
+        }
+        // assert both TCCL are the same
+        Assert.assertEquals(originalCl, observer.getTccl());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/Foo.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.event.async.contextClassLoader;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Foo {
+
+    public ClassLoader getTccl() {
+        return Thread.currentThread().getContextClassLoader();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/Message.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/Message.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.event.async.contextClassLoader;
+
+public interface Message {
+    void receive();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/Observer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/contextClassLoader/Observer.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.event.async.contextClassLoader;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.ObservesAsync;
+import javax.enterprise.inject.spi.CDI;
+
+@ApplicationScoped
+public class Observer {
+
+    private ClassLoader tccl = null;
+
+    public void observe(@ObservesAsync Message msg) {
+        // using CDI.current() in WFLY means you need correct TCCL to find the right Container instance
+        this.tccl = CDI.current().select(Foo.class).get().getTccl();
+        msg.receive();
+    }
+
+    public ClassLoader getTccl() {
+        return tccl;
+    }
+}


### PR DESCRIPTION
@nziakova could you please run this down with SM enabled (in SE and EE).
Both, the actual fix and the test are juggling with TCCL which is likely SM-sensitive and might cause some troubles.