### PR TITLE
Docs - add an execution that generates multiple HTMLs; add index page…

### DIFF
--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -59,6 +59,7 @@
                         </goals>
                         <configuration>
                             <backend>pdf</backend>
+                            <sourceDocumentName>Weld_-_JSR-299_Reference_Implementation.asciidoc</sourceDocumentName>
                             <outputDirectory>${doc.output.directory}/en-US/pdf</outputDirectory>
                             <outputFile>${pdf.name}</outputFile>
                         </configuration>
@@ -71,11 +72,28 @@
                         </goals>
                         <configuration>
                             <backend>html5</backend>
-                            <attributes>
-                                <docinfo>shared</docinfo>
-                            </attributes>
+                            <sourceDocumentName>Weld_-_JSR-299_Reference_Implementation.asciidoc</sourceDocumentName>
                             <outputDirectory>${doc.output.directory}/en-US/html_single</outputDirectory>
                             <outputFile>${html.name}</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>output-html-chunked</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <attributes>
+                                <docinfo>shared</docinfo>
+                                <!-- Auto-generate TOC for each HTML -->
+                                <toc>left</toc>
+                                <toclevels>3</toclevels>
+                                <!-- Triggers conditional addition of link to index page -->
+                                <generate-index-link></generate-index-link>
+                            </attributes>
+                            <outputDirectory>${doc.output.directory}/en-US/html</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -83,7 +101,6 @@
                 <configuration>
                     <doctype>book</doctype>
                     <sourceDirectory>${basedir}/src/main/asciidoc</sourceDirectory>
-                    <sourceDocumentName>Weld_-_JSR-299_Reference_Implementation.asciidoc</sourceDocumentName>
                     <templateEngine>slim</templateEngine>
                     <headerFooter>true</headerFooter>
                     <attributes>

--- a/docs/reference/src/main/asciidoc/beans.asciidoc
+++ b/docs/reference/src/main/asciidoc/beans.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[beanscdi]]
 == More about beans
 
@@ -49,7 +53,10 @@ We can replace one bean with another different bean that implements the
 same interface and has a different lifecycle (a different scope) without
 affecting the other bean implementation. In fact, CDI defines a simple
 facility for overriding bean implementations at deployment time, as we
-will see in <<alternatives>>.
+will see in
+ifndef::generate-index-link[<<alternatives>>]
+ifdef::generate-index-link[link:injection.html#alternatives[Alternatives]]
+.
 
 Note that not all clients of a bean are beans themselves. Other objects
 such as servlets or message-driven beans—which are by nature not
@@ -121,7 +128,9 @@ NOTE: The bean types of a session bean include local interfaces and the bean
 class local view (if any). EJB remote interfaces are not considered bean
 types of a session bean. You can't inject an EJB using its remote
 interface unless you define a _resource_, which we'll meet in
-<<resources>>.
+ifndef::generate-index-link[<<resources>>]
+ifdef::generate-index-link[link:resources.html[Java EE component environment resources]]
+.
 
 Bean types may be restricted to an explicit set by annotating the bean
 with the `@Typed` annotation and listing the classes that should be bean
@@ -202,7 +211,10 @@ it has the default qualifier, `@Default`.
 That's not quite the end of the story. CDI also defines a simple
 _resolution rule_ that helps the container decide what to do if there is
 more than one bean that satisfies a particular contract. We'll get into
-the details in <<injection>>.
+the details in
+ifndef::generate-index-link[<<injection>>]
+ifdef::generate-index-link[link:injection.html[Dependency injection and programmatic lookup]]
+.
 
 ==== Scope
 
@@ -234,7 +246,10 @@ special scope called the _dependent pseudo-scope_. Beans with this scope
 live to serve the object into which they were injected, which means
 their lifecycle is bound to the lifecycle of that object.
 
-We'll talk more about scopes in <<scopescontexts>>.
+We'll talk more about scopes in
+ifndef::generate-index-link[<<scopescontexts>>]
+ifdef::generate-index-link[link:scopescontexts.html[Scopes and contexts]]
+.
 
 ==== EL name
 
@@ -301,7 +316,10 @@ Different modules can specify that they use different alternatives.
 The other way to enable an alternative is to annotate the bean with
 `@Priority` annotation. This will enable it globally.
 
-We cover alternatives in more detail in <<alternatives>>.
+We cover alternatives in more detail in
+ifndef::generate-index-link[<<alternatives>>]
+ifdef::generate-index-link[link:injection.html#alternatives[Alternatives]]
+.
 
 ==== Interceptor binding types
 
@@ -370,7 +388,14 @@ also where we specify the interceptor ordering.
 Better still, we can use `@Priority` annotation to enable the interceptor
 and define it's ordering at the same time.
 
-We'll discuss interceptors, and their cousins, decorators, in <<interceptors>> and <<decorators>>.
+We'll discuss interceptors, and their cousins, decorators, in
+ifndef::generate-index-link[<<interceptors>>]
+ifdef::generate-index-link[link:interceptors.html[Interceptors]]
+and
+ifndef::generate-index-link[<<decorators>>]
+ifdef::generate-index-link[link:decorators.html[Decorators]]
+.
+<<interceptors>> and <<decorators>>.
 
 === What kinds of classes are beans?
 
@@ -590,7 +615,10 @@ injection.
 }
 ------------------------------------------
 
-We'll talk much more about producer methods in <<producer_methods>>.
+We'll talk much more about producer methods in
+ifndef::generate-index-link[<<producer_methods>>]
+ifdef::generate-index-link[link:producermethods.html[Producer methods]]
+.
 
 ==== Producer fields
 
@@ -616,5 +644,7 @@ A producer field is really just a shortcut that lets us avoid writing a
 useless getter method. However, in addition to convenience, producer
 fields serve a specific purpose as an adaptor for Java EE component
 environment injection, but to learn more about that, you'll have to wait
-until <<resources>>. Because we can't wait to get
-to work on some examples.
+until
+ifndef::generate-index-link[<<resources>>]
+ifdef::generate-index-link[link:resources.html[Java EE component environment resources]]
+. Because we can't wait to get to work on some examples.

--- a/docs/reference/src/main/asciidoc/configure.asciidoc
+++ b/docs/reference/src/main/asciidoc/configure.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[configure]]
 == Configuration
 
