### PR TITLE
WELD-2649 Add jakartaee URI to BeansXmlStreamParser

### DIFF
--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
@@ -64,7 +64,7 @@ public class BeansXmlStreamParser {
 
     public static final String JAVAEE_LEGACY_URI = "http://java.sun.com/xml/ns/javaee";
     public static final String JAVAEE_URI = "http://xmlns.jcp.org/xml/ns/javaee";
-    public static final String JAKARTAEE_URI = "http://jakarta.ee/xml/ns/jakartaee";
+    public static final String JAKARTAEE_URI = "https://jakarta.ee/xml/ns/jakartaee";
     public static final Set<String> JAVAEE_URIS = ImmutableSet.of(JAVAEE_LEGACY_URI, JAVAEE_URI, JAKARTAEE_URI);
 
     public static final String WELD_URI = "http://jboss.org/schema/weld/beans";

--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
@@ -64,10 +64,11 @@ public class BeansXmlStreamParser {
 
     public static final String JAVAEE_LEGACY_URI = "http://java.sun.com/xml/ns/javaee";
     public static final String JAVAEE_URI = "http://xmlns.jcp.org/xml/ns/javaee";
-    public static final Set<String> JAVAEE_URIS = ImmutableSet.of(JAVAEE_LEGACY_URI, JAVAEE_URI);
+    public static final String JAKARTAEE_URI = "http://jakarta.ee/xml/ns/jakartaee";
+    public static final Set<String> JAVAEE_URIS = ImmutableSet.of(JAVAEE_LEGACY_URI, JAVAEE_URI, JAKARTAEE_URI);
 
     public static final String WELD_URI = "http://jboss.org/schema/weld/beans";
-    public static final Set<String> SCANNING_URIS = ImmutableSet.of(WELD_URI, JAVAEE_URI, JAVAEE_LEGACY_URI);
+    public static final Set<String> SCANNING_URIS = ImmutableSet.of(WELD_URI, JAVAEE_URI, JAVAEE_LEGACY_URI, JAKARTAEE_URI);
 
     private static final String VERSION_ATTRIBUTE_NAME = "version";
     private static final String BEAN_DISCOVERY_MODE_ATTRIBUTE_NAME = "bean-discovery-mode";

--- a/tests/src/test/java/org/jboss/weld/tests/unit/bootstrap/xml/cdi30/Beans30XmlParsingTest.java
+++ b/tests/src/test/java/org/jboss/weld/tests/unit/bootstrap/xml/cdi30/Beans30XmlParsingTest.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.weld.tests.unit.bootstrap.xml.cdi30;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.jboss.weld.bootstrap.WeldBootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
+import org.jboss.weld.bootstrap.spi.BeansXml;
+import org.jboss.weld.bootstrap.spi.Filter;
+import org.jboss.weld.bootstrap.spi.Metadata;
+import org.jboss.weld.metadata.FilterPredicate;
+import org.jboss.weld.resources.DefaultResourceLoader;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+
+public class Beans30XmlParsingTest {
+
+    private final WeldBootstrap bootstrap = new WeldBootstrap();
+
+    private BeansXml getBeansXml(String filename) {
+        return bootstrap.parse(Beans30XmlParsingTest.class.getResource(filename));
+    }
+
+    @Test
+    public void testCdi30Namespace() {
+        BeansXml xml = getBeansXml("cdi30-beans.xml");
+        assertEquals(xml.getBeanDiscoveryMode(), BeanDiscoveryMode.ANNOTATED);
+        assertEquals(xml.getVersion(), "3.0");
+        Collection<Metadata<Filter>> filters = xml.getScanning().getExcludes();
+        assertEquals(filters.size(), 3);
+        for (Metadata<Filter> filter : filters) {
+            new FilterPredicate(filter, DefaultResourceLoader.INSTANCE);
+        }
+    }
+}

--- a/tests/src/test/resources/org/jboss/weld/tests/unit/bootstrap/xml/cdi30/cdi30-beans.xml
+++ b/tests/src/test/resources/org/jboss/weld/tests/unit/bootstrap/xml/cdi30/cdi30-beans.xml
@@ -1,0 +1,10 @@
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       version="3.0" bean-discovery-mode="annotated">
+    <scan>
+        <exclude name="com.acme.foo.Foo" />
+        <exclude name="com.acme.bar.*" />
+        <exclude name="com.acme.baz.**" />
+    </scan>
+</beans>


### PR DESCRIPTION
This updates BeansXmlStreamParser to recognise the new jakartaee URI for beans.xmls [as per the spec](https://jakarta.ee/specifications/cdi/3.0/jakarta-cdi-spec-3.0.html#_major_changes)  

This fixes https://issues.redhat.com/browse/WELD-2649