### PR TITLE
WELD-2595 Allow for private final methods on intercepted beans.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/injection/producer/InterceptionModelInitializer.java
+++ b/impl/src/main/java/org/jboss/weld/injection/producer/InterceptionModelInitializer.java
@@ -203,7 +203,12 @@ public class InterceptionModelInitializer<T> {
                 if (configuration.isFinalMethodIgnored(javaMethod.getDeclaringClass().getName())) {
                     BeanLogger.LOG.finalMethodNotIntercepted(javaMethod, methodBoundInterceptors.get(0).getBeanClass().getName());
                 } else {
-                    throw BeanLogger.LOG.finalInterceptedBeanMethodNotAllowed(method, methodBoundInterceptors.get(0).getBeanClass().getName());
+                    if (Reflections.isPrivate(javaMethod)) {
+                        // private final methods are OK, we just ignore them and log a warning
+                        BeanLogger.LOG.privateFinalMethodOnInterceptedBean(method.getDeclaringType(), method);
+                    } else {
+                        throw BeanLogger.LOG.finalInterceptedBeanMethodNotAllowed(method, methodBoundInterceptors.get(0).getBeanClass().getName());
+                    }
                 }
             } else {
                 builder.interceptMethod(interceptionType, javaMethod, asInterceptorMetadata(methodBoundInterceptors), methodBindingAnnotations);

--- a/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
@@ -542,4 +542,8 @@ public interface BeanLogger extends WeldLogger {
     @LogMessage(level = Level.DEBUG)
     @Message(id = 1576, value = "Using {1} to instantiate a shared proxy class {0}; the deployment implementation [{2}] does not match the instantiator the proxy was created with", format = Format.MESSAGE_FORMAT)
     void creatingProxyInstanceUsingDifferentInstantiator(Object proxyClass, Object newInstantiator, Object oldInstantiator);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 1577, value = "Detected private final method: {1}\non an intercepted bean: {0}\nWeld will ignore this method during interception.", format = Format.MESSAGE_FORMAT)
+    void privateFinalMethodOnInterceptedBean(Object beanClass, Object method);
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/BeanWithPrivateFinalMethod.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/BeanWithPrivateFinalMethod.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.privateFinalMethods;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@Watches
+@ApplicationScoped
+public class BeanWithPrivateFinalMethod {
+
+    protected void protectedMethod() {
+    }
+
+    private final void privateFinalMethod() {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/BeanWithPrivateFinalMethodTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/BeanWithPrivateFinalMethodTest.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.privateFinalMethods;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+/**
+ * Tests that for classes which have private final methods an interceptor subclass can be created.
+ * Such methods are then ignored for interception.
+ *
+ * The point of the test is not to see deployment exception, the actual test is just to ensure that interceptor
+ * was enabled and does something.
+ */
+@RunWith(Arquillian.class)
+public class BeanWithPrivateFinalMethodTest {
+
+    @Deployment
+    public static JavaArchive createDeployment()
+    {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(BeanWithPrivateFinalMethodTest.class))
+                .addPackage(BeanWithPrivateFinalMethodTest.class.getPackage());
+    }
+
+    @Inject
+    BeanWithPrivateFinalMethod bean;
+
+    @Test
+    public void testSubclassGenerationIgnoresPrivateFinalMethod() {
+        // test interception works, e.g. that subclass was created
+        Assert.assertEquals(0, MyInterceptor.INTERCEPTOR_INVOKED);
+        bean.protectedMethod();
+        Assert.assertEquals(1, MyInterceptor.INTERCEPTOR_INVOKED);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/MyInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/MyInterceptor.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.privateFinalMethods;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Watches
+@Interceptor
+@Priority(1)
+public class MyInterceptor {
+
+    public static int INTERCEPTOR_INVOKED = 0;
+
+    @AroundInvoke
+    public Object aroundInvoke(InvocationContext ic) throws Exception {
+        this.INTERCEPTOR_INVOKED++;
+        return ic.proceed();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/Watches.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/privateFinalMethods/Watches.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.privateFinalMethods;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@InterceptorBinding
+@Documented
+@Retention(RUNTIME)
+@Target({METHOD, TYPE})
+public @interface Watches {
+}


### PR DESCRIPTION
Note that `InterceptionModelInitializer` throws this exception on two places.
Second one is inside `initMethodDeclaredEjbInterceptors()` method but that one searches for method-level annotations in which case having the method private final is an error.