### PR TITLE
Backport javadoc creation changes and few other tweks from 3.1.

### DIFF
--- a/bundles/osgi/pom.xml
+++ b/bundles/osgi/pom.xml
@@ -284,7 +284,71 @@
             <artifactId>weld-probe-core</artifactId>
         </dependency>
 
+        <!-- Following deps are for the sake of javadoc creation -->
+        <!-- We cannot delare them inside plugin otherwise we have to hardcode versions -->
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>com.github.spotbugs</groupId>
+                                    <artifactId>spotbugs-annotations</artifactId>
+                                    <version>${spotbugs-annotations-version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-annotations</artifactId>
+                                    <version>${jboss.logging.processor.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.apache.bcel</groupId>
+                                    <artifactId>bcel</artifactId>
+                                    <version>${apache.bcel.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>jakarta.faces</groupId>
+                                    <artifactId>jakarta.faces-api</artifactId>
+                                    <version>${jsf.api.version}</version>
+                                </additionalDependency>
+                            </additionalDependencies>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>javadoc</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <!-- SCM and distribution management -->
     <scm>

--- a/environments/se/build/pom.xml
+++ b/environments/se/build/pom.xml
@@ -35,6 +35,31 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <version>${weld.api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -106,11 +131,28 @@
                         <configuration>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
-                                <dependency-source>org.jboss.weld:*</dependency-source>
-                                <dependency-source>org.jboss.weld.se:*</dependency-source>
-                                <dependency-source>jakarta.enterprise:*</dependency-source>
-                                <dependency-source>jakarta.inject:*</dependency-source>
+                                <dependencySourceInclude>org.jboss.weld:*</dependencySourceInclude>
+                                <dependencySourceInclude>org.jboss.weld.se:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.enterprise:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.inject:*</dependencySourceInclude>
                             </dependencySourceIncludes>
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>com.github.spotbugs</groupId>
+                                    <artifactId>spotbugs-annotations</artifactId>
+                                    <version>${spotbugs-annotations-version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-annotations</artifactId>
+                                    <version>${jboss.logging.processor.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.apache.bcel</groupId>
+                                    <artifactId>bcel</artifactId>
+                                    <version>${apache.bcel.version}</version>
+                                </additionalDependency>
+                            </additionalDependencies>
                         </configuration>
                         <executions>
                             <execution>

--- a/environments/servlet/build/pom.xml
+++ b/environments/servlet/build/pom.xml
@@ -40,6 +40,36 @@
             <optional>true</optional>
         </dependency>
 
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-api</artifactId>
+            <version>${weld.api.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -73,7 +103,6 @@
                                     <exclude>org.apache.tomcat:juli</exclude>
                                     <exclude>org.apache.tomcat:annotations-api</exclude>
                                     <exclude>jakarta.faces:jsf-api</exclude>
-                                    <exclude>org.mortbay.jetty:jetty</exclude>
                                     <exclude>jakarta.el:el-api</exclude>
                                 </excludes>
                             </artifactSet>
@@ -100,12 +129,69 @@
                         <configuration>
                             <includeDependencySources>true</includeDependencySources>
                             <dependencySourceIncludes>
-                                <dependency-source>org.jboss.weld:*</dependency-source>
-                                <dependency-source>org.jboss.weld.module:*</dependency-source>
-                                <dependency-source>org.jboss.weld.servlet:*</dependency-source>
-                                <dependency-source>jakarta.enterprise:*</dependency-source>
-                                <dependency-source>jakarta.inject:*</dependency-source>
+                                <dependencySourceInclude>org.jboss.weld:*</dependencySourceInclude>
+                                <dependencySourceInclude>org.jboss.weld.module:*</dependencySourceInclude>
+                                <dependencySourceInclude>org.jboss.weld.servlet:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.enterprise:*</dependencySourceInclude>
+                                <dependencySourceInclude>jakarta.inject:*</dependencySourceInclude>
                             </dependencySourceIncludes>
+                            <additionalDependencies>
+                                <additionalDependency>
+                                    <groupId>com.github.spotbugs</groupId>
+                                    <artifactId>spotbugs-annotations</artifactId>
+                                    <version>${spotbugs-annotations-version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging-annotations</artifactId>
+                                    <version>${jboss.logging.processor.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.apache.bcel</groupId>
+                                    <artifactId>bcel</artifactId>
+                                    <version>${apache.bcel.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>io.undertow</groupId>
+                                    <artifactId>undertow-servlet</artifactId>
+                                    <version>${undertow.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>jakarta.servlet.jsp</groupId>
+                                    <artifactId>jakarta.servlet.jsp-api</artifactId>
+                                    <version>${jsp.api.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.jboss</groupId>
+                                    <artifactId>jandex</artifactId>
+                                    <version>${jandex.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>jakarta.faces</groupId>
+                                    <artifactId>jakarta.faces-api</artifactId>
+                                    <version>${jsf.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.eclipse.jetty</groupId>
+                                    <artifactId>jetty-server</artifactId>
+                                    <version>${jetty.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.eclipse.jetty</groupId>
+                                    <artifactId>jetty-util</artifactId>
+                                    <version>${jetty.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.eclipse.jetty</groupId>
+                                    <artifactId>jetty-servlet</artifactId>
+                                    <version>${jetty.version}</version>
+                                </additionalDependency>
+                                <additionalDependency>
+                                    <groupId>org.apache.tomcat.embed</groupId>
+                                    <artifactId>tomcat-embed-core</artifactId>
+                                    <version>${tomcat.version}</version>
+                                </additionalDependency>
+                            </additionalDependencies>
                         </configuration>
                         <executions>
                             <execution>

--- a/environments/servlet/core/pom.xml
+++ b/environments/servlet/core/pom.xml
@@ -148,6 +148,14 @@
             <artifactId>undertow-servlet</artifactId>
             <version>${undertow.version}</version>
             <scope>provided</scope>
+            <!-- TODO remove once on EE 9 undertow version, otherwise this breaks jboss logging processor as it
+            enforces usage of javax.annotation.Generated instead of javax.annotation.processing.Generated -->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.spec.javax.annotation</groupId>
+                    <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         
         <dependency>

--- a/probe/core/pom.xml
+++ b/probe/core/pom.xml
@@ -87,6 +87,13 @@
                     <failIfNoTests>false</failIfNoTests>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <configuration>
+                    <excludeResources>true</excludeResources>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Javadoc creation was manually tested.

Note that bundle plugin for OSGi needs update to work with anything containing JMPS modules but that will come with API upgrade.
Also, there is an exclusion from undertow dep to prevent old `@Generated` annotation leaking in which then breaks generated classes from jboss logging processor.