### PR TITLE
Replace double property reference for TCKs with single one since we c…

### DIFF
--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -46,7 +46,6 @@
         <!--Running with -Pdownload-wfly will make Maven download the version specified below-->
         <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-${wildfly.download.version}</wildflyOriginal>
         <wildfly.download.version>20.0.1.Final</wildfly.download.version>
-        <cdi.tck.version>${cdi.tck-3-0.version}</cdi.tck.version>
 
         <!--Plugin versions-->
         <download.maven.plugin>1.3.0</download.maven.plugin>
@@ -87,7 +86,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-ext-lib</artifactId>
-            <version>${cdi.tck.version}</version>
+            <version>${cdi.tck-3-0.version}</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -305,7 +304,7 @@
                                     <target>
                                         <copy todir="${env.JBOSS_HOME}/standalone/lib/ext" overwrite="true">
                                             <fileset dir="target/dependency/lib">
-                                                <include name="cdi-tck-ext-lib-${cdi.tck.version}.jar" />
+                                                <include name="cdi-tck-ext-lib-${cdi.tck-3-0.version}.jar" />
                                             </fileset>
                                         </copy>
                                     </target>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-api</artifactId>
-            <version>${cdi.tck.version}</version>
+            <version>${cdi.tck-3-0.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>jakarta.el</groupId>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-impl</artifactId>
-            <version>${cdi.tck.version}</version>
+            <version>${cdi.tck-3-0.version}</version>
             <type>xml</type>
             <classifier>suite</classifier>
             <scope>test</scope>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-impl</artifactId>
-            <version>${cdi.tck.version}</version>
+            <version>${cdi.tck-3-0.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -232,9 +232,6 @@
                     <name>!tck12</name>
                 </property>
             </activation>
-            <properties>
-                <cdi.tck.version>${cdi.tck-3-0.version}</cdi.tck.version>
-            </properties>
             <build>
                 <plugins>
                     <plugin>


### PR DESCRIPTION
…an no longer run against dual TCK version.

The variable `<cdi.tck.version>` used to be in place so that we could swap between TCK 1.2 and 2 for Weld 3.
With Weld 4 we can no longer run multiple versions due to package changes so we can simplify this.