### PR TITLE
[WELD-2578] Permits DiscoveryStrategy instances to be loaded via ServiceLoader.

### DIFF
--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
@@ -63,7 +63,7 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
     private final List<BeanArchiveHandler> handlers;
 
     protected AbstractDiscoveryStrategy() {
-        this.handlers = new LinkedList<BeanArchiveHandler>();
+        handlers = new LinkedList<BeanArchiveHandler>();
     }
 
     /**
@@ -73,10 +73,10 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
      * @param initialBeanDefiningAnnotations
      */
     public AbstractDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap, Set<Class<? extends Annotation>> initialBeanDefiningAnnotations) {
-        this();
-        this.setResourceLoader(resourceLoader);
-        this.setBootstrap(bootstrap);
-        this.setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
+        handlers = new LinkedList<BeanArchiveHandler>();
+        setResourceLoader(resourceLoader);
+        setBootstrap(bootstrap);
+        setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
     }
 
     @Override
@@ -94,14 +94,8 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
         this.scanner = scanner;
     }
 
-    public void setInitialBeanDefiningAnnotations(Set<? extends Class<? extends Annotation>> initialBeanDefiningAnnotations) {
-        if (initialBeanDefiningAnnotations == null) {
-            this.initialBeanDefiningAnnotations = null;
-        } else if (initialBeanDefiningAnnotations.isEmpty()) {
-            this.initialBeanDefiningAnnotations = Collections.emptySet();
-        } else {
-            this.initialBeanDefiningAnnotations = Collections.unmodifiableSet(new HashSet<>(initialBeanDefiningAnnotations));
-        }
+    public void setInitialBeanDefiningAnnotations(Set<Class<? extends Annotation>> initialBeanDefiningAnnotations) {
+        this.initialBeanDefiningAnnotations = initialBeanDefiningAnnotations;
     }
 
     @Override

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
@@ -47,7 +47,8 @@ import org.jboss.weld.util.ServiceLoader;
  * @author Matej Briškár
  * @author Martin Kouba
  * @author Jozef Hartinger
- * @author <a href="https://about.me/lairdnelson" target="_parent">Laird Nelson</a>
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
  */
 public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
 
@@ -78,10 +79,12 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
         this.setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
     }
 
+    @Override
     public void setResourceLoader(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
     }
 
+    @Override
     public void setBootstrap(Bootstrap bootstrap) {
         this.bootstrap = bootstrap;
     }

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014-2019, Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *
@@ -47,18 +47,23 @@ import org.jboss.weld.util.ServiceLoader;
  * @author Matej Briškár
  * @author Martin Kouba
  * @author Jozef Hartinger
+ * @author <a href="https://about.me/lairdnelson" target="_parent">Laird Nelson</a>
  */
 public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
 
-    protected final ResourceLoader resourceLoader;
+    protected ResourceLoader resourceLoader;
 
-    protected final Bootstrap bootstrap;
+    protected Bootstrap bootstrap;
 
-    protected final Set<Class<? extends Annotation>> initialBeanDefiningAnnotations;
+    protected Set<Class<? extends Annotation>> initialBeanDefiningAnnotations;
 
     protected BeanArchiveScanner scanner;
 
     private final List<BeanArchiveHandler> handlers;
+
+    protected AbstractDiscoveryStrategy() {
+        this.handlers = new LinkedList<BeanArchiveHandler>();
+    }
 
     /**
      *
@@ -67,15 +72,33 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
      * @param initialBeanDefiningAnnotations
      */
     public AbstractDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap, Set<Class<? extends Annotation>> initialBeanDefiningAnnotations) {
+        this();
+        this.setResourceLoader(resourceLoader);
+        this.setBootstrap(bootstrap);
+        this.setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
+    }
+
+    public void setResourceLoader(ResourceLoader resourceLoader) {
         this.resourceLoader = resourceLoader;
+    }
+
+    public void setBootstrap(Bootstrap bootstrap) {
         this.bootstrap = bootstrap;
-        this.handlers = new LinkedList<BeanArchiveHandler>();
-        this.initialBeanDefiningAnnotations = initialBeanDefiningAnnotations;
     }
 
     @Override
     public void setScanner(BeanArchiveScanner scanner) {
         this.scanner = scanner;
+    }
+
+    public void setInitialBeanDefiningAnnotations(Set<? extends Class<? extends Annotation>> initialBeanDefiningAnnotations) {
+        if (initialBeanDefiningAnnotations == null) {
+            this.initialBeanDefiningAnnotations = null;
+        } else if (initialBeanDefiningAnnotations.isEmpty()) {
+            this.initialBeanDefiningAnnotations = Collections.emptySet();
+        } else {
+            this.initialBeanDefiningAnnotations = Collections.unmodifiableSet(new HashSet<>(initialBeanDefiningAnnotations));
+        }
     }
 
     @Override

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategy.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * Copyright 2014-2019 Red Hat, Inc. and/or its affiliates, and individual
  * contributors by the @authors tag. See the copyright.txt in the
  * distribution for a full listing of individual contributors.
  *
