### PR TITLE
[3.1] [WELD-2664] Don't wrap ImmediateInstanceFactory in WeldInstanceFactory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .project
+.checkstyle
 .classpath
 .settings
 .factorypath

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/undertow/WeldServletExtension.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/undertow/WeldServletExtension.java
@@ -19,8 +19,12 @@ package org.jboss.weld.environment.undertow;
 import io.undertow.servlet.ServletExtension;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.FilterInfo;
+import io.undertow.servlet.api.InstanceFactory;
 import io.undertow.servlet.api.ListenerInfo;
 import io.undertow.servlet.api.ServletInfo;
+import io.undertow.servlet.util.ImmediateInstanceFactory;
+
+import java.util.EventListener;
 
 import javax.servlet.ServletContext;
 
@@ -54,7 +58,10 @@ public class WeldServletExtension implements ServletExtension {
             // Listener injection
             for (ListenerInfo listener : deploymentInfo.getListeners()) {
                 UndertowLogger.LOG.installingCdiSupport(listener.getListenerClass());
-                listener.setInstanceFactory(WeldInstanceFactory.of(listener.getInstanceFactory(), servletContext, listener.getListenerClass()));
+                InstanceFactory<? extends EventListener> instanceFactory = listener.getInstanceFactory();
+                if (!(instanceFactory instanceof ImmediateInstanceFactory)) {
+                    listener.setInstanceFactory(WeldInstanceFactory.of(instanceFactory, servletContext, listener.getListenerClass()));
+                }
             }
             servletContext.setAttribute(INSTALLED, INSTALLED_FULL);
         } catch (NoSuchMethodError e) {


### PR DESCRIPTION
Undertow uses the ImmediateInstanceFactory where a pre-instantiated instance of the Object should be used so this should not be wrapped in a WeldInstanceFactory as that attempts to create a second instance.

https://issues.redhat.com/browse/WELD-2664