### PR TITLE
Update Weld API to SP4.

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <weld.api.bom.version>3.1.SP3</weld.api.bom.version>
+        <weld.api.bom.version>3.1.SP4</weld.api.bom.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <shrinkwrap.resolver.version>3.1.4</shrinkwrap.resolver.version>
         <testng.version>6.14.3</testng.version>
         <testng.jcommander.version>1.78</testng.jcommander.version>
-        <weld.api.version>3.1.SP3</weld.api.version>
+        <weld.api.version>3.1.SP4</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>3.0.1.Final</wildfly.arquillian.version>
     </properties>


### PR DESCRIPTION
New API version doesn't have any functional changes it just deprecates the `ProxyServices#supportsClassDefining`.