### PR TITLE
Fix htmlunit version used in example ftests.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -139,6 +139,11 @@
             </dependency>
 
             <dependency>
+                <groupId>net.sourceforge.htmlunit</groupId>
+                <artifactId>htmlunit</artifactId>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>${arquillian.version}</version>


### PR DESCRIPTION
This fixes example ftests locally. Hopefully Jenkins won't complain (they aren't run as part of PR checks).