### PR TITLE
Create GH Actions config file

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -1,0 +1,352 @@
+name: Weld CI
+
+on:
+  pull_request:
+    branches: [ master ]
+    # Do not run for non-code changes
+    paths-ignore:
+      - '.gitignore'
+      - '*.md'
+      - '*.adoc'
+      - '*.txt'
+
+jobs:
+  # builds Weld snapshot, downloads WFLY and upgrades it, prepares ENV variable
+  build-jdk11:
+    name: "Initial JDK 11 Weld Build + WildFly patch"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - name: Download WildFly
+        run: |
+          wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastSuccessful/wildfly-latest-SNAPSHOT.zip
+          unzip wildfly-latest-SNAPSHOT.zip
+          # ZIP contains two more ZIPs, sources and actual WFLY
+          rm wildfly-*-src.zip
+          rm wildfly-latest-SNAPSHOT.zip
+          unzip wildfly-*.zip -d container
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          # Caching is an automated pre/post action that installs the cache if the key exists and exports the cache
+          # after the job is done. In this case we refresh the cache monthly (by changing key) to avoid unlimited growth.
+          key: q2maven-master-${{ steps.get-date.outputs.date }}
+      - name: Build Weld SNAPSHOT
+        run: mvn clean install -DskipTests -B -V
+      - name: Patch WildFly
+        run: |
+          JBOSS_HOME=`pwd`'/container/*'
+          export JBOSS_HOME=`echo $JBOSS_HOME`
+          mvn clean package -Pupdate-jboss-as -Dtck -f jboss-as/pom.xml
+      - name: Zip Patched WildFly
+        run: |
+          cd container/
+          mv ./* wildfly/
+          zip -r wildfly.zip wildfly
+          cd ..
+      - name: Persist WildFly
+        uses: actions/upload-artifact@v1
+        with:
+          name: wildfly-patched-zip
+          path: container/wildfly.zip
+      - name: Tar Maven Repo
+        shell: bash
+        run: tar -czf maven-repo.tgz -C ~ .m2/repository
+      - name: Persist Maven Repo
+        uses: actions/upload-artifact@v1
+        with:
+          name: maven-repo
+          path: maven-repo.tgz
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -r ~/.m2/repository/org/jboss/weld*
+
+  # Weld in-container tests, does NOT include TCKs which are run as a separate job
+  incontainer-tests:
+    name: "Weld In-container Tests - JDK ${{matrix.java.name}}"
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - { name: "8",
+              java-version: 8,
+          }
+          - {
+            name: "11",
+            java-version: 11,
+          }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java.name }}
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: ${{ matrix.java.java-version }}
+
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Download Patched WildFly
+        uses: actions/download-artifact@v1
+        with:
+          name: wildfly-patched-zip
+          path: .
+      - name: Extract WildFly
+        run: unzip wildfly.zip
+      - name: Build with Maven
+        run: |
+          JBOSS_HOME=`pwd`'/wildfly'
+          export JBOSS_HOME=`echo $JBOSS_HOME`
+          mvn clean verify -Dincontainer -pl '!jboss-tck-runner'
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-incontainer-jdk${{matrix.java.name}}
+          path: 'test-reports.tgz'
+
+  # CDI TCKs in WildFly
+  CDI-TCK:
+    name: "CDI TCK - JDK ${{matrix.java.name}}"
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - { name: "8",
+              java-version: 8,
+          }
+          - {
+            name: "11",
+            java-version: 11,
+          }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java.name }}
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: ${{ matrix.java.java-version }}
+
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Download Patched WildFly
+        uses: actions/download-artifact@v1
+        with:
+          name: wildfly-patched-zip
+          path: .
+      - name: Extract WildFly
+        run: unzip wildfly.zip
+      - name: Build with Maven
+        run: |
+          JBOSS_HOME=`pwd`'/wildfly'
+          export JBOSS_HOME=`echo $JBOSS_HOME`
+          mvn clean verify -Dincontainer -f jboss-tck-runner/pom.xml
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-cdi-tck-jdk${{matrix.java.name}}
+          path: 'test-reports.tgz'
+
+  # Weld no-container tests, includes junit, Weld SE tests plus CDI TCKs and integration tests that don't require EE container
+  no-container-tests:
+    name: "Weld Tests w/o Container - JDK ${{matrix.java.name}}"
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - { name: "8",
+              java-version: 8,
+          }
+          - {
+            name: "11",
+            java-version: 11,
+          }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java.name }}
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: ${{ matrix.java.java-version }}
+
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Build with Maven
+        run: |
+          mvn clean verify
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-no-container-jdk${{matrix.java.name}}
+          path: 'test-reports.tgz'
+
+  # Weld Examples build and test, only JDK 11
+  examples-tests:
+    name: "Weld Examples build and test - JDK 11}"
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Download Patched WildFly
+        uses: actions/download-artifact@v1
+        with:
+          name: wildfly-patched-zip
+          path: .
+      - name: Extract WildFly
+        run: unzip wildfly.zip
+      - name: Build with Maven
+        run: |
+          JBOSS_HOME=`pwd`'/wildfly'
+          export JBOSS_HOME=`echo $JBOSS_HOME`
+          mvn clean verify -Darquillian=wildfly-managed -f examples/pom.xml
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-examples
+          path: 'test-reports.tgz'
+
+  # CDI TCK for SE environment
+  CDI-TCK-SE:
+    name: "CDI TCK SE - JDK ${{matrix.java.name}}"
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - { name: "8",
+              java-version: 8,
+          }
+          - {
+            name: "11",
+            java-version: 11,
+          }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java.name }}
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: ${{ matrix.java.java-version }}
+
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Build with Maven
+        run: |
+          mvn clean verify -Dincontainer=se -f jboss-tck-runner/pom.xml
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-cdi-tck-se-jdk${{matrix.java.name}}
+          path: 'test-reports.tgz'
+
+  # Weld SE/Servlet cooperation
+  weld-se-servlet-coop:
+    name: "Weld SE-Servlet Cooperation"
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Build with Maven
+        run: |
+          mvn clean verify -Dincontainer=weld-se-coop -f environments/servlet/tests/jetty/pom.xml
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-se-servlet-coop
+          path: 'test-reports.tgz'

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -11,24 +11,79 @@ on:
       - '*.txt'
 
 jobs:
+  # Job is to be removed once there is a stable nightly build of EE 9 WFLY
+  build-wfly-ee9:
+    name: "Build WFLY EE 9 version"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - name: Checkout WFLY repo
+        uses: actions/checkout@v2
+        with:
+          repository: wildfly/wildfly
+          path: wildfly
+          ref: master
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          # special cache just for WFLY build not to bloat main build
+          key: wfly-maven-cache-${{ steps.get-date.outputs.date }}
+      - name: Build WFLY
+        run: |
+          cd wildfly
+          mvn clean install -DskipTests
+      - name: Zip Patched WildFly
+        run: |
+          cd wildfly/ee-9/dist/target
+          rm wildfly-preview-*.jar
+          mv wildfly-preview-* wildfly/
+          zip -r wildfly-ee9.zip wildfly
+      - name: Persist WildFly
+        uses: actions/upload-artifact@v1
+        with:
+          name: wildfly-snapshot-ee9-zip
+          path: wildfly/ee-9/dist/target/wildfly-ee9.zip
+
   # builds Weld snapshot, downloads WFLY and upgrades it, prepares ENV variable
   build-jdk11:
     name: "Initial JDK 11 Weld Build + WildFly patch"
     runs-on: ubuntu-latest
+    needs: build-wfly-ee9
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
         uses: actions/setup-java@v1.4.3
         with:
           java-version: 11
-      - name: Download WildFly
+      - name: Download EE 9 SNAPSHOT WildFly
+        uses: actions/download-artifact@v1
+        with:
+          name: wildfly-snapshot-ee9-zip
+          path: .
+      - name: Unzip WFLY
         run: |
-          wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastSuccessful/wildfly-latest-SNAPSHOT.zip
-          unzip wildfly-latest-SNAPSHOT.zip
-          # ZIP contains two more ZIPs, sources and actual WFLY
-          rm wildfly-*-src.zip
-          rm wildfly-latest-SNAPSHOT.zip
-          unzip wildfly-*.zip -d container
+          unzip wildfly-ee9.zip -d container
+# This is the original solution that we will use once there is stable WFLY for EE 9 download (replacing the two steps above)
+#      - name: Download WildFly
+#        run: |
+#          wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastSuccessful/wildfly-latest-SNAPSHOT.zip
+#          unzip wildfly-latest-SNAPSHOT.zip
+#          # ZIP contains two more ZIPs, sources and actual WFLY
+#          rm wildfly-*-src.zip
+#          rm wildfly-latest-SNAPSHOT.zip
+#          unzip wildfly-*.zip -d container
+#          cd container
+#          mv ./* wildfly/
       - name: Get Date
         id: get-date
         run: |
@@ -52,7 +107,6 @@ jobs:
       - name: Zip Patched WildFly
         run: |
           cd container/
-          mv ./* wildfly/
           zip -r wildfly.zip wildfly
           cd ..
       - name: Persist WildFly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: java
-jdk:
-  - openjdk8
-  - openjdk11
-script: "mvn verify"
-sudo: false
-cache:
-  directories:
-   - $HOME/.m2/repository


### PR DESCRIPTION
This is a draft and will not yet pass because it doesn't yet use EE 9 version of WFLY. I have talked to Brian and there is a good chance there will be nightly builds of those later this week.
So instead of creating a hacky build that needs several snapshots, I'd rather consume their nightly.

The testing setup is otherwise identical to that of 3.1 branch with the exception of different cache setup so that both branches use their own cache.