### PR TITLE
WELD-2650 Use Phaser to implement a barrier system and prevent race c…

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/servlet/dispatch/TestBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/servlet/dispatch/TestBean.java
@@ -16,6 +16,9 @@
  */
 package org.jboss.weld.tests.servlet.dispatch;
 
+import java.util.concurrent.Phaser;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
@@ -23,21 +26,31 @@ public class TestBean {
 
     private int constructions;
     private int destructions;
+    private Phaser phaser;
 
     public void constructed() {
         constructions++;
+        phaser.register();
     }
 
     public void destroyed() {
         destructions++;
+        phaser.arriveAndDeregister();
     }
 
     public boolean isOk() {
+        try {
+            // either the phaser has already reached stability (phase 0 and terminated) or we wait for it
+            phaser.awaitAdvanceInterruptibly(0, 2l, TimeUnit.SECONDS);
+        } catch (InterruptedException | TimeoutException e) {
+            throw new IllegalStateException("Waiting for Phaser stability failed, exception throws was: " + e);
+        }
         return (constructions == destructions) && (constructions + destructions > 0);
     }
 
     public void reset() {
         constructions = destructions = 0;
+        phaser = new Phaser();
     }
 
     public int getConstructions() {


### PR DESCRIPTION
…ondition.

The issue here is that sometimes the second assertion (== second https request) gets completed before the first one is done with bean destructions. Hence we need some sort of barrier approach to make sure we give it enough time.