### PR TITLE
WELD-2615: Fix AttributeBeanStore.remove()

### DIFF
--- a/impl/src/main/java/org/jboss/weld/contexts/beanstore/AttributeBeanStore.java
+++ b/impl/src/main/java/org/jboss/weld/contexts/beanstore/AttributeBeanStore.java
@@ -156,9 +156,14 @@ public abstract class AttributeBeanStore implements BoundBeanStore {
     @Override
     public <T> ContextualInstance<T> remove(BeanIdentifier id) {
         ContextualInstance<T> instance = beanStore.remove(id);
+        String prefixedId = namingScheme.prefix(id);
+        if (instance == null && isAttached() && isAttributeLazyFetchingEnabled()) {
+            // If no instance is found and the bean store is attached then attempt to get the attribute from the backing store
+            instance = cast(getAttribute(prefixedId));
+        }
         if (instance != null) {
             if (isAttached()) {
-                removeAttribute(namingScheme.prefix(id));
+                removeAttribute(prefixedId);
             }
             ContextLogger.LOG.contextualInstanceRemoved(id, this);
         }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/destroy/SessionContextDestroyTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/destroy/SessionContextDestroyTest.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.session.destroy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.category.Integration;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+
+@RunWith(Arquillian.class)
+@Category(Integration.class)
+public class SessionContextDestroyTest {
+
+    @ArquillianResource
+    URL url;
+
+    private final WebClient client = new WebClient();
+
+    @Deployment(testable = false)
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(WebArchive.class, Utils.getDeploymentNameAsHash(SessionContextDestroyTest.class, Utils.ARCHIVE_TYPE.WAR))
+                .addPackage(SessionContextDestroyTest.class.getPackage()).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void test() throws IOException {
+        String id = pageAsString("action=init");
+        assertEquals("ok", pageAsString("action=destroy"));
+        String test = pageAsString("action=test");
+        assertTrue("Destroyed beans:" + test, test.contains(id));
+    }
+
+    private String pageAsString(String param) throws IOException {
+        return client.getPage(url.toString() + "/test?" + param).getWebResponse().getContentAsString();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/destroy/SessionScopedBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/destroy/SessionScopedBean.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.session.destroy;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.SessionScoped;
+
+@SuppressWarnings("serial")
+@SessionScoped
+public class SessionScopedBean implements Serializable {
+
+    static final List<String> DESTROYED = new CopyOnWriteArrayList<>();
+
+    private AtomicReference<String> id = new AtomicReference<>();
+
+    public String ping() {
+        return id.get();
+    }
+
+    @PostConstruct
+    void init() {
+        id.set(UUID.randomUUID().toString());
+    }
+
+    @PreDestroy
+    void destroy() {
+        DESTROYED.add(id.get());
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/destroy/TestServlet.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/session/destroy/TestServlet.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2020, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.contexts.session.destroy;
+
+import java.io.IOException;
+
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.context.spi.AlterableContext;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.inject.Inject;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@SuppressWarnings("serial")
+@WebServlet("/test")
+public class TestServlet extends HttpServlet {
+
+    @Inject
+    SessionScopedBean bean;
+
+    @Inject
+    BeanManager beanManager;
+
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        String action = req.getParameter("action");
+        switch (action) {
+            case "init":
+                resp.getWriter().print(bean.ping());
+                break;
+            case "destroy":
+                Bean<?> bean = beanManager.getBeans(SessionScopedBean.class).iterator().next();
+                AlterableContext sessionContext = (AlterableContext) beanManager.getContext(SessionScoped.class);
+                sessionContext.destroy(bean);
+                resp.getWriter().print("ok");
+                break;
+            case "test":
+                resp.getWriter().print(SessionScopedBean.DESTROYED);
+                break;
+            default:
+                throw new IllegalStateException("Unknown action");
+        }
+    }
+
+}


### PR DESCRIPTION
- HttpSessionContext#destroy(Contextual<?>) should always destroy the
underlying contextual instance