### PR TITLE
WELD-2647 Add two automated tests; one standard and one using generic… 

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/InterceptedSubclassFactory.java
@@ -242,12 +242,9 @@ public class InterceptedSubclassFactory<T> extends ProxyFactory<T> {
                                 createForwardingMethodBody(classMethod, methodInfo, staticConstructor);
                                 BeanLogger.LOG.addingMethodToProxy(method);
                             } else {
+                                // we only want to add default methods, rest is abstract and cannot be invoked
                                 if (Reflections.isDefault(method)) {
                                     createDelegateMethod(proxyClassType, method, methodInfo);
-                                } else {
-                                    final ClassMethod classMethod = proxyClassType.addMethod(method);
-                                    createSpecialMethodBody(classMethod, methodInfo, staticConstructor);
-                                    BeanLogger.LOG.addingMethodToProxy(method);
                                 }
                             }
                         } catch (DuplicateMemberException e) {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/AbstractDecorator.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/AbstractDecorator.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated;
+
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+
+@Decorator
+public abstract class AbstractDecorator implements InterfaceWithDefaultMethod {
+
+    @Inject
+    @Delegate
+    InterfaceWithDefaultMethod delegate;
+
+    @Override
+    public String decoratedMethod() {
+        return AbstractDecorator.class.getSimpleName() + delegate.decoratedMethod();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/DecoratingInterfaceWithDefaultMethodTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/DecoratingInterfaceWithDefaultMethodTest.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Decorator on an interface that only decorated non-default method. Contains a variant for standard and
+ * abstract decorators.
+ *
+ * See also WELD-2647
+ */
+@RunWith(Arquillian.class)
+public class DecoratingInterfaceWithDefaultMethodTest {
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(DecoratingInterfaceWithDefaultMethodTest.class))
+                .decorate(NonAbstractDecorator.class)
+                .decorate(AbstractDecorator.class)
+                .addPackage(DecoratingInterfaceWithDefaultMethodTest.class.getPackage());
+    }
+
+    @Inject
+    FooBean bean;
+
+    @Test
+    public void testDecoratorOnInterfaceWithDefaultMethod() {
+        Assert.assertEquals(InterfaceWithDefaultMethod.class.getSimpleName(), bean.defaultPing());
+        Assert.assertEquals(AbstractDecorator.class.getSimpleName() + FooBean.class.getSimpleName() + NonAbstractDecorator.class.getSimpleName(), bean.decoratedMethod());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/FooBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/FooBean.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class FooBean implements InterfaceWithDefaultMethod {
+
+    @Override
+    public String decoratedMethod() {
+        return FooBean.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/InterfaceWithDefaultMethod.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/InterfaceWithDefaultMethod.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated;
+
+public interface InterfaceWithDefaultMethod extends PlainInterface{
+
+    default String defaultPing() {
+        return InterfaceWithDefaultMethod.class.getSimpleName();
+    }
+
+    String decoratedMethod();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/NonAbstractDecorator.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/NonAbstractDecorator.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated;
+
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+
+@Decorator
+public class NonAbstractDecorator implements InterfaceWithDefaultMethod {
+
+    @Inject
+    @Delegate
+    InterfaceWithDefaultMethod delegate;
+
+    @Override
+    public String decoratedMethod() {
+        return delegate.decoratedMethod() + NonAbstractDecorator.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/PlainInterface.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/PlainInterface.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated;
+
+public interface PlainInterface {
+    String defaultPing();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/DecoratingInterfaceWithDefaultMethodAndGenericsTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/DecoratingInterfaceWithDefaultMethodAndGenericsTest.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated.generic;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Similar to {@code DecoratingInterfaceWithDefaultMethodTest} but the interface uses generics.
+ */
+@RunWith(Arquillian.class)
+public class DecoratingInterfaceWithDefaultMethodAndGenericsTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(DecoratingInterfaceWithDefaultMethodAndGenericsTest.class))
+                .decorate(DecoratorClass.class)
+                .addPackage(DecoratingInterfaceWithDefaultMethodAndGenericsTest.class.getPackage());
+    }
+
+    @Inject
+    SomeBean bean;
+
+    @Test
+    public void testDecoratorOnInterfaceWithDefaultMethod() {
+        Assert.assertEquals("foo", bean.defaultMethod().getString());
+        Assert.assertEquals(DecoratorClass.class.getSimpleName() + SomeBean.class.getSimpleName(), bean.ping());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/DecoratorClass.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/DecoratorClass.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated.generic;
+
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.inject.Inject;
+
+@Decorator
+public class DecoratorClass implements GenericInterfaceWithDefaultMethod {
+
+    @Inject
+    @Delegate
+    GenericInterfaceWithDefaultMethod delegate;
+
+    @Override
+    public String ping() {
+        return DecoratorClass.class.getSimpleName() + delegate.ping();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/Foo.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated.generic;
+
+/**
+ * Dummy class used for generic syntax
+ */
+public class Foo<K, L extends String> {
+
+    private K typeParam;
+    private L string;
+
+    public Foo(K typeParam, L string) {
+        this.typeParam = typeParam;
+        this.string = string;
+    }
+
+    public L getString() {
+        return string;
+    }
+
+    public K getTypeParam() {
+        return typeParam;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/GenericInterface.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/GenericInterface.java
@@ -1,0 +1,22 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated.generic;
+
+public interface GenericInterface<K extends Number> {
+    Foo<K, String> defaultMethod();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/GenericInterfaceWithDefaultMethod.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/GenericInterfaceWithDefaultMethod.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated.generic;
+
+public interface GenericInterfaceWithDefaultMethod extends GenericInterface<Integer> {
+
+    default Foo<Integer, String> defaultMethod() {
+        return new Foo<>(1, "foo");
+    }
+
+    String ping();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/SomeBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/decorators/defaultmethod/notDecorated/generic/SomeBean.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.decorators.defaultmethod.notDecorated.generic;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class SomeBean implements GenericInterfaceWithDefaultMethod {
+
+    @Override
+    public String ping() {
+        return SomeBean.class.getSimpleName();
+    }
+}


### PR DESCRIPTION
…s. Note that these tests were failing intermittently based on order in which interfaces were processed. Added a fix that subclasses don't create method delegation for abstract interface methods.

The removed code doesn't seem to have any purpose and was probably never invoked as it would have to result in `UnsupportedException` because the invocation was always made on an interface method that was abstract.
In this case it was problematic only if the superinterface (without default method impl) was processed first and generated the method code into subclass. Subsequently, the creation of proper delegation for default method was skipped because duplicate method was already present. Hence the failures were intermittent because based on ordering of interface processing, it might first generate delegate method for the correct (default) method impl.