### PR TITLE
WELD-2583 INtercepted subclasses should not contain private methods w…

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/CommonProxiedMethodFilters.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/CommonProxiedMethodFilters.java
@@ -18,6 +18,7 @@ package org.jboss.weld.bean.proxy;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 
 import org.jboss.weld.util.reflection.Reflections;
 
@@ -54,6 +55,26 @@ public final class CommonProxiedMethodFilters {
                         if (Reflections.isPackagePrivate(parameterType.getModifiers())) {
                             return false;
                         }
+                    }
+                }
+            }
+            return true;
+        }
+    };
+
+    /**
+     * Filter used to exclude private methods that have parameters which are package private types
+     */
+    public static final ProxiedMethodFilter NON_PRIVATE_WITHOUT_PACK_PRIVATE_PARAMS = new ProxiedMethodFilter() {
+        @Override
+        public boolean accept(Method method, Class<?> proxySuperclass) {
+            if (Modifier.isPrivate(method.getModifiers())) {
+                for (Parameter param : method.getParameters()) {
+                    Class<?> paramClass = param.getType();
+                    if (!Modifier.isProtected(paramClass.getModifiers())
+                            && !Modifier.isPublic(paramClass.getModifiers())
+                            && !Modifier.isPrivate(paramClass.getModifiers())) {
+                        return false;
                     }
                 }
             }

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
@@ -156,7 +156,7 @@ public class InterceptedSubclassFactory<T> extends ProxyFactory<T> {
                     final MethodSignatureImpl methodSignature = new MethodSignatureImpl(method);
 
                     if (!Modifier.isFinal(method.getModifiers()) && !method.isBridge() && enhancedMethodSignatures.contains(methodSignature)
-                            && !finalMethods.contains(methodSignature)
+                            && !finalMethods.contains(methodSignature) && CommonProxiedMethodFilters.NON_PRIVATE_WITHOUT_PACK_PRIVATE_PARAMS.accept(method, getProxySuperclass())
                             && !bridgeMethodsContainsMethod(processedBridgeMethods, methodSignature, method.getGenericReturnType(), Modifier.isAbstract(method.getModifiers()))) {
                         try {
                             final MethodInformation methodInfo = new RuntimeMethodInformation(method);

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/InterceptionWithPackagePrivateTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/InterceptionWithPackagePrivateTest.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.visibility.packagePrivate;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack1.SoMuchBetterFoo;
+import org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack2.Foo;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+@RunWith(Arquillian.class)
+public class InterceptionWithPackagePrivateTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(InterceptionWithPackagePrivateTest.class))
+                .addPackage(SoMuchBetterFoo.class.getPackage())
+                .addPackage(Foo.class.getPackage())
+                .addClass(InterceptionWithPackagePrivateTest.class);
+    }
+
+    @Inject
+    Instance<SoMuchBetterFoo> instance;
+
+    @Test
+    public void testSubclassCreationOnFoo() {
+        Assert.assertTrue(instance.isResolvable());
+        org.junit.Assert.assertEquals(Foo.class.getSimpleName(), instance.get().ping());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack1/GameChangingInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack1/GameChangingInterceptor.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack1;
+
+import javax.annotation.Priority;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Interceptor
+@Priority(1)
+@VeryImportantBinding
+public class GameChangingInterceptor {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        return context.proceed();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack1/SoMuchBetterFoo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack1/SoMuchBetterFoo.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack1;
+
+import org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack2.Foo;
+
+@VeryImportantBinding
+public class SoMuchBetterFoo extends Foo {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack1/VeryImportantBinding.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack1/VeryImportantBinding.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack1;
+
+import javax.interceptor.InterceptorBinding;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VeryImportantBinding {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack2/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack2/Foo.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack2;
+
+public class Foo {
+
+    /**
+     * This is the offending method because of its package private param
+     */
+    private void notToBeInterceptedMethod(PackPrivate param){
+
+    }
+
+    public String ping() {
+        return Foo.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack2/PackPrivate.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/visibility/packagePrivate/pack2/PackPrivate.java
@@ -1,0 +1,21 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.interceptors.visibility.packagePrivate.pack2;
+
+class PackPrivate {
+}


### PR DESCRIPTION
…ith pack-private parameters, add automated test.

(cherry picked from commit 9298f185b196bc04814a9e8e20cbc8818cec1810)

issue: https://issues.jboss.org/browse/JBEAP-16974
upstream issue: https://issues.jboss.org/browse/WELD-2583
upstream PR: https://github.com/weld/core/pull/1923

This backport for EAP 7.2 CP, please hold for the downstream PM ack.