### PR TITLE
WELD-2574 Make PrivateMethodHandler serializable.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/PrivateMethodHandler.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/PrivateMethodHandler.java
@@ -17,6 +17,7 @@
 
 package org.jboss.weld.bean.proxy;
 
+import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -26,9 +27,10 @@ import java.lang.reflect.Method;
  * @author Martin Kouba
  * @see InterceptedSubclassFactory
  */
-class PrivateMethodHandler implements MethodHandler {
+class PrivateMethodHandler implements MethodHandler, Serializable {
 
     static final PrivateMethodHandler INSTANCE = new PrivateMethodHandler();
+    private static final long serialVersionUID = -1785189321581448377L;
 
     @Override
     public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/passivating/serialization/interception/FooImpl.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/passivating/serialization/interception/FooImpl.java
@@ -47,4 +47,7 @@ public class FooImpl implements Foo, Serializable {
 
     }
 
+    private void methodThatIsPrivate(){
+        // class will have to use PrivateMethodHandler, see WELD-2574
+    }
 }


### PR DESCRIPTION
Fix for WELD-2574 that I verified with the reproducer in linked issue.
I'll try to think of an automated test for this (requires to enforce serialization) before proceeding to merge.