### PR TITLE
Update WFLY version for patches, add on-release job to build and test…

### DIFF
--- a/.github/workflows/ci-release-job.yml
+++ b/.github/workflows/ci-release-job.yml
@@ -1,0 +1,76 @@
+# This job triggers automatically when a tag is created from the branch
+# Its purpose is to create and archive WFLY patch as zip file and to test it
+name: Weld Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build-jdk11:
+    name: "Create Patch file"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Weld Core repo
+        uses: actions/checkout@v2
+        with:
+          path: core
+      # TODO not used ATM; if we try to build dist here, the artifacts wouldn't be signed
+      - name: Checkout Weld dist repo
+        uses: actions/checkout@v2
+        with:
+          repository: weld/dist
+          path: dist
+      - name: Set up JDK
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: 11
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
+      - name: Cache Maven Repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: q2maven-${{ steps.get-date.outputs.date }}
+      - name: Build Weld SNAPSHOT
+        run: mvn clean install -Ddist -DskipTests -B -V -f core/pom.xml
+      - name: Export env variables
+        run: |
+          echo "WELD_VERSION=$(mvn -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive exec:exec -f core/pom.xml)" >> $GITHUB_ENV
+          echo "WFLY_VERSION=$(mvn help:evaluate -Dexpression=wildfly.download.version -q -DforceStdout -f core/jboss-as/pom.xml)" >> $GITHUB_ENV
+      # TODO we should figure out why patch building doesn't work with 11+
+      - name: Set up JDK 8 for patch building
+        uses: actions/setup-java@v1.4.3
+        with:
+          # done with JDK 8 because WFLY patch building utilities don't work with 11
+          java-version: 8
+      - name: Create WFLY patch
+        run: mvn clean package -Pdownload-wfly,update-jboss-as,wfly-patch-gen -f core/jboss-as/pom.xml
+      - name: Rename patch
+        run: |
+          cd core/jboss-as/target
+          mv patch.zip $GITHUB_WORKSPACE/wildfly-$WFLY_VERSION-weld-$WELD_VERSION-patch.zip
+      - name: Persist WildFly patch
+        uses: actions/upload-artifact@v2
+        with:
+          name: wildfly-patch
+          path: wildfly-${{ env.WFLY_VERSION }}-weld-${{ env.WELD_VERSION }}-patch.zip
+      - name: Get WFLY and patch it
+        run: |
+          mvn clean package -Pdownload-wfly -f core/jboss-as/pom.xml
+          mkdir wflyServer
+          mv core/jboss-as/target/wildfly-original/*/* wflyServer
+          cd wflyServer
+          ./bin/jboss-cli.bat|sh --command="patch apply $GITHUB_WORKSPACE/wildfly-$WFLY_VERSION-weld-$WELD_VERSION-patch.zip"
+      - name: Use Patched WFLY To Run Arq. Tests
+        run: |
+          export JBOSS_HOME=$GITHUB_WORKSPACE/wflyServer
+          mvn clean verify -Dincontainer -f core/tests-arquillian/pom.xml
+      - name: Delete Local Artifacts From Cache
+        shell: bash
+        run: rm -r ~/.m2/repository/org/jboss/weld*

--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -35,7 +35,7 @@
         <!-- Following section is dedicated to WFLY download and patch creation -->
         <!-- Path to the patched WFLY server, if you chose to let Maven download it, this default will be used-->
         <!-- Maven will download pristine WFLY for you, but you need to provide a patched one yourself and make JBOSS_HOME point at it-->
-        <wildflyPatched>${project.build.directory}/wildfly-patched/wildfly-${wildfly.download.version}</wildflyPatched>
+        <wildflyPatched>${project.build.directory}/wildfly-patched/wildfly-preview-${wildfly.download.version}</wildflyPatched>
         <!--Path to patch file; only change if you have your own, else Maven downloads it-->
         <patchConfigFile>${project.build.directory}/patch.xml</patchConfigFile>
         <!--These patches are automatically downloaded from github.com/weld/build/tree/master/wildfly; specify the file name here to determine which one to use-->
@@ -44,8 +44,8 @@
         <patchOutputFile>${project.build.directory}/patch.zip</patchOutputFile>
         <!--Path to original (pristine) WFLY-->
         <!--Running with -Pdownload-wfly will make Maven download the version specified below-->
-        <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-${wildfly.download.version}</wildflyOriginal>
-        <wildfly.download.version>20.0.1.Final</wildfly.download.version>
+        <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-preview-${wildfly.download.version}</wildflyOriginal>
+        <wildfly.download.version>23.0.0.Final</wildfly.download.version>
 
         <!--Plugin versions-->
         <download.maven.plugin>1.6.1</download.maven.plugin>
@@ -94,11 +94,11 @@
         <profile>
             <id>download-wfly</id>
             <properties>
-                <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-${wildfly.download.version}</wildflyOriginal>
+                <wildflyOriginal>${project.build.directory}/wildfly-original/wildfly-preview-${wildfly.download.version}</wildflyOriginal>
                 <!--Set jboss.home property to the location of the copy of WFLY we download-->
-                <jboss.home>${project.build.directory}/wildfly-patched/wildfly-${wildfly.download.version}</jboss.home>
+                <jboss.home>${project.build.directory}/wildfly-patched/wildfly-preview-${wildfly.download.version}</jboss.home>
                 <!--Set wildflyPatched property for patch creation, this assumes you patch the WFLY by running -Pupdate-jboss-as as well-->
-                <wildflyPatched>${project.build.directory}/wildfly-patched/wildfly-${wildfly.download.version}</wildflyPatched>
+                <wildflyPatched>${project.build.directory}/wildfly-patched/wildfly-preview-${wildfly.download.version}</wildflyPatched>
             </properties>
             <build>
                 <plugins>
@@ -115,7 +115,7 @@
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>org.wildfly</groupId>
-                                            <artifactId>wildfly-dist</artifactId>
+                                            <artifactId>wildfly-preview-dist</artifactId>
                                             <version>${wildfly.download.version}</version>
                                             <type>tar.gz</type>
                                             <overWrite>false</overWrite>


### PR DESCRIPTION
… patch.

This should theoretically let us build patches for Weld 4 (which we didn't do until now since there was no WFLY release) but in practice the patch-gen util fails. I am trying to see why it happens and whether it's misconfiguration or just plain impossible to use that tool for WFLY preview ATM.