### PR TITLE
[WELD-2580] Ensure InjectionTarget#dispose(Object) method is called in ManagedBean implementation

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/ManagedBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/ManagedBean.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2008, Red Hat, Inc., and individual contributors
+ * Copyright 2008-2019, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -55,6 +55,8 @@ import org.jboss.weld.util.reflection.Reflections;
  * @author Marius Bogoevici
  * @author Ales Justin
  * @author Marko Luksa
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
  */
 public class ManagedBean<T> extends AbstractClassBean<T> {
 
@@ -189,7 +191,9 @@ public class ManagedBean<T> extends AbstractClassBean<T> {
     public void destroy(T instance, CreationalContext<T> creationalContext) {
         super.destroy(instance, creationalContext);
         try {
-            getProducer().preDestroy(instance);
+            InjectionTarget<T> injectionTarget = getProducer();
+            injectionTarget.preDestroy(instance);
+            injectionTarget.dispose(instance);
             // WELD-1010 hack?
             if (creationalContext instanceof CreationalContextImpl) {
                 ((CreationalContextImpl<T>) creationalContext).release(this, instance);

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/DisposingExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/DisposingExtension.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.injectionTarget.dispose;
+
+import java.util.Set;
+
+import javax.enterprise.context.spi.CreationalContext;
+
+import javax.enterprise.event.Observes;
+
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.InjectionPoint;
+import javax.enterprise.inject.spi.InjectionTarget;
+import javax.enterprise.inject.spi.ProcessInjectionTarget;
+
+/**
+ * Helps test fix for <a
+ * href="https://issues.jboss.org/browse/WELD-2580">WELD-2580</a>.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ */
+public class DisposingExtension implements Extension {
+
+  static boolean disposeCalled;
+
+  public DisposingExtension() {
+    super();
+  }
+
+  private final void processInjectionTarget(@Observes final ProcessInjectionTarget<Widget> event) {
+    final InjectionTarget<Widget> delegate = event.getInjectionTarget();
+    event.setInjectionTarget(new InjectionTarget<Widget>() {
+
+        @Override
+        public final Widget produce(final CreationalContext<Widget> cc) {
+          return delegate.produce(cc);
+        }
+
+        @Override
+        public final void inject(final Widget instance, final CreationalContext<Widget> cc) {
+          delegate.inject(instance, cc);
+        }
+
+        @Override
+        public final void postConstruct(final Widget instance) {
+          delegate.postConstruct(instance);
+        }
+
+        @Override
+        public Set<InjectionPoint> getInjectionPoints() {
+          return delegate.getInjectionPoints();
+        }
+
+        @Override
+        public final void preDestroy(final Widget instance) {
+          delegate.preDestroy(instance);
+        }
+
+        @Override
+        public final void dispose(final Widget instance) {
+          delegate.dispose(instance);
+          disposeCalled = true;
+        }
+
+      });
+  }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/InjectionTargetDisposeTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/InjectionTargetDisposeTest.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.injectionTarget.dispose;
+
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+
+import org.jboss.arquillian.junit.Arquillian;
+
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+
+import org.jboss.weld.test.util.Utils;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.junit.runner.RunWith;
+
+/**
+ * Tests fix for <a
+ * href="https://issues.jboss.org/browse/WELD-2580">WELD-2580</a>.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ */
+@RunWith(Arquillian.class)
+public class InjectionTargetDisposeTest {
+
+    @Deployment
+    public static final Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class,
+                                 Utils.getDeploymentNameAsHash(InjectionTargetDisposeTest.class))
+            .addPackage(InjectionTargetDisposeTest.class.getPackage())
+            .addAsServiceProvider(Extension.class, DisposingExtension.class);
+    }
+
+    @Inject
+    private Widget widget;
+
+    @Test
+    public void runOrdinaryContainerLifecycle() {
+
+    }
+
+    @BeforeClass
+    public static void ensureDisposeHasNotYetBeenCalled() {
+        Assert.assertFalse(DisposingExtension.disposeCalled);
+    }
+
+    // WELD-2580
+    @AfterClass
+    public static void ensureDisposeWasCalled() {
+        Assert.assertTrue(DisposingExtension.disposeCalled);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/InjectionTargetDisposeTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/InjectionTargetDisposeTest.java
@@ -16,7 +16,7 @@
  */
 package org.jboss.weld.tests.injectionTarget.dispose;
 
-import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.spi.Extension;
 
 import javax.inject.Inject;
@@ -31,9 +31,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 
 import org.jboss.weld.test.util.Utils;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.junit.runner.RunWith;
@@ -57,21 +55,13 @@ public class InjectionTargetDisposeTest {
     }
 
     @Inject
-    private Widget widget;
+    Instance<Widget> instanceWidget;
 
     @Test
     public void runOrdinaryContainerLifecycle() {
-
-    }
-
-    @BeforeClass
-    public static void ensureDisposeHasNotYetBeenCalled() {
-        Assert.assertFalse(DisposingExtension.disposeCalled);
-    }
-
-    // WELD-2580
-    @AfterClass
-    public static void ensureDisposeWasCalled() {
+        Widget widget = instanceWidget.get();
+        widget.ping();
+        instanceWidget.destroy(widget);
         Assert.assertTrue(DisposingExtension.disposeCalled);
     }
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/Widget.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/Widget.java
@@ -32,4 +32,5 @@ final class Widget {
         super();
     }
 
+    public void ping(){}
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/Widget.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/injectionTarget/dispose/Widget.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.injectionTarget.dispose;
+
+import javax.enterprise.context.Dependent;
+
+/**
+ * Helps test fix for <a
+ * href="https://issues.jboss.org/browse/WELD-2580">WELD-2580</a>.
+ *
+ * @author <a href="https://about.me/lairdnelson"
+ * target="_parent">Laird Nelson</a>
+ */
+@Dependent
+final class Widget {
+
+    Widget() {
+        super();
+    }
+
+}


### PR DESCRIPTION
Fixes https://issues.jboss.org/browse/WELD-2580.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>