### PR TITLE
WELD-2570 Fix WebAppBeanArchiveScanner not excluding duplicate bean.xml correctly

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java
@@ -109,7 +109,7 @@ public class WebAppBeanArchiveScanner extends DefaultBeanArchiveScanner {
         for (Iterator<ScanResult> iterator = results.iterator(); iterator.hasNext();) {
             ScanResult result = iterator.next();
             String path = result.getBeanArchiveRef().toString();
-            if (new File(path).equals(webInfClasses)) {
+            if (path.contains(WEB_INF_CLASSES_FILE_PATH) || path.contains(WEB_INF_CLASSES) || new File(path).equals(webInfClasses)) {
                 iterator.remove();
             } else {
                 result.extractBeanArchiveId(contextPath, WEB_INF);


### PR DESCRIPTION
See latest discussion in https://issues.redhat.com/browse/WELD-2570.

Changed WebBeanArchiveScanner such that first it resolves, the real path of the file found through the servelet context, and afterwards compares that to the beans.xml file paths found in the classpath.
This avoids duplicate entries in settings where the deployment specifies a logical path for the server that is different from the actual file path.