### PR TITLE
WELD-2618 Make proxy name creation more deterministic.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -35,7 +35,6 @@ import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -277,10 +276,12 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
         for (Class<?> type : typeInfo.getInterfaces()) {
             interfaces.add(type.getSimpleName());
         }
-        Collections.sort(interfaces);
-        for (final String iface : interfaces) {
-            name.append(iface);
-            name.append('$');
+        // no need to sort the set, because we copied and already sorted one
+        for (int i = 0; i < interfaces.size(); i++) {
+            name.append(interfaces.get(i));
+            if (i < interfaces.size() - 1) {
+                name.append("$");
+            }
         }
         //there is a remote chance that this could generate the same
         //proxy name for two interfaces with the same simple name.


### PR DESCRIPTION
See https://issues.redhat.com/browse/WELD-2618 for more information on what is the current "issue" with the creation process and for reproducer.

I did use the same test the aforementioned issue has to confirm results although I chose not to add it into this PR as it uses not-so-nice reflections to invoke the method because whole `ProxyFactory` isn't public.

I do not have a string opinion about the current versus proposed proxy names, but I don't see a reason to make it more deterministic and readable.
@mkouba WDYT?