### PR TITLE
WELD-2628 Fix integer overflow when sorting alternatives

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/enablement/Item.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/enablement/Item.java
@@ -88,8 +88,11 @@ class Item implements Comparable<Item> {
              * their class name lexicographically.
              */
             return javaClass.getName().compareTo(o.javaClass.getName());
+        } else if (p1 < p2) {
+            return -1;
+        } else {
+            return 1;
         }
-        return p1 - p2;
     }
 
     @Override

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/AfterTypeDiscoveryObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/AfterTypeDiscoveryObserver.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/AfterTypeDiscoveryObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/AfterTypeDiscoveryObserver.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.lifecycle.atd.minvaluepriority;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterTypeDiscovery;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.Extension;
+
+
+public class AfterTypeDiscoveryObserver implements Extension {
+
+    private List<Class<?>> initialAlternatives = null;
+
+    public void observeAfterTypeDiscovery(@Observes AfterTypeDiscovery event, BeanManager beanManager) {
+
+        initialAlternatives = Collections.unmodifiableList(new ArrayList<Class<?>>(event.getAlternatives()));
+
+    }
+
+    public List<Class<?>> getInitialAlternatives() {
+        return initialAlternatives;
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityAlternative.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2014, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityAlternative.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.lifecycle.atd.minvaluepriority;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+
+@Alternative
+@Priority(Integer.MIN_VALUE)
+public class MinValuePriorityAlternative {
+	
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityTest.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.lifecycle.atd.minvaluepriority;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.enterprise.inject.spi.Extension;
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This tests the sorting of alternatives by priority when one of the priorities is {@link Integer.MIN_VALUE}.
+ * This previously caused an integer overflow in the sorting, and resulted in an incorrect ordering.
+ *
+ * @author Karl von Randow
+ * @see WELD-2628
+ */
+@RunWith(Arquillian.class)
+public class MinValuePriorityTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(MinValuePriorityTest.class)).addPackage(AfterTypeDiscoveryObserver.class.getPackage())
+                .addAsServiceProvider(Extension.class, AfterTypeDiscoveryObserver.class);
+    }
+
+    @Inject
+    AfterTypeDiscoveryObserver extension;
+
+    @Test
+    public void testInitialAlternatives() {
+        assertEquals(extension.getInitialAlternatives().size(), 2);
+        assertEquals(extension.getInitialAlternatives().get(0), MinValuePriorityAlternative.class);
+        assertEquals(extension.getInitialAlternatives().get(1), NormalAlternative.class);
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/MinValuePriorityTest.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2014, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/NormalAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/NormalAlternative.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.extensions.lifecycle.atd.minvaluepriority;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Alternative;
+
+@Alternative
+@Priority(100)
+public class NormalAlternative {
+	
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/NormalAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/atd/minvaluepriority/NormalAlternative.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2014, Red Hat, Inc., and individual contributors
+ * Copyright 2020, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *


### PR DESCRIPTION
This PR fixes an integer overflow issue when sorting alternatives with a priority of `Integer.MIN_VALUE`, and includes a test proving the fix.