### PR TITLE
Make sure jboss-logging is not adding @Generated annotation to its cl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
…asses as it can cause mess between JDK 8 and 9+.