### PR TITLE
WELD-2662 Fix an issue where you couldn't create proxy for producer m…

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/ClassDefiningWithProducerTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/ClassDefiningWithProducerTest.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.classDefining.a.BeanWithProducer;
+import org.jboss.weld.tests.classDefining.b.BeanInterface;
+import org.jboss.weld.tests.classDefining.c.AppScopedBean;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+/**
+ * Tests that we are able to define a proxy class for producer method that returns a type from different package.
+ * In JDK 11+ this means we need to perform lsookup in correct module.
+ */
+@RunWith(Arquillian.class)
+public class ClassDefiningWithProducerTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ClassDefiningWithProducerTest.class))
+                .addClass(ClassDefiningWithProducerTest.class)
+                .addClass(BeanWithProducer.class)
+                .addClass(BeanInterface.class)
+                .addClass(AppScopedBean.class);
+    }
+
+    @Inject
+    BeanWithProducer bean;
+
+    @Test
+    public void testProxyDefinitionWorks() {
+        // invoke the method
+        Assert.assertEquals(666, bean.ping());
+        Assert.assertEquals(666, bean.pingNested());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/a/BeanWithProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/a/BeanWithProducer.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.a;
+
+import org.jboss.weld.tests.classDefining.c.AppScopedBean;
+import org.jboss.weld.tests.classDefining.b.BeanInterface;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithProducer {
+
+    @Inject
+    private AppScopedBean bean;
+
+    private int number;
+    private int number2;
+
+    @Produces
+    @ApplicationScoped
+    public BeanInterface createTestInterface() {
+        return x -> number = x;
+    }
+
+
+    @Produces
+    @ApplicationScoped
+    public BeanInterface.NestedInterface createNestedInterface() {
+        return x -> number2 = x;
+    }
+
+    public int ping() {
+        bean.passNumberToInterface();
+        return number;
+    }
+
+    public int pingNested() {
+        bean.passNumberToNestedInterface();
+        return number2;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/b/BeanInterface.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/b/BeanInterface.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.b;
+
+@FunctionalInterface
+public interface BeanInterface {
+
+    void setNumber(int number);
+
+    @FunctionalInterface
+    interface NestedInterface {
+        void setNumber(int number);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/c/AppScopedBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/c/AppScopedBean.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.c;
+
+import org.jboss.weld.tests.classDefining.b.BeanInterface;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class AppScopedBean {
+
+    @Inject
+    private BeanInterface intf;
+
+    @Inject
+    private BeanInterface.NestedInterface nested;
+
+    public void passNumberToInterface() {
+        intf.setNumber(666);
+    }
+
+    public void passNumberToNestedInterface() {
+        nested.setNumber(666);
+    }
+}


### PR DESCRIPTION
…ethod with return type from another package.

The actual issue lies in `WeldDefaultProxyServices#defineWithMethodLookup` where we need to determine which module is the target of lookup. We do so by looking at earliest occurrence of `$` which was missing in this scenario.