### PR TITLE
Update javadoc generation for Weld SE shaded - this had lots package …

### DIFF
--- a/environments/se/build/pom.xml
+++ b/environments/se/build/pom.xml
@@ -35,6 +35,31 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <version>${weld.api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -106,11 +131,28 @@
                         <configuration>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
-                                <dependency-source>org.jboss.weld:*</dependency-source>
-                                <dependency-source>org.jboss.weld.se:*</dependency-source>
-                                <dependency-source>javax.enterprise:*</dependency-source>
-                                <dependency-source>javax.inject:*</dependency-source>
+                                <dependencySourceInclude>org.jboss.weld:*</dependencySourceInclude>
+                                <dependencySourceInclude>org.jboss.weld.se:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.enterprise:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.inject:*</dependencySourceInclude>
                             </dependencySourceIncludes>
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>com.github.spotbugs</groupId>
+                                    <artifactId>spotbugs-annotations</artifactId>
+                                    <version>${spotbugs-annotations-version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-annotations</artifactId>
+                                    <version>${jboss.logging.processor.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.apache.bcel</groupId>
+                                    <artifactId>bcel</artifactId>
+                                    <version>${apache.bcel.version}</version>
+                                </additionalDependency>
+                            </additionalDependencies>
                         </configuration>
                         <executions>
                             <execution>

--- a/environments/servlet/build/pom.xml
+++ b/environments/servlet/build/pom.xml
@@ -40,6 +40,31 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <version>${weld.api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_4.0_spec</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -101,12 +126,79 @@
                         <configuration>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
-                                <dependency-source>org.jboss.weld:*</dependency-source>
-                                <dependency-source>org.jboss.weld.module:*</dependency-source>
-                                <dependency-source>org.jboss.weld.servlet:*</dependency-source>
-                                <dependency-source>javax.enterprise:*</dependency-source>
-                                <dependency-source>javax.inject:*</dependency-source>
+                                <dependencySourceInclude>org.jboss.weld:*</dependencySourceInclude>
+                                <dependencySourceInclude>org.jboss.weld.module:*</dependencySourceInclude>
+                                <dependencySourceInclude>org.jboss.weld.servlet:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.enterprise:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.inject:*</dependencySourceInclude>
                             </dependencySourceIncludes>
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>com.github.spotbugs</groupId>
+                                    <artifactId>spotbugs-annotations</artifactId>
+                                    <version>${spotbugs-annotations-version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-annotations</artifactId>
+                                    <version>${jboss.logging.processor.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.apache.bcel</groupId>
+                                    <artifactId>bcel</artifactId>
+                                    <version>${apache.bcel.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>io.undertow</groupId>
+                                    <artifactId>undertow-servlet</artifactId>
+                                    <version>${undertow.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>jakarta.servlet.jsp</groupId>
+                                    <artifactId>jakarta.servlet.jsp-api</artifactId>
+                                    <version>${jsp.api.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.jboss</groupId>
+                                    <artifactId>jandex</artifactId>
+                                    <version>${jandex.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>jakarta.faces</groupId>
+                                    <artifactId>jakarta.faces-api</artifactId>
+                                    <version>${jsf.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.eclipse.jetty</groupId>
+                                    <artifactId>jetty-server</artifactId>
+                                    <version>${jetty.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.eclipse.jetty</groupId>
+                                    <artifactId>jetty-util</artifactId>
+                                    <version>${jetty.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.eclipse.jetty</groupId>
+                                    <artifactId>jetty-servlet</artifactId>
+                                    <version>${jetty.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.apache.tomcat.embed</groupId>
+                                    <artifactId>tomcat-embed-core</artifactId>
+                                    <version>${tomcat.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.mortbay.jetty</groupId>
+                                    <artifactId>jetty</artifactId>
+                                    <version>${jetty6.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.mortbay.jetty</groupId>
+                                    <artifactId>jetty-util</artifactId>
+                                    <version>${jetty6.version}</version>
+                                </additionalDependency>
+                            </additionalDependencies>
                         </configuration>
                         <executions>
                             <execution>

--- a/probe/core/pom.xml
+++ b/probe/core/pom.xml
@@ -87,6 +87,13 @@
                     <failIfNoTests>false</failIfNoTests>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <excludeResources>true</excludeResources>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -141,7 +148,6 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-resources-plugin</artifactId>
-                        <version>2.6</version>
                         <executions>
                             <execution>
                                 <id>copy-resources</id>


### PR DESCRIPTION
This avoids the warnings on JDK 8 which were errors with JDK 11.
However, there is still tons of other warnings (bad documentations, missing docs for return statements, ...). But those at least don't break build/release with JDK 11.

@mkouba could you please sanity-check the SE shaded javadoc jar this generates for you? With either java you have, just to have a double check on this :-)