### PR TITLE
WELD-2597 Rename the attributes for Jetty integration #2587

### DIFF
--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -176,7 +176,7 @@ jetty modules listed below needs to be enabled.
 
 ===== Jetty `cdi-decorate` Module
 
-Since Jetty-9.4.20 and Weld 3.1.2, the Weld/Jetty integration uses the jetty `cdi-decorate` module.
+Since Jetty-9.4.20 and Weld 3.1.2.Final, the Weld/Jetty integration uses the jetty `cdi-decorate` module.
 To activate this module in jetty the argument `--module=cdi-decorate` needs to be added to the
 command line, which can be done for a standard distribution by running the commands:
 

--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -174,15 +174,15 @@ No further configuration is needed when starting Jetty as an embedded webapp ser
 However, if you’re using a Jetty standalone instance one more configuration step is required, one of the
 jetty modules listed below needs to be enabled.
 
-===== Jetty `decorate` Module
+===== Jetty `cdi-decorate` Module
 
-Since Jetty-9.4.20 and Weld 3.1.2, the Weld/Jetty integration uses the jetty `decorate` module.
-To activate this module in jetty the argument `--module=decorate` needs to be added to the
+Since Jetty-9.4.20 and Weld 3.1.2, the Weld/Jetty integration uses the jetty `cdi-decorate` module.
+To activate this module in jetty the argument `--module=cdi-decorate` needs to be added to the
 command line, which can be done for a standard distribution by running the commands:
 
 -------------------------
 cd $JETTY_BASE
