### PR TITLE
Update Weld parent, satisfy checkstyle.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/collections/ImmutableArrayList.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/ImmutableArrayList.java
@@ -138,6 +138,11 @@ class ImmutableArrayList<E> extends ImmutableList<E> implements RandomAccess, Se
     }
 
     @Override
+    public boolean equals(Object o) {
+        return super.equals(o);
+    }
+
+    @Override
     public Object[] toArray() {
         return Arrays.copyOf(elements, size());
     }

--- a/impl/src/main/java/org/jboss/weld/util/collections/ImmutableTinyList.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/ImmutableTinyList.java
@@ -95,6 +95,11 @@ abstract class ImmutableTinyList<E> extends ImmutableList<E> implements RandomAc
         }
 
         @Override
+        public boolean equals(Object o) {
+            return super.equals(o);
+        }
+
+        @Override
         public E get(int index) {
             if (index == 0) {
                 return element;

--- a/impl/src/main/java/org/jboss/weld/util/collections/ImmutableTinySet.java
+++ b/impl/src/main/java/org/jboss/weld/util/collections/ImmutableTinySet.java
@@ -16,12 +16,12 @@
  */
 package org.jboss.weld.util.collections;
 
+import org.jboss.weld.util.Preconditions;
+
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Set;
-
-import org.jboss.weld.util.Preconditions;
 
 /**
  * Contains {@link Set} implementations optimized for tiny number of elements. These implementations do not use hashing. {@link Set#contains(Object)} is o(n)
@@ -76,6 +76,11 @@ abstract class ImmutableTinySet<T> extends ImmutableSet<T> {
         }
 
         @Override
+        public boolean equals(Object obj) {
+            return super.equals(obj);
+        }
+
+        @Override
         public Iterator<T> iterator() {
             return new Iterators.IndexIterator<T>(this.size()) {
                 @Override
@@ -123,6 +128,11 @@ abstract class ImmutableTinySet<T> extends ImmutableSet<T> {
         @Override
         public int hashCode() {
             return element1.hashCode() + element2.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return super.equals(obj);
         }
 
         @Override
@@ -182,6 +192,11 @@ abstract class ImmutableTinySet<T> extends ImmutableSet<T> {
         @Override
         public int hashCode() {
             return element1.hashCode() + element2.hashCode() + element3.hashCode();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return super.equals(obj);
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-parent</artifactId>
-        <version>39</version>
+        <version>40</version>
     </parent>
 
     <prerequisites>
@@ -565,7 +565,7 @@
                                     <pluginExecutionFilter>
                                         <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-checkstyle-plugin</artifactId>
-                                        <versionRange>[1.0.0,)</versionRange>
+                                        <versionRange>[3.1.0,)</versionRange>
                                         <goals>
                                             <goal>checkstyle</goal>
                                         </goals>


### PR DESCRIPTION
Related to https://github.com/weld/parent/pull/10.
Updates the parent to fetch in the new checkstyle version. Adds `equals` impls to our own set/list implementations to satisfy checkstyle.