@@ -31,7 +35,10 @@ This mode is not enabled by default. It can be enabled using the following confi
 |`org.jboss.weld.construction.relaxed` |false (true in weld-se)|If set to `true`, then requirements on bean constructors are relaxed.
 |=======================================================================
 
-Note that relaxed construction is enabled by default in <<weld-se,Weld SE>>.
+Note that relaxed construction is enabled by default in
+ifndef::generate-index-link[<<weld-se,Weld SE>>]
+ifdef::generate-index-link[link:environments.html#weld-se[Weld SE]]
+.
 
 ==== Concurrent deployment configuration
 
@@ -188,7 +195,10 @@ This optimization is used to reduce the HTTP session replication overhead. Howev
 |`org.jboss.weld.serialization.beanIdentifierIndexOptimization` |true (false in weld-servlet)|If set to `true`, the optimization is enabled.
 |=======================================================================
 
-NOTE: This optimization is disabled by default in <<weld-servlet,Servlet containers>>.
+NOTE: This optimization is disabled by default in
+ifndef::generate-index-link[<<weld-servlet,Servlet containers>>]
+ifdef::generate-index-link[link:environments.html#weld-servlet[Servlet containers]]
+.
 
 ==== Rolling upgrades ID delimiter
 
@@ -220,19 +230,43 @@ WARNING: Bean archive identifiers are provided by integrators. Therefore, the ab
 [[config-dev-mode]]
 ==== Development Mode
 
-Some features of the <<devmode,development mode>> may have negative impact on the performance and/or functionality of the application. The following configuration properties allow to tune or disable these features, e.g. to specify the set of components which will be monitored.
+Some features of the
+ifndef::generate-index-link[<<devmode,development mode>>]
+ifdef::generate-index-link[link:developmentmode.html[development mode]]
+may have negative impact on the performance and/or functionality of the application. The following configuration properties allow to tune or disable these features, e.g. to specify the set of components which will be monitored.
 
 .Supported configuration properties
 [cols="1,1,1,2",options="header"]
 |=======================================================================
 |Configuration key|Tool|Default value |Description
-|`org.jboss.weld.probe.invocationMonitor.excludeType`|<<probe,Probe>>|'' |A regular expression. If a non-empty string and the base type for an AnnotatedType or a declaring type for an AnnotatedMember matches this pattern the type is excluded from monitoring.
-|`org.jboss.weld.probe.invocationMonitor.skipJavaBeanProperties`|<<probe,Probe>>|'true' |If set to `true`, the JavaBean accessor methods are not monitored.
-|`org.jboss.weld.probe.eventMonitor.excludeType`|<<probe,Probe>>|'' |A regular expression. If a non-empty string  and the runtime class of the event object matches this pattern the event is excluded from monitoring.
-|`org.jboss.weld.probe.eventMonitor.containerLifecycleEvents`|<<probe,Probe>>|'false'|If set to `true` all the container lifecycle events are monitored during bootstrap.
-|`org.jboss.weld.probe.embedInfoSnippet`|<<probe,Probe>>|'true' | If set to `true` an informative HTML snippet will be added to every HTTP response with Content-Type of value `text/html`.
-|`org.jboss.weld.probe.jmxSupport`|<<probe,Probe>>|'false' | If set to `true` one or more MBean components may be registered so that it's possible to use JMX to access the Probe development tool data.
-|`org.jboss.weld.probe.exportDataAfterDeployment`|<<probe,Probe>>|'' | If a non-empty string the Probe data will be automatically exported after deployment validation. The value represents the path of the directory where to export the data file.
+|`org.jboss.weld.probe.invocationMonitor.excludeType`|
+ifndef::generate-index-link[<<probe,Probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+|'' |A regular expression. If a non-empty string and the base type for an AnnotatedType or a declaring type for an AnnotatedMember matches this pattern the type is excluded from monitoring.
+|`org.jboss.weld.probe.invocationMonitor.skipJavaBeanProperties`|
+ifndef::generate-index-link[<<probe,Probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+|'true' |If set to `true`, the JavaBean accessor methods are not monitored.
+|`org.jboss.weld.probe.eventMonitor.excludeType`|
+ifndef::generate-index-link[<<probe,Probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+|'' |A regular expression. If a non-empty string  and the runtime class of the event object matches this pattern the event is excluded from monitoring.
+|`org.jboss.weld.probe.eventMonitor.containerLifecycleEvents`|
+ifndef::generate-index-link[<<probe,Probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+|'false'|If set to `true` all the container lifecycle events are monitored during bootstrap.
+|`org.jboss.weld.probe.embedInfoSnippet`|
+ifndef::generate-index-link[<<probe,Probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+|'true' | If set to `true` an informative HTML snippet will be added to every HTTP response with Content-Type of value `text/html`.
+|`org.jboss.weld.probe.jmxSupport`|
+ifndef::generate-index-link[<<probe,Probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+|'false' | If set to `true` one or more MBean components may be registered so that it's possible to use JMX to access the Probe development tool data.
+|`org.jboss.weld.probe.exportDataAfterDeployment`|
+ifndef::generate-index-link[<<probe,Probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+|'' | If a non-empty string the Probe data will be automatically exported after deployment validation. The value represents the path of the directory where to export the data file.
 |=======================================================================
 
 TIP: To disable the monitoring entirely set `org.jboss.weld.probe.invocationMonitor.excludeType` and `org.jboss.weld.probe.eventMonitor.excludeType` properties to `.*`.
@@ -279,7 +313,10 @@ The functionality is implemented as a built-in portable extension processing all
 CDI applications consist of user-defined beans implementing the business logic, but also beans coming from libraries (e.g. DeltaSpike) and integrations (e.g. various Java EE technologies - JSF, Bean Validation, Batch).
 Most applications actually use only a small part of the beans provided by libraries and integrations.
 Still, Weld has to retain the metadata for all the beans in memory which can be considerably vast footprint, depending on the application.
-If <<allow-optimized-cleanup>> is allowed, Weld can remove _unused_ beans after bootstrap.
+If
+ifndef::generate-index-link[<<allow-optimized-cleanup>>]
+ifdef::generate-index-link[link:ri-spi.html#allow-optimized-cleanup[Optimized cleanup after bootstrap]]
+is allowed, Weld can remove _unused_ beans after bootstrap.
 
 An _unused_ bean:
 
@@ -291,7 +328,10 @@ An _unused_ bean:
 * does not declare a producer which is eligible for injection to any injection point,
 * is not eligible for injection into any `Instance<X>` injection point.
 
-TIP: If you run <<probe>> and list all the beans in your application, you will almost certainly notice some of them coming from 3rd party libraries which you never use (marked with a trash icon). Those are candidates for _unused beans_ as you can be sure you are not using them.
+TIP: If you run
+ifndef::generate-index-link[<<probe>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe]]
+and list all the beans in your application, you will almost certainly notice some of them coming from 3rd party libraries which you never use (marked with a trash icon). Those are candidates for _unused beans_ as you can be sure you are not using them.
 
 NOTE: As usual, there is a trade-off between memory consumption and bootstrap time. The results may vary depending on the application, but you should always expect (most probably negligible) increase of the bootstrap time.
 
@@ -331,7 +371,10 @@ public class MyExternalConfiguration implements ExternalConfiguration {
 }
 --------------------------------------------------------------------------
 
-Bear in mind that because `ExternalConfiguration` extends a `Service` it is required that any custom external configuration implementation is explicitly registered. See <<_the_weld_spi>> for more information.
+Bear in mind that because `ExternalConfiguration` extends a `Service` it is required that any custom external configuration implementation is explicitly registered. See
+ifndef::generate-index-link[<<_the_weld_spi>>]
+ifdef::generate-index-link[link:ri-spi.html#_the_weld_spi[The Weld SPI]]
+for more information.
 
 Last but not least external configuration is considered a source with the lowest priority which means that the properties specified there can be overriden by other sources such as system properties.
 For information on supported configuration keys, see <<_weld_configuration>>. Also note that entries with unsupported properties will be ignored while invalid property values will lead
@@ -352,7 +395,10 @@ CDI specification does not support regular expression patterns and `!`
 character to invert the activation condition.
 
 All the configuration is done in the `beans.xml` file. For more
-information see <<packaging-and-deployment>>.
+information see
+ifndef::generate-index-link[<<packaging-and-deployment>>]
+ifdef::generate-index-link[link:ee.html#packaging-and-deployment[Packaging and deployment]]
+.
 
 [source.XML, xml]
 ------------------------------------------------------------------------------------------------------

--- a/docs/reference/src/main/asciidoc/contexts.asciidoc
+++ b/docs/reference/src/main/asciidoc/contexts.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[contexts]]
 == Context Management
 

--- a/docs/reference/src/main/asciidoc/decorators.asciidoc
+++ b/docs/reference/src/main/asciidoc/decorators.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[decorators]]
 == Decorators
 

--- a/docs/reference/src/main/asciidoc/developmentmode.asciidoc
+++ b/docs/reference/src/main/asciidoc/developmentmode.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[devmode]]
 == Development Mode
 
@@ -72,10 +76,16 @@ You should see the following log message during initialization of your applicati
 This tool allows you to inspect the application CDI components at runtime.
 There is a default UI - HTML client (single-page application), which is only available in web applications.
 Just point your browser to `protocol://host:port/webappContextPath/weld-probe`, e.g. `http://localhost:8080/weld-numberguess/weld-probe`.
-However, it's also posible to obtain the JSON data through the REST API, eventually (if <<config-dev-mode,JMX support is enabled>>) through the MXBean of name `org.jboss.weld.probe:type=JsonData,context=ID` where ID should be replaced with an idenfitier of an application.
+However, it's also posible to obtain the JSON data through the REST API, eventually (if
+ifndef::generate-index-link[<<config-dev-mode,JMX support is enabled>>]
+ifdef::generate-index-link[link:configure.html#config-dev-mode[JMX support is enabled]]
+) through the MXBean of name `org.jboss.weld.probe:type=JsonData,context=ID` where ID should be replaced with an idenfitier of an application.
 Right now, Probe integration is provided for WildFly, Tomcat and Jetty (Weld Servlet), and Weld SE.
 
-TIP: There are some configuration properties which allow to tune or disable Probe features, e.g. to restrict the set of components which will be monitored. See also <<config-dev-mode>>.
+TIP: There are some configuration properties which allow to tune or disable Probe features, e.g. to restrict the set of components which will be monitored. See also
+ifndef::generate-index-link[<<config-dev-mode>>]
+ifdef::generate-index-link[link:configure.html#config-dev-mode[Development Mode]]
+.
 
 
 [[validation-report]]
@@ -84,7 +94,10 @@ TIP: There are some configuration properties which allow to tune or disable Prob
 If a deployment validation fails and the development mode is enabled a simple HTML report is generated.
 The report contains a lot of useful information such as Weld version, list of enabled beans, list of bean archives, Weld configuration, etc.
 By default, the report is generated to the user's current working directory, ie. `user.dir`.
-However, it is also possible to specify a path to the target directory using the `org.jboss.weld.probe.exportDataAfterDeployment` configuration property - see also <<config-dev-mode>>.
+However, it is also possible to specify a path to the target directory using the `org.jboss.weld.probe.exportDataAfterDeployment` configuration property - see also
+ifndef::generate-index-link[<<config-dev-mode>>]
+ifdef::generate-index-link[link:configure.html#config-dev-mode[Development Mode]]
+.
 
 You should see a similar log message which contains the path to the report file:
 

--- a/docs/reference/src/main/asciidoc/ee.asciidoc
+++ b/docs/reference/src/main/asciidoc/ee.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[ee]]
 == Java EE integration
 

--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -1,10 +1,17 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[environments]]
 == Application servers and environments supported by Weld
 
 === Using Weld with WildFly
 
 WildFly comes with pre-configured Weld. There is no configuration needed to use Weld (or CDI for that matter).
-You may still want to fine-tune Weld with <<configure,additional configuration settings>>.
+You may still want to fine-tune Weld with
+ifndef::generate-index-link[<<configure,additional configuration settings>>]
+ifdef::generate-index-link[link:configure.html[additional configuration settings]]
+.
 
 === GlassFish
 
@@ -379,7 +386,10 @@ NOTE: Bean archive isolation is supported (and enabled by default) from version 
 
 ==== Implicit Bean Archive Support
 
-CDI 1.1 introduced the bean discovery mode of `annotated` used for implicit bean archives (see also <<packaging-and-deployment>>).
+CDI 1.1 introduced the bean discovery mode of `annotated` used for implicit bean archives (see also
+ifndef::generate-index-link[<<packaging-and-deployment>>]
+ifdef::generate-index-link[link:ee.html#packaging-and-deployment[Packaging and deployment]]
+.
 This mode may bring additional overhead during container bootstrap. Therefore, Weld Servlet supports the use of https://github.com/wildfly/jandex[Jandex] bytecode scanning library to speed up the scanning process. Simply put the http://search.maven.org/#search|gav|1|g%3A%22org.jboss%22%20AND%20a%3A%22jandex%22[jandex.jar] on the classpath.
 If Jandex is not found on the classpath Weld will use the Java Reflection as a fallback.
 
@@ -736,7 +746,10 @@ TIP: All Weld SE specific configuration properties could be also set through CDI
 
 ==== Implicit Bean Archive Support
 
-CDI 1.1 introduced the bean discovery mode of `annotated` used for implicit bean archives (see also <<packaging-and-deployment>>). This mode may bring additional overhead during container bootstrap.
+CDI 1.1 introduced the bean discovery mode of `annotated` used for implicit bean archives (see also
+ifndef::generate-index-link[<<packaging-and-deployment>>]
+ifdef::generate-index-link[link:ee.html#packaging-and-deployment[Packaging and deployment]]
+. This mode may bring additional overhead during container bootstrap.
 Therefore, Weld Servlet supports the use of https://github.com/wildfly/jandex[Jandex] bytecode scanning library to speed up the scanning process. Simply put the http://search.maven.org/#search|gav|1|g%3A%22org.jboss%22%20AND%20a%3A%22jandex%22[jandex.jar] on the classpath.
 If Jandex is not found on the classpath Weld will use the Java Reflection as a fallback.
 

--- a/docs/reference/src/main/asciidoc/events.asciidoc
+++ b/docs/reference/src/main/asciidoc/events.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[events]]
 == Events
 

--- a/docs/reference/src/main/asciidoc/example.asciidoc
+++ b/docs/reference/src/main/asciidoc/example.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[example]]
 == JSF web application example
 

--- a/docs/reference/src/main/asciidoc/extend.asciidoc
+++ b/docs/reference/src/main/asciidoc/extend.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[extend]]
 == Portable extensions
 
@@ -226,7 +230,10 @@ BeanManager manager = CDI.current().getBeanManager();
 -----------------------------------------------------
 
 The `CDI` class can be used directly to programmatically lookup CDI
-beans as described in <<_obtaining_a_contextual_instance_by_programmatic_lookup>>
+beans as described in
+ifndef::generate-index-link[<<_obtaining_a_contextual_instance_by_programmatic_lookup>>]
+ifdef::generate-index-link[link:injection.html#_obtaining_a_contextual_instance_by_programmatic_lookup[Obtaining a contextual instance by programmatic lookup]]
+.
 
 [source.JAVA, java]
 ---------------------------
@@ -287,7 +294,10 @@ application. There are even `Bean` objects representing interceptors,
 decorators and producer methods.
 
 The `BeanAttributes` interface exposes all the interesting things we
-discussed in <<_the_anatomy_of_a_bean>>.
+discussed in
+ifndef::generate-index-link[<<_the_anatomy_of_a_bean>>]
+ifdef::generate-index-link[link:beans.html#_the_anatomy_of_a_bean[The anatomy of a bean]]
+.
 
 [source.JAVA, java]
 ------------------------------------------------------------

--- a/docs/reference/src/main/asciidoc/gettingstarted.asciidoc
+++ b/docs/reference/src/main/asciidoc/gettingstarted.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[gettingstarted]]
 == Getting started with Weld
 
@@ -199,7 +203,13 @@ container-managed transactions.
 
 NOTE: Note that due to limitations of servlet containers (e.g. read-only JNDI)
 your application might require some additional configuration as well
-(see <<_tomcat>> and <<_jetty>> for more info).
+(see
+ifndef::generate-index-link[<<_tomcat>>]
+ifdef::generate-index-link[link:environments.html#_tomcat[Tomcat]]
+and
+ifndef::generate-index-link[<<_jetty>>]
+ifdef::generate-index-link[link:environments.html#_jetty[Jetty]]
+for more info).
 
 Let's give the Weld servlet extension a spin on Apache Tomcat. First,
 you'll need to download Tomcat 9.0.11 or later from

--- a/docs/reference/src/main/asciidoc/index.asciidoc
+++ b/docs/reference/src/main/asciidoc/index.asciidoc
@@ -1,0 +1,63 @@
+= Weld {weldVersion} - CDI Reference Implementation
+
+[preface]
+= A note about naming and nomenclature
+
+Throughout this document, mentions of JSR-299, JSR-346 and JSR-365 appear. JSR is
+a document of a proposed specification used in the Java Community
+Process (JCP). JSRs are somewhat analogous to RFCs used by IETF. JSR-299
+and JSR-346 are the JCP specification names for the 1.0 and 1.1 versions
+of CDI, respectively. JSR-365 is the JCP specification name for the CDI 2.0 version.
+
+Shortly before the final draft of JSR-299 was submitted, the
+specification changed its name from "Web Beans" to "Java Contexts and
+Dependency Injection for the Java EE platform", abbreviated CDI. For a
+brief period after the renaming, the reference implementation adopted
+the name "Web Beans". However, this ended up causing more confusion than
+it solved and Red Hat decided to change the name of the reference
+implementation to "Weld". You may still find other documentation, blogs,
+forum posts, etc. that use the old nomenclature. Please update any
+references you can. The naming game is over.
+
+You'll also find that some of the functionality that once existed in the
+specification is now missing, such as defining beans in XML. These
+features will be available as portable extensions.
+
+Note that this reference guide was started while changes were still
+being made to the specification. We've done our best to update it for
+accuracy. If you discover a conflict between what is written in this
+guide and the specification, the specification is the authority—assume
+it is correct. If you believe you have found an error in the
+specification, please report it to the CDI EG.
+
+Below are links to separate documentation chapters.
+
+. link:part1.html[Beans]
+.. link:intro.html[Introduction]
+.. link:beans.html[More about beans]
+.. link:example.html[JSF web application example]
+.. link:injection.html[Dependency injection and programmatic lookup]
+.. link:scopescontexts.html[Scopes and contexts]
+. link:part2.html[Getting Start with Weld, the CDI Reference Implementation]
+.. link:gettingstarted.html[Getting started with Weld]
+.. link:weldexamples.html[Diving into the Weld examples]
+. link:part3.html[Loose Coupling with Strong Typing]
+.. link:producermethods.html[Producer methods]
+.. link:interceptors.html[Interceptors]
+.. link:decorators.html[Decorators]
+.. link:events.html[Events]
+.. link:stereotypes.html[Stereotypes]
+.. link:specialization.html[Specialization, inheritance and alternatives]
+.. link:resources.html[Java EE component environment resources]
+. link:part4.html[CDI and the Java EE Ecosystem]
+.. link:ee.html[Java EE integration]
+.. link:extend.html[Portable extensions]
+.. link:next.html[Next steps]
+. link:part5.html[Weld Reference Guide]
+.. link:environments.html[Application servers and environments supported by Weld]
+.. link:configure.html[Weld configuration]
+.. link:logging.html[Logging]
+.. link:weldmanager.html[`WeldManager` interface]
+.. link:developmentmode.html[Development Mode]
+.. link:contexts.html[Context Management]
+.. link:ri-spi.html[Integrating Weld into other environments]

--- a/docs/reference/src/main/asciidoc/injection.asciidoc
+++ b/docs/reference/src/main/asciidoc/injection.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[injection]]
 == Dependency injection and programmatic lookup
 
@@ -96,7 +100,10 @@ for producer methods:
 
 This is a case where the `@Inject` annotation _is not_ required at the
 injection point. The same is true for observer methods (which we'll meet
-in <<events>>) and disposer methods.
+in
+ifndef::generate-index-link[<<events>>]
+ifdef::generate-index-link[link:events.html[events]]
+) and disposer methods.
 
 === What gets injected
 
@@ -468,7 +475,10 @@ change the type of the injection point to `Y`, or
 [NOTE]
 ====
 Weld also supports a non-standard workaround for this limitation.
-See <<relaxedConstruction,the Configuration chapter>> for more information.
+See
+ifndef::generate-index-link[<<relaxedConstruction, the Configuration chapter>>]
+ifdef::generate-index-link[link:configure.html#relaxedConstruction[the Configuration chapter]]
+for more information.
 ====
 
 === Obtaining a contextual instance by programmatic lookup

--- a/docs/reference/src/main/asciidoc/interceptors.asciidoc
+++ b/docs/reference/src/main/asciidoc/interceptors.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[interceptors]]
 == Interceptors
 

--- a/docs/reference/src/main/asciidoc/intro.asciidoc
+++ b/docs/reference/src/main/asciidoc/intro.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[intro]]
 == Introduction
 

--- a/docs/reference/src/main/asciidoc/logging.asciidoc
+++ b/docs/reference/src/main/asciidoc/logging.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[logging]]
 == Logging
 Weld is using link:https://developer.jboss.org/wiki/JBossLoggingTooling[JBoss Logging], an abstraction layer which provides support for the internationalization and localization of log messages and exception messages. However, JBoss Logging itself does not write any log messages. Instead, it only constructs a log message and delegates to one of the supported logging frameworks.

--- a/docs/reference/src/main/asciidoc/next.asciidoc
+++ b/docs/reference/src/main/asciidoc/next.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[next]]
 == Next steps
 

--- a/docs/reference/src/main/asciidoc/part1.asciidoc
+++ b/docs/reference/src/main/asciidoc/part1.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[part-1]]
 = Beans
 
@@ -23,7 +27,10 @@ full support for Java EE modularity and the Java EE component
 architecture. But the specification does not limit the use of CDI to the
 Java EE environment. Starting with CDI 2.0, the specification covers the use of CDI
 in the Java SE environment as well. In Java SE, the services might be
-provided by a standalone CDI implementation like Weld (see <<_cdi_se_module>>), or even
+provided by a standalone CDI implementation like Weld (see
+ifndef::generate-index-link[<<_cdi_se_module>>]
+ifdef::generate-index-link[link:environments.html#_cdi_se_module[CDI SE Module]]
+), or even
 by a container that also implements the subset of EJB defined for
 embedded usage by the EJB 3.2 specification. CDI is especially useful in
 the context of web application development, but the problems it solves

--- a/docs/reference/src/main/asciidoc/part2.asciidoc
+++ b/docs/reference/src/main/asciidoc/part2.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[part-2]]
 = Getting Start with Weld, the CDI Reference Implementation
 

--- a/docs/reference/src/main/asciidoc/part3.asciidoc
+++ b/docs/reference/src/main/asciidoc/part3.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[part-3]]
 = Loose coupling with strong typing
 

--- a/docs/reference/src/main/asciidoc/part4.asciidoc
+++ b/docs/reference/src/main/asciidoc/part4.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[part-4]]
 = CDI and the Java EE ecosystem
 

--- a/docs/reference/src/main/asciidoc/part5.asciidoc
+++ b/docs/reference/src/main/asciidoc/part5.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[part-5]]
 = Weld Reference Guide
 
@@ -16,7 +20,10 @@ portable extensions to CDI.
 
 If you want to get started quickly using Weld (and, in turn, CDI) with
 WildFly, GlassFish or Tomcat and experiment with one of the examples,
-take a look at <<gettingstarted>>. Otherwise read on for a
+take a look at
+ifndef::generate-index-link[<<gettingstarted>>]
+ifdef::generate-index-link[link:gettingstarted.html[Getting started with Weld]]
+. Otherwise read on for a
 exhaustive discussion of using Weld in all the environments and application
 servers it supports and the Weld extensions.
 --

--- a/docs/reference/src/main/asciidoc/producermethods.asciidoc
+++ b/docs/reference/src/main/asciidoc/producermethods.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[producer_methods]]
 == Producer methods
 

--- a/docs/reference/src/main/asciidoc/resources.asciidoc
+++ b/docs/reference/src/main/asciidoc/resources.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[resources]]
 == Java EE component environment resources
 

--- a/docs/reference/src/main/asciidoc/ri-spi.asciidoc
+++ b/docs/reference/src/main/asciidoc/ri-spi.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[ri-spi]]
 [appendix]
 == Integrating Weld into other environments
