### PR TITLE
WELD-2609 Fix OM configurator when reading from an AnnotatedMethod.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/ObserverMethodConfiguratorImpl.java
@@ -119,8 +119,10 @@ public class ObserverMethodConfiguratorImpl<T> implements ObserverMethodConfigur
         if (observesAnnotation != null) {
             reception(observesAnnotation.notifyObserver());
             transactionPhase(observesAnnotation.during());
+            async(false);
         } else {
             reception(eventParameter.getAnnotation(ObservesAsync.class).notifyObserver());
+            async(true);
         }
         Priority priority = method.getAnnotation(Priority.class);
         if (priority != null) {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/observers/custom/CustomAsyncObserverExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/observers/custom/CustomAsyncObserverExtension.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.observers.custom;
+
+import java.util.concurrent.CountDownLatch;
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.Extension;
+import javax.enterprise.inject.spi.ProcessObserverMethod;
+
+public class CustomAsyncObserverExtension implements Extension {
+
+    public static boolean NOTIFIED = false;
+
+    private AnnotatedMethod<?> om = null;
+    public void monitorOM(@Observes ProcessObserverMethod<CountDownLatch, FooBean> event) {
+        if (om == null) {
+            this.om = event.getAnnotatedMethod();
+            event.veto();
+        }
+    }
+
+    public void registerObservers(@Observes AfterBeanDiscovery event) {
+        if (om == null) {
+            throw new IllegalStateException("Did not find observer method to read from!");
+        } else {
+            event.<CountDownLatch>addObserverMethod().read(om).notifyWith(context -> {
+                NOTIFIED = true;
+                context.getEvent().countDown();
+            });
+        }
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/observers/custom/FooBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/observers/custom/FooBean.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.observers.custom;
+
+import java.util.concurrent.CountDownLatch;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.ObservesAsync;
+
+@ApplicationScoped
+public class FooBean {
+
+    public void observeLatch(@ObservesAsync CountDownLatch latch){
+        //noop, just for reading from extension
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/observers/custom/ObserverConfiguratorForAsyncTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/observers/custom/ObserverConfiguratorForAsyncTest.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.observers.custom;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+
+@RunWith(Arquillian.class)
+public class ObserverConfiguratorForAsyncTest {
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ObserverConfiguratorForAsyncTest.class))
+                .addPackage(CustomObserverWithoutNotifyTest.class.getPackage())
+                .addAsServiceProvider(Extension.class, CustomAsyncObserverExtension.class);
+    }
+
+    @Test
+    public void testObserverWasAsync(BeanManager beanManager) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        beanManager.getEvent().fireAsync(latch);
+        latch.await(5, TimeUnit.SECONDS);
+        assertTrue(CustomAsyncObserverExtension.NOTIFIED);
+    }
+}


### PR DESCRIPTION
Issue only impacts reading from `AnnotatedMethod`, if you use `ObserverMethod`, then it works just fine.