### PR TITLE
Attempt to fix intemittent failures in RequestScopeEventMessageDelive…

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/Controller.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/resources/proxy/weld1782/Controller.java
@@ -27,8 +27,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class Controller {
 
-    private CountDownLatch msgDeliveredLatch = new CountDownLatch(1);
-    private CountDownLatch contextDestroyedLatch = new CountDownLatch(1);
+    private final CountDownLatch msgDeliveredLatch = new CountDownLatch(1);
+    private final CountDownLatch contextDestroyedLatch = new CountDownLatch(1);
 
     public CountDownLatch getMsgDeliveredLatch() {
         return msgDeliveredLatch;
@@ -36,10 +36,5 @@ public class Controller {
 
     public CountDownLatch getContextDestroyedLatch() {
         return contextDestroyedLatch;
-    }
-
-    public void resetLatches() {
-        msgDeliveredLatch = new CountDownLatch(1);
-        contextDestroyedLatch = new CountDownLatch(1);
     }
 }


### PR DESCRIPTION
…ryTest by making certain fields final to prevent possible concurrent write.