### PR TITLE
Add null checks into WeldInitialListener.

### DIFF
--- a/modules/web/src/main/java/org/jboss/weld/module/web/logging/ServletLogger.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/logging/ServletLogger.java
@@ -97,4 +97,6 @@ public interface ServletLogger extends WeldLogger {
     @Message(id = 718, value = "No EEModuleDescriptor defined for bean archive with ID: {0}. @Initialized and @Destroyed events for ApplicationScoped may be fired twice.", format = Format.MESSAGE_FORMAT)
     void noEeModuleDescriptor(Object beanArchiveId);
 
+    @Message(id = 720, value = "A call to WeldInitialListener#{0} was made, but the WeldInitialListener#contextInitialized method wasn't yet executed!", format = Format.MESSAGE_FORMAT)
+    IllegalStateException lifecycleNotInitialized(String listenerMethod);
 }

--- a/modules/web/src/main/java/org/jboss/weld/module/web/servlet/WeldInitialListener.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/servlet/WeldInitialListener.java
@@ -110,21 +110,25 @@ public class WeldInitialListener extends AbstractServletListener {
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
+        assertLifecycleInitialized("contextDestroyed");
         lifecycle.contextDestroyed(sce.getServletContext());
     }
 
     @Override
     public void sessionCreated(HttpSessionEvent event) {
+        assertLifecycleInitialized("sessionCreated");
         lifecycle.sessionCreated(event.getSession());
     }
 
     @Override
     public void sessionDestroyed(HttpSessionEvent event) {
+        assertLifecycleInitialized("sessionDestroyed");
         lifecycle.sessionDestroyed(event.getSession());
     }
 
     @Override
     public void requestDestroyed(ServletRequestEvent event) {
+        assertLifecycleInitialized("requestDestroyed");
         if (event.getServletRequest() instanceof HttpServletRequest) {
             lifecycle.requestDestroyed((HttpServletRequest) event.getServletRequest());
         } else {
@@ -134,6 +138,7 @@ public class WeldInitialListener extends AbstractServletListener {
 
     @Override
     public void requestInitialized(ServletRequestEvent event) {
+        assertLifecycleInitialized("requestInitialized");
         if (!lifecycle.isConversationActivationSet()) {
             Object value = event.getServletContext().getAttribute(CONVERSATION_FILTER_REGISTERED);
             if (Boolean.TRUE.equals(value)) {
@@ -146,6 +151,12 @@ public class WeldInitialListener extends AbstractServletListener {
             lifecycle.requestInitialized((HttpServletRequest) event.getServletRequest(), event.getServletContext());
         } else {
             throw ServletLogger.LOG.onlyHttpServletLifecycleDefined();
+        }
+    }
+
+    private void assertLifecycleInitialized(String listenerMethod) {
+        if (lifecycle == null) {
+            throw ServletLogger.LOG.lifecycleNotInitialized(listenerMethod);
         }
     }
 }


### PR DESCRIPTION
Related to weld-dev conversation - https://lists.jboss.org/pipermail/weld-dev/2020-July/003828.html


We can either blow up or just log something and skip execution. I chose to blow up as I don't think you should call other methods on a listener if you skipped init. But I don't mind going the other way either.