@@ -221,7 +225,8 @@ the integrator.
 
 The integrator may choose to provide all EE resource injection services
 themselves, using another library or framework. In this case the
-integrator should use the `EE` environment, and implement the <<_injection_services>> SPI.
+integrator should use the `EE` environment, and implement the
+<<_injection_services>> SPI.
 
 Alternatively, the integrator may choose to use CDI to provide EE
 resource injection. In this case, the `EE_INJECT` environment should be
@@ -462,7 +467,10 @@ To validate the deployed beans, call `Bootstrap.validateBeans()`.
 To place the container into a state where it can service requests, call
 `Bootstrap.endInitialization()`
 
-NOTE: Integrators can set `org.jboss.weld.bootstrap.allowOptimizedCleanup` configuration property using <<external_config>> to allow to perform efficient cleanup and further optimizations after bootstrap. In this case, `Bootstrap.endInitialization()` must be called after all EE components which support injection are installed (that means all relevant `ProcessInjectionTarget` events were already fired).
+NOTE: Integrators can set `org.jboss.weld.bootstrap.allowOptimizedCleanup` configuration property using
+ifndef::generate-index-link[<<external_config>>]
+ifdef::generate-index-link[link:configure.html#external_config[Defining external configuration]]
+to allow to perform efficient cleanup and further optimizations after bootstrap. In this case, `Bootstrap.endInitialization()` must be called after all EE components which support injection are installed (that means all relevant `ProcessInjectionTarget` events were already fired).
 
 To shutdown the container you call `Bootstrap.shutdown()`. This allows
 the container to perform any cleanup operations needed.
@@ -841,7 +849,13 @@ for more details.
 
 ==== Probe Development Tool (Optional)
 
-Optionally, an integrator may register the following <<probe,Probe Development Tool>> components in order to enable its functionality. Note that these components should only be registered if the development mode is enabled - see also <<devmode-enable>>.
+Optionally, an integrator may register the following
+ifndef::generate-index-link[<<probe,Probe Development Tool>>]
+ifdef::generate-index-link[link:developmentmode.html#probe[Probe Development Tool]]
+components in order to enable its functionality. Note that these components should only be registered if the development mode is enabled - see also
+ifndef::generate-index-link[<<devmode-enable>>]
+ifdef::generate-index-link[link:developmentmode.html#devmode-enable[How to enable the development mode]]
+.
 
 .Probe components
 [cols="1,1,2",options="header"]
@@ -859,7 +873,11 @@ NOTE: Probe REST API is implemented using a servlet filter. However, not all ser
 ==== Optimized cleanup after bootstrap
 
 Weld can perfom additional cleanup operations after bootstrap, in order to conserve resources.
-See for example <<remove-unused-beans>>.
+See for example
+ifndef::generate-index-link[<<remove-unused-beans>>]
+ifdef::generate-index-link[link:configure.html#remove-unused-beans[Memory consumption optimization - removing unused beans]]
+.
+
 However, this feature is disabled by default.
 An integrator may enable this feature provided the following requirements are met:
 
@@ -872,7 +890,10 @@ An integrator may enable this feature provided the following requirements are me
 |`org.jboss.weld.bootstrap.allowOptimizedCleanup` |`false`| If set to `true` Weld is allowed to perform efficient cleanup and further optimizations after bootstrap
 |=======================================================================
 
-NOTE: This property can only be set by integrators through <<external_config>>.
+NOTE: This property can only be set by integrators through
+ifndef::generate-index-link[<<external_config>>]
+ifdef::generate-index-link[link:configure.html#external_config[Defining external configuration]]
+.
 
 === Migration notes
 
@@ -978,7 +999,10 @@ Instead, this dependency needs to be deployed separately to the OSGi container.
 
 * Java 6 support was dropped. Java 7 or newer is now required for both compile time and runtime.
 
-* An observer for `@Initialized(ConversationScoped.class)` or `@Destroyed(ConversationScoped.class)` event no longer forces eager conversation context initialization. See also <<_lazy_and_eager_conversation_context_initialization>>.
+* An observer for `@Initialized(ConversationScoped.class)` or `@Destroyed(ConversationScoped.class)` event no longer forces eager conversation context initialization. See also
+ifndef::generate-index-link[<<_lazy_and_eager_conversation_context_initialization>>]
+ifdef::generate-index-link[link:scopescontexts.html#_lazy_and_eager_conversation_context_initialization[Lazy and eager conversation context initialization]]
+.
 
 * `ScheduledExecutorServiceFactory` is deprecated and no default implementation is provided by default. This service has not been used by Weld internals at least since version 1.1.0.Final.
 

--- a/docs/reference/src/main/asciidoc/scopescontexts.asciidoc
+++ b/docs/reference/src/main/asciidoc/scopescontexts.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[scopescontexts]]
 == Scopes and contexts
 
@@ -233,7 +237,10 @@ conversation.setTimeout(timeoutInMillis);
 -----------------------------------------
 
 Another option how to set conversation timeout is to provide configuration
-property defining the new time value. See <<config-conversation-timeout>>.
+property defining the new time value. See
+ifndef::generate-index-link[<<config-conversation-timeout>>]
+ifdef::generate-index-link[link:configure.html#config-conversation-timeout[Conversation timeout and Conversation concurrent access timeout]]
+.
 However note that any conversation might be destroyed any time sooner when
 HTTP session invalidation or timeout occurs.
 

--- a/docs/reference/src/main/asciidoc/specialization.asciidoc
+++ b/docs/reference/src/main/asciidoc/specialization.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[specialization]]
 == Specialization, inheritance and alternatives
 

--- a/docs/reference/src/main/asciidoc/stereotypes.asciidoc
+++ b/docs/reference/src/main/asciidoc/stereotypes.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[stereotypes]]
 == Stereotypes
 

--- a/docs/reference/src/main/asciidoc/weldexamples.asciidoc
+++ b/docs/reference/src/main/asciidoc/weldexamples.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[weldexamples]]
 == Diving into the Weld examples
 
@@ -405,7 +409,10 @@ as a CDI application.
 NOTE: The `beans.xml` file is no longer required for CDI enablement as of CDI
 1.1. CDI is automatically enabled for archives which don't contain
 `beans.xml` but contain one or more bean classes with a _bean defining
-annotation_, as described in section <<_implicit_bean_archive>>.
+annotation_, as described in section
+ifndef::generate-index-link[<<_implicit_bean_archive>>]
+ifdef::generate-index-link[link:ee.html#_implicit_bean_archive[Implicit bean archive]]
+.
 
 The game's main logic is located in `Game.java`. Here is the code for
 that class, highlighting the ways in which this differs from the web
@@ -816,7 +823,10 @@ Finally, let's look at the EJB module, which is located in the example's
 NOTE: The `beans.xml` file is no longer required for CDI enablement as of CDI
 1.1. CDI is automatically enabled for archives which don't contain
 `beans.xml` but contain one or more bean classes with a _bean defining
-annotation_, as described in section <<_implicit_bean_archive>>.
+annotation_, as described in section
+ifndef::generate-index-link[<<_implicit_bean_archive>>]
+ifdef::generate-index-link[link:ee.html#_implicit_bean_archive[Implicit bean archive]]
+.
 
 We've saved the most interesting bit for last, the code! The project has
 two simple beans, `SentenceParser` and `TextTranslator` and two session

--- a/docs/reference/src/main/asciidoc/weldmanager.asciidoc
+++ b/docs/reference/src/main/asciidoc/weldmanager.asciidoc
@@ -1,3 +1,7 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
 [[weldmanager]]
 == `WeldManager` interface
 


### PR DESCRIPTION
…; make sure links are generated conditionally based on whether its single or multi HTML.

Summary:
* Re-introduces mutli HTML docs so that existing links (out in the wild) won't stop working
* Adds index page
* Each HTML now has its TOC and a link to the index page at its top
* All links between varying HTMLs has to be remade to be conditional in order to work correctly for both, single and multi HTML outputs