### PR TITLE
WELD-2657 With JDK 11, Class.getPackage no longer returns null for cl…

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -106,7 +106,7 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
     protected static final String INVOKE_METHOD_NAME = "invoke";
     protected static final String METHOD_HANDLER_FIELD_NAME = "methodHandler";
     static final String JAVA = "java";
-    static final String NULL = "the class package is null";
+    static final String NO_PACKAGE = "the class package is null or empty";
     static final String SIGNED = "the class is signed";
     private static final Set<ProxiedMethodFilter> METHOD_FILTERS;
 
@@ -203,7 +203,7 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
             }
         } else {
             String reason = getDefaultPackageReason(proxiedBeanType);
-            if (reason != null && reason.equals(NULL)) {
+            if (reason != null && reason.equals(NO_PACKAGE)) {
                 proxyPackage = DEFAULT_PROXY_PACKAGE;
                 BeanLogger.LOG.generatingProxyToDefaultPackage(proxiedBeanType, DEFAULT_PROXY_PACKAGE, reason);
             } else {
@@ -283,8 +283,8 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
     }
 
     private static String getDefaultPackageReason(Class<?> clazz) {
-        if (clazz.getPackage() == null) {
-            return NULL;
+        if (clazz.getPackage() == null || clazz.getPackage().getName().isEmpty()) {
+            return NO_PACKAGE;
         }
         if (clazz.getSigners() != null) {
             return SIGNED;


### PR DESCRIPTION
…asses in default packages.

WELD-2657 holds more details about this - https://issues.redhat.com/browse/WELD-2657