### PR TITLE
WELD-2635: GWT uses Jetty from Eclipse foundation, so changing to not…

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/gwtdev/GwtDevHostedModeContainer.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/gwtdev/GwtDevHostedModeContainer.java
@@ -24,6 +24,7 @@ import javax.servlet.ServletContext;
 import org.jboss.weld.environment.servlet.Container;
 import org.jboss.weld.environment.servlet.ContainerContext;
 import org.jboss.weld.environment.jetty.AbstractJettyContainer;
+import org.jboss.weld.environment.jetty.JettyContainer;
 import org.jboss.weld.environment.jetty.JettyWeldInjector;
 import org.jboss.weld.environment.servlet.logging.JettyLogger;
 
@@ -43,7 +44,7 @@ public class GwtDevHostedModeContainer extends AbstractJettyContainer {
     }
 
     protected Class<?> getWeldServletHandlerClass() {
-        return MortbayWeldServletHandler.class;
+      return JettyContainer.class;
     }
 
     public void initialize(ContainerContext context) {


### PR DESCRIPTION
… use Mortbay anymore

https://issues.redhat.com/browse/WELD-2635