### PR TITLE
WELD-2645 Change OSGi export statement for modules.

### DIFF
--- a/bundles/osgi/pom.xml
+++ b/bundles/osgi/pom.xml
@@ -90,6 +90,7 @@
                             org.jboss.weld.interceptor.util.proxy;
                             org.jboss.weld.logging;
                             org.jboss.weld.manager;
+                            org.jboss.weld.module.*;
                             org.jboss.weld.security;
                             org.jboss.weld.util;
                             org.jboss.weld.xml;


### PR DESCRIPTION
3.1 variant of https://github.com/weld/core/pull/2159 to make sure this fix lands on both branches.
Again, CI results apart from Travis are to be temporarily ignored.