@@ -16,18 +16,49 @@
  */
 package org.jboss.weld.environment.deployment.discovery;
 
+import java.lang.annotation.Annotation;
+
 import java.util.Set;
 
+import org.jboss.weld.bootstrap.api.Bootstrap;
 import org.jboss.weld.environment.deployment.WeldBeanDeploymentArchive;
 import org.jboss.weld.resources.spi.ClassFileServices;
+import org.jboss.weld.resources.spi.ResourceLoader;
 
 /**
  * This construct is not thread-safe.
  *
  * @author Matej Briškár
  * @author Martin Kouba
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
  */
 public interface DiscoveryStrategy {
+
+    /**
+     * Installs a {@link ResourceLoader} for use by the
+     * implementation.
+     *
+     * @param resourceLoader the {@link ResourceLoader} to install
+     */
+    void setResourceLoader(ResourceLoader resourceLoader);
+
+    /**
+     * Installs a {@link Bootstrap} for use by the
+     * implementation.
+     *
+     * @param bootstrap the {@link Bootstrap} to install
+     */
+    void setBootstrap(Bootstrap bootstrap);
+
+    /**
+     * Installs the {@link Set} of bean defining annotations that the
+     * implementation may use when discovering beans.
+     *
+     * @param initialBeanDefiningAnnotations the initial {@link Set}
+     * of bean defining annotations
+     */
+    void setInitialBeanDefiningAnnotations(Set<? extends Class<? extends Annotation>> initialBeanDefiningAnnotations);
 
     /**
      * Optionally, a client may set a custom scanner implementation. If not set, the impl is allowed to use anything it considers appropriate.

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategy.java
@@ -58,7 +58,7 @@ public interface DiscoveryStrategy {
      * @param initialBeanDefiningAnnotations the initial {@link Set}
      * of bean defining annotations
      */
-    void setInitialBeanDefiningAnnotations(Set<? extends Class<? extends Annotation>> initialBeanDefiningAnnotations);
+    void setInitialBeanDefiningAnnotations(Set<Class<? extends Annotation>> initialBeanDefiningAnnotations);
 
     /**
      * Optionally, a client may set a custom scanner implementation. If not set, the impl is allowed to use anything it considers appropriate.

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
@@ -30,7 +30,8 @@ import org.jboss.weld.util.ServiceLoader;
 
 /**
  * @author Martin Kouba
- * @author <a href="https://about.me/lairdnelson" target="_parent">Laird Nelson</a>
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
  */
 public final class DiscoveryStrategyFactory {
 
@@ -51,25 +52,20 @@ public final class DiscoveryStrategyFactory {
         if (iterator != null && iterator.hasNext()) {
             final DiscoveryStrategy candidate = iterator.next().getValue();
             if (candidate != null) {
-                if (candidate instanceof AbstractDiscoveryStrategy) {
-                    final AbstractDiscoveryStrategy strategy = (AbstractDiscoveryStrategy) candidate;
-                    strategy.setResourceLoader(resourceLoader);
-                    strategy.setBootstrap(bootstrap);
-                    strategy.setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
-                }
+                candidate.setResourceLoader(resourceLoader);
+                candidate.setBootstrap(bootstrap);
+                candidate.setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
                 returnValue = candidate;
             }
+        } else if (jandexStrategyDisabled) {
+            CommonLogger.LOG.jandexDiscoveryStrategyDisabled();
         } else if (Jandex.isJandexAvailable(resourceLoader)) {
-            if (jandexStrategyDisabled) {
-                CommonLogger.LOG.jandexDiscoveryStrategyDisabled();
-            } else {
-                CommonLogger.LOG.usingJandex();
-                try {
-                    returnValue = Jandex.createJandexDiscoveryStrategy(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
-                } catch (Exception e) {
-                    throw CommonLogger.LOG.unableToInstantiate(Jandex.JANDEX_DISCOVERY_STRATEGY_CLASS_NAME,
-                        Arrays.toString(new Object[] { resourceLoader, bootstrap, initialBeanDefiningAnnotations }), e);
-                }
+            CommonLogger.LOG.usingJandex();
+            try {
+                returnValue = Jandex.createJandexDiscoveryStrategy(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
+            } catch (Exception e) {
+                throw CommonLogger.LOG.unableToInstantiate(Jandex.JANDEX_DISCOVERY_STRATEGY_CLASS_NAME,
+                    Arrays.toString(new Object[] { resourceLoader, bootstrap, initialBeanDefiningAnnotations }), e);
             }
         }
         if (returnValue == null) {

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
@@ -57,15 +57,17 @@ public final class DiscoveryStrategyFactory {
                 candidate.setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
                 returnValue = candidate;
             }
-        } else if (jandexStrategyDisabled) {
-            CommonLogger.LOG.jandexDiscoveryStrategyDisabled();
         } else if (Jandex.isJandexAvailable(resourceLoader)) {
-            CommonLogger.LOG.usingJandex();
-            try {
-                returnValue = Jandex.createJandexDiscoveryStrategy(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
-            } catch (Exception e) {
-                throw CommonLogger.LOG.unableToInstantiate(Jandex.JANDEX_DISCOVERY_STRATEGY_CLASS_NAME,
-                    Arrays.toString(new Object[] { resourceLoader, bootstrap, initialBeanDefiningAnnotations }), e);
+            if (jandexStrategyDisabled) {
+                CommonLogger.LOG.jandexDiscoveryStrategyDisabled();
+            } else {
+                CommonLogger.LOG.usingJandex();
+                try {
+                    returnValue = Jandex.createJandexDiscoveryStrategy(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
+                } catch (Exception e) {
+                    throw CommonLogger.LOG.unableToInstantiate(Jandex.JANDEX_DISCOVERY_STRATEGY_CLASS_NAME,
+                        Arrays.toString(new Object[] { resourceLoader, bootstrap, initialBeanDefiningAnnotations }), e);
+                }
             }
         }
         if (returnValue == null) {

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
@@ -55,6 +55,7 @@ public final class DiscoveryStrategyFactory {
                 candidate.setResourceLoader(resourceLoader);
                 candidate.setBootstrap(bootstrap);
                 candidate.setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
+                CommonLogger.LOG.usingServiceLoaderSourcedDiscoveryStrategy(candidate);
                 returnValue = candidate;
             }
         } else if (Jandex.isJandexAvailable(resourceLoader)) {

--- a/environments/common/src/main/java/org/jboss/weld/environment/logging/CommonLogger.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/logging/CommonLogger.java
@@ -159,4 +159,8 @@ public interface CommonLogger extends WeldEnvironmentLogger {
     @Message(id = 40, value = "Jandex discovery strategy was disabled.", format = Format.MESSAGE_FORMAT)
     void jandexDiscoveryStrategyDisabled();
 
+    @LogMessage(level = Level.INFO)
+    @Message(id = 41, value = "Using {0} for bean discovery", format = Format.MESSAGE_FORMAT)
+    void usingServiceLoaderSourcedDiscoveryStrategy(Object discoveryStrategy);
+
 }


### PR DESCRIPTION
Signed-off-by: Laird Nelson <ljnelson@gmail.com>

This experimental PR allows `DiscoveryStrategy` instances to be loaded using a `ServiceLoader`.  All tests in `weld/core` continue to pass.  Any and all feedback welcome.  A [discussion in the Weld forums](https://developer.jboss.org/thread/279931) sparked this idea.