-java -jar $JETTY_HOME/start.jar --add-to-start=decorate
+java -jar $JETTY_HOME/start.jar --add-to-start=cdi-decorate
 -------------------------
 
 ===== Jetty `cdi2` Module

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
@@ -85,7 +85,7 @@ public class JettyContainer extends AbstractJettyContainer {
                     // Initialize a JettyWeldInjector and create WeldDecorator for it
                     super.initialize(context);
                     servletContext.setAttribute(CDI_DECORATING_LISTENER_ATTRIBUTE, new WeldDecorator(servletContext));
-                    JettyLogger.LOG.jettyDecorationIsSupported();
+                    JettyLogger.LOG.jettyCdiDecorationIsSupported();
                     break;
 
                 case DECORATING_LISTENER_MODE:

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
@@ -42,11 +42,12 @@ import org.jboss.weld.resources.spi.ResourceLoader;
  * @author <a href="mailto:gregw@webtide.com">Greg Wilkins</a>
  */
 public class JettyContainer extends AbstractJettyContainer {
-
     public static final Container INSTANCE = new JettyContainer();
-    public static final String JETTY_DECORATING_ATTRIBUTE = "org.eclipse.jetty.webapp.DecoratingListener";
     public static final String JETTY_CDI_ATTRIBUTE = "org.eclipse.jetty.cdi";
-    public static final String JETTY_CDI_VALUE = "CdiDecorator";
+    public static final String CDI_SPI_DECORATOR_MODE = "CdiSpiDecorator";
+    public static final String CDI_DECORATING_LISTENER_MODE = "CdiDecoratingListener";
+    public static final String DECORATING_LISTENER_MODE = "DecoratingListener";
+    public static final String DECORATING_LISTENER_ATTRIBUTE = "org.eclipse.jetty.webapp.DecoratingListener";
 
     protected String classToCheck() {
         // Never called because touch is overridden below.
@@ -55,24 +56,49 @@ public class JettyContainer extends AbstractJettyContainer {
 
     @Override
     public boolean touch(ResourceLoader resourceLoader, ContainerContext context) throws Exception {
-        ServletContext sc = context.getServletContext();
-        // The jetty decorate module from 9.4.20 sets this attribute to indicate that a DecoratingListener is registered.
-        return sc.getAttribute(JETTY_DECORATING_ATTRIBUTE) instanceof String ||
-            JETTY_CDI_VALUE.equals(sc.getAttribute(JETTY_CDI_ATTRIBUTE));
+        ServletContext servletContext = context.getServletContext();
+        // The jetty cdi modules from 9.4.20 sets JETTY_CDI_ATTRIBUTE to indicate that a
+        // DecoratingListener is registered. Weld-3.1.2.Final documented that the decorate module
+        // could be used directly, which sets DECORATING_LISTENER_ATTRIBUTE
+        return servletContext.getAttribute(JETTY_CDI_ATTRIBUTE) instanceof String ||
+            servletContext.getAttribute(DECORATING_LISTENER_ATTRIBUTE) instanceof String;
     }
 
     @Override
     public void initialize(ContainerContext context) {
         try {
             ServletContext servletContext = context.getServletContext();
-            // Is the Jetty server doing its own CDI SPI integration?
-            if (JettyContainer.JETTY_CDI_VALUE.equals(servletContext.getAttribute(JettyContainer.JETTY_CDI_ATTRIBUTE))) {
-                // Yes, no further integration required
-                JettyLogger.LOG.jettyCdiSpiIsSupported();
-            } else {
-                // No, we need to initialize a JettyWeldInjector and WeldDecorator for it
-                super.initialize(context);
-                WeldDecorator.process(servletContext);
+            String mode = (String)servletContext.getAttribute(JETTY_CDI_ATTRIBUTE);
+            if (mode == null) {
+                mode = DECORATING_LISTENER_MODE;
+            }
+            switch (mode) {
+                case CDI_SPI_DECORATOR_MODE:
+                    // For use with the cdi-spi module
+                    // No further integration required
+                    JettyLogger.LOG.jettyCdiSpiIsSupported();
+                    break;
+
+                case CDI_DECORATING_LISTENER_MODE:
+                    // For use with the cdi-decorate module
+                    // Initialize a JettyWeldInjector and create WeldDecorator for it
+                    super.initialize(context);
+                    servletContext.setAttribute(WeldDecorator.JETTY_LISTENING_ATTRIBUTE, new WeldDecorator(servletContext));
+                    JettyLogger.LOG.jettyDecorationIsSupported();
+                    break;
+
+                case DECORATING_LISTENER_MODE:
+                    // For use with the decorate module
+                    // This mode is only needed to match the Weld-3.1.2 documentation.
+                    // Initialize a JettyWeldInjector and create WeldDecorator for it
+                    super.initialize(context);
+                    String attribute = (String) servletContext.getAttribute(DECORATING_LISTENER_ATTRIBUTE);
+                    servletContext.setAttribute(attribute, new WeldDecorator(servletContext));
+                    JettyLogger.LOG.jettyDecorationIsSupported();
+                    break;
+
+                default:
+                    throw new IllegalStateException("unknown mode: " + mode);
             }
         } catch (Exception e) {
             JettyLogger.LOG.unableToCreateJettyWeldInjector(e);

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
@@ -46,6 +46,7 @@ public class JettyContainer extends AbstractJettyContainer {
     public static final String JETTY_CDI_ATTRIBUTE = "org.eclipse.jetty.cdi";
     public static final String CDI_SPI_DECORATOR_MODE = "CdiSpiDecorator";
     public static final String CDI_DECORATING_LISTENER_MODE = "CdiDecoratingListener";
+    public static final String CDI_DECORATING_LISTENER_ATTRIBUTE = "org.eclipse.jetty.cdi.decorator";
     public static final String DECORATING_LISTENER_MODE = "DecoratingListener";
     public static final String DECORATING_LISTENER_ATTRIBUTE = "org.eclipse.jetty.webapp.DecoratingListener";
 
@@ -83,7 +84,7 @@ public class JettyContainer extends AbstractJettyContainer {
                     // For use with the cdi-decorate module
                     // Initialize a JettyWeldInjector and create WeldDecorator for it
                     super.initialize(context);
-                    servletContext.setAttribute(WeldDecorator.JETTY_LISTENING_ATTRIBUTE, new WeldDecorator(servletContext));
+                    servletContext.setAttribute(CDI_DECORATING_LISTENER_ATTRIBUTE, new WeldDecorator(servletContext));
                     JettyLogger.LOG.jettyDecorationIsSupported();
                     break;
 

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/JettyContainer.java
@@ -99,7 +99,7 @@ public class JettyContainer extends AbstractJettyContainer {
                     break;
 
                 default:
-                    throw new IllegalStateException("unknown mode: " + mode);
+                    throw JettyLogger.LOG.unknownIntegrationMode(mode);
             }
         } catch (Exception e) {
             JettyLogger.LOG.unableToCreateJettyWeldInjector(e);

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/WeldDecorator.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/WeldDecorator.java
@@ -30,8 +30,6 @@ import org.jboss.weld.environment.servlet.logging.JettyLogger;
  * @author <a href="mailto:gregw@webtide.com">Greg Wilkins</a>
  */
 public class WeldDecorator  {
-    public static final String JETTY_LISTENING_ATTRIBUTE = "org.eclipse.jetty.cdi.decorator";
-
     private JettyWeldInjector injector;
 
     protected WeldDecorator(ServletContext servletContext) {

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/WeldDecorator.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/jetty/WeldDecorator.java
@@ -30,6 +30,7 @@ import org.jboss.weld.environment.servlet.logging.JettyLogger;
  * @author <a href="mailto:gregw@webtide.com">Greg Wilkins</a>
  */
 public class WeldDecorator  {
+    public static final String JETTY_LISTENING_ATTRIBUTE = "org.eclipse.jetty.cdi.decorator";
 
     private JettyWeldInjector injector;
 
@@ -37,17 +38,6 @@ public class WeldDecorator  {
         injector = (JettyWeldInjector) servletContext.getAttribute(AbstractJettyContainer.INJECTOR_ATTRIBUTE_NAME);
         if (injector == null) {
             throw JettyLogger.LOG.noSuchJettyInjectorFound();
-        }
-    }
-
-    public static void process(ServletContext context) {
-        String attribute = (String)context.getAttribute(JettyContainer.JETTY_DECORATING_ATTRIBUTE);
-        if (attribute != null) {
-            // The jetty decorate module from 9.4.20 listens for attributes as decorators.
-            context.setAttribute(attribute, new WeldDecorator(context));
-            JettyLogger.LOG.jettyDecorationIsSupported();
-        } else {
-            throw new IllegalStateException("No Jetty Decorating Listener integration detected");
         }
     }
 

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/logging/JettyLogger.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/logging/JettyLogger.java
@@ -79,14 +79,18 @@ public interface JettyLogger extends WeldEnvironmentLogger {
     @Message(id = 1210, value = "No such Jetty injector found in servlet context attributes.")
     IllegalStateException noSuchJettyInjectorFound();
 
-    @LogMessage(level = Level.INFO)
-    @Message(id = 1211, value = "Jetty Decorate support detected, CDI injection will be available in Listeners, Servlets and Filters.")
+    @LogMessage(level = Level.WARN)
+    @Message(id = 1211, value = "Deprecated Jetty DecoratingListener support detected, CDI injection will be available in Listeners, Servlets and Filters.")
     void jettyDecorationIsSupported();
 
     @LogMessage(level = Level.INFO)
-    @Message(id = 1212, value = "Jetty CDI SPI support detected, CDI injection will be available in Listeners, Servlets and Filters.")
+    @Message(id = 1212, value = "Jetty CdiDecoratingListener support detected, CDI injection will be available in Listeners, Servlets and Filters.")
+    void jettyCdiDecorationIsSupported();
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 1213, value = "Jetty CDI SPI support detected, CDI injection will be available in Listeners, Servlets and Filters.")
     void jettyCdiSpiIsSupported();
 
-    @Message(id = 1213, value = "Unknown Jetty integration mode: {0}", format = Format.MESSAGE_FORMAT)
+    @Message(id = 1214, value = "Unknown Jetty integration mode: {0}", format = Format.MESSAGE_FORMAT)
     IllegalStateException unknownIntegrationMode(String mode);
 }

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/logging/JettyLogger.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/logging/JettyLogger.java
@@ -86,4 +86,7 @@ public interface JettyLogger extends WeldEnvironmentLogger {
     @LogMessage(level = Level.INFO)
     @Message(id = 1212, value = "Jetty CDI SPI support detected, CDI injection will be available in Listeners, Servlets and Filters.")
     void jettyCdiSpiIsSupported();
+
+    @Message(id = 1213, value = "Unknown Jetty integration mode: {0}", format = Format.MESSAGE_FORMAT)
+    IllegalStateException unknownIntegrationMode(String mode);
 }


### PR DESCRIPTION
For https://issues.jboss.org/browse/WELD-2597

Sorry about this, but the changes for jetty-9.4.20 have had a tough time in review because of the two mechanism and somewhat confused names.
Thus we are considering a bit of a renaming... but in a way that will not break Weld-3.1.2, which will still work with either `cdi2` or `decorate` modules.
However, going forward, we'd like to have `cdi-decorate` or `cdi-spi` modules.

This PR reflects the proposed rename in https://github.com/eclipse/jetty.project/pull/3946.    It also includes support for continuing to use the `decorate` directly, but you only really need that if you are worried about people applying 3.1.2 documentation to 3.1.3 and beyond.

Note that this is still a draft proposal until 3946 is reviewed and we've gotten your feedback as well.

Signed-off-by: Greg Wilkins <gregw@webtide.com>