### PR TITLE
Jetty servlet tests should have parent version 4.0.1.

### DIFF
--- a/environments/servlet/tests/jetty/pom.xml
+++ b/environments/servlet/tests/jetty/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>weld-servlet-parent</artifactId>
         <groupId>org.jboss.weld.servlet</groupId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This is currently breaking other PR tests for master because se-servlet coop tests are using it.