### PR TITLE
Close weld.properties in finally block

### DIFF
--- a/impl/src/main/java/org/jboss/weld/config/WeldConfiguration.java
+++ b/impl/src/main/java/org/jboss/weld/config/WeldConfiguration.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.config;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.security.AccessController;
@@ -481,11 +482,15 @@ public class WeldConfiguration implements Service {
     private Properties loadProperties(URL url) {
         Properties properties = new Properties();
         try {
-            properties.load(url.openStream());
+            InputStream propertiesStream = url.openStream();
+            try {
+                properties.load(propertiesStream);
+            } finally {
+                propertiesStream.close();
+            }
         } catch (IOException e) {
             throw new ResourceLoadingException(e);
         }
         return properties;
     }
-
 }


### PR DESCRIPTION
This PR closes the InputStream for the weld.properties file in a finally block after the file is read. This will help avoid integration problems when weld is integrated into servers that expect files to be closed quickly after use.