### PR TITLE
WELD-2666 - Reproducer and potential fix for proxy naming of hierarchical interfa…

### DIFF
--- a/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
@@ -397,8 +397,6 @@ public interface BeanLogger extends WeldLogger {
 
     /**
      * ID of this message was originally 0 but in jboss-logging zero is a special value meaning no ID
-     *
-     * @param params
      */
     @LogMessage(level = Level.TRACE)
     @Message(id = 1536, value = "Found {0} constructors annotated with @Inject for {1}", format = Format.MESSAGE_FORMAT)
@@ -549,4 +547,7 @@ public interface BeanLogger extends WeldLogger {
 
     @Message(id = 1578, value = "WeldDefaultProxyServices failed to load/define a class with name {0} whose original class was {1} because all attempts to determine a class loader ended with null.", format = Format.MESSAGE_FORMAT)
     IllegalStateException cannotDetermineClassLoader(Object beanName, Object originalClass);
+
+    @Message(id = 1579, value = "An instance of ProxyFactory.ProxyNameHolder has to contain a class name. This instance was created for bean class: {1}", format = Format.MESSAGE_FORMAT)
+    IllegalArgumentException tryingToCreateProxyNameHolderWithoutClassName(Object bean);
 }

--- a/impl/src/main/java/org/jboss/weld/util/CustomClassComparator.java
+++ b/impl/src/main/java/org/jboss/weld/util/CustomClassComparator.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.util;
+
+import java.util.Comparator;
+
+/**
+ * This comparator sorts classes alphabetically based on {@link Class#getName()} with notable difference that all
+ * classes starting with {@code java.*} or {@code javax.*} come <b>after</b> all other classes.
+ *
+ * E.g. a set of these classes {javax.bar.Baz, java.something.Foo, bar.baz.Quax, mypackage.indeed.SomeBean} would be sorted
+ * in the following manner - {bar.baz.Quax, mypackage.indeed.SomeBean, java.something.Foo, javax.bar.Baz}.
+ */
+public class CustomClassComparator implements Comparator<Class<?>> {
+
+    private final String javaPrefix = "java.";
+    private final String javaxPrefix = "javax.";
+
+    @Override
+    public int compare(Class<?> o1, Class<?> o2) {
+        String firstClassName = o1.getName();
+        String secondClassName = o2.getName();
+        // if no class starts with java.* or javax.* or if both start with it, perform standard comparison
+        // if only one starts with this prefix, it goes later
+        boolean firstClassHasJavaPrefix = firstClassName.startsWith(javaPrefix) || firstClassName.startsWith(javaxPrefix);
+        boolean secondClassHasJavaPrefix = secondClassName.startsWith(javaPrefix) || secondClassName.startsWith(javaxPrefix);
+        if (firstClassHasJavaPrefix) {
+            if (secondClassHasJavaPrefix) {
+                // both classes prefixed
+                return firstClassName.compareTo(secondClassName);
+            } else {
+                // first class prefixed, second class not
+                return 1;
+            }
+        } else {
+            if (secondClassHasJavaPrefix) {
+                // first class is not prefixed, second class is
+                return -1;
+            } else {
+                // neither class is prefixed
+                return firstClassName.compareTo(secondClassName);
+            }
+        }
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/util/Proxies.java
+++ b/impl/src/main/java/org/jboss/weld/util/Proxies.java
@@ -24,10 +24,12 @@ import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.enterprise.inject.spi.Bean;
@@ -39,6 +41,8 @@ import org.jboss.weld.exceptions.UnproxyableResolutionException;
 import org.jboss.weld.logging.UtilLogger;
 import org.jboss.weld.logging.ValidatorLogger;
 import org.jboss.weld.util.collections.Arrays2;
+import org.jboss.weld.util.collections.ImmutableList;
+import org.jboss.weld.util.collections.ImmutableMap;
 import org.jboss.weld.util.reflection.Reflections;
 
 /**
@@ -56,32 +60,35 @@ public class Proxies {
 
         private final List<Class<?>> interfaces;
         private final List<Class<?>> classes;
+        private final Map<String, String> classToPackageMap;
 
         private TypeInfo(Set<? extends Type> types) {
-            Comparator<Class<?>> classComparator = Comparator.comparing(Class::getName);
             List<Class<?>> foundInterfaces = new ArrayList<>();
             List<Class<?>> foundClasses = new ArrayList<>();
+            Map<String, String> classToPackage = new HashMap<>();
 
-            types.stream().forEach(type -> add(type, foundInterfaces, foundClasses));
+            types.stream().forEach(type -> add(type, foundInterfaces, foundClasses, classToPackage));
 
-            // sort both collections and create unmodifiable lists
-            Collections.sort(foundClasses, classComparator);
-            Collections.sort(foundInterfaces, classComparator);
-            this.interfaces = Collections.unmodifiableList(foundInterfaces);
-            this.classes = Collections.unmodifiableList(foundClasses);
+            // sort both collections and create immutable collections
+            Collections.sort(foundClasses, Comparator.comparing(Class::getName));
+            Collections.sort(foundInterfaces, new CustomClassComparator());
+            this.interfaces = ImmutableList.copyOf(foundInterfaces);
+            this.classes = ImmutableList.copyOf(foundClasses);
+            this.classToPackageMap = ImmutableMap.copyOf(classToPackage);
         }
 
         // only invoked during object construction, arrays are then immutable
-        private TypeInfo add(Type type, List<Class<?>> foundInterfaces, List<Class<?>> foundClasses) {
+        private TypeInfo add(Type type, List<Class<?>> foundInterfaces, List<Class<?>> foundClasses, Map<String, String> classToPackageMap) {
             if (type instanceof Class<?>) {
                 Class<?> clazz = (Class<?>) type;
+                classToPackageMap.put(clazz.getName(), clazz.getPackage().getName());
                 if (clazz.isInterface()) {
                     foundInterfaces.add(clazz);
                 } else {
                     foundClasses.add(clazz);
                 }
             } else if (type instanceof ParameterizedType) {
-                add(((ParameterizedType) type).getRawType(), foundInterfaces, foundClasses);
+                add(((ParameterizedType) type).getRawType(), foundInterfaces, foundClasses, classToPackageMap);
             } else {
                 throw UtilLogger.LOG.cannotProxyNonClassType(type);
             }
@@ -124,6 +131,10 @@ public class Proxies {
 
         public List<Class<?>> getInterfaces() {
             return interfaces;
+        }
+
+        public String getPackageNameForClass(Class<?> clazz) {
+            return classToPackageMap.get(clazz.getName());
         }
 
         public static TypeInfo of(Set<? extends Type> types) {

--- a/impl/src/test/java/foo/bar/Foo.java
+++ b/impl/src/test/java/foo/bar/Foo.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foo.bar;
+
+/**
+ * Used by {@link org.jboss.weld.tests.unit.comparator.CustomComparatorTest}
+ */
+public class Foo {
+}

--- a/impl/src/test/java/foo/bar/quax/Quax.java
+++ b/impl/src/test/java/foo/bar/quax/Quax.java
@@ -1,0 +1,24 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package foo.bar.quax;
+
+/**
+ * Used by {@link org.jboss.weld.tests.unit.comparator.CustomComparatorTest}
+ */
+public class Quax {
+}

--- a/impl/src/test/java/org/jboss/weld/tests/unit/comparator/CustomComparatorTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/comparator/CustomComparatorTest.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.unit.comparator;
+
+import foo.bar.Foo;
+import foo.bar.quax.Quax;
+import org.jboss.weld.SimpleCDI;
+import org.jboss.weld.util.CustomClassComparator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.security.Principal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests sorting collections with {@link CustomClassComparator}.
+ */
+public class CustomComparatorTest {
+
+    @Test
+    public void testComparator() {
+        List<Class<?>> testedList = prepareList(new ArrayList<>(), false);
+        List<Class<?>> expectedList = prepareList(new ArrayList<>(), true);
+        // sort the list
+        Collections.sort(testedList, new CustomClassComparator());
+        // assert
+        assertListsEqual(expectedList, testedList);
+    }
+
+    private List<Class<?>> prepareList(List<Class<?>> list, boolean sorted) {
+        Class<?> clazz1 = Principal.class;
+        Class<?> clazz2 = CustomClassComparator.class;
+        Class<?> clazz3 = CustomComparatorTest.class;
+        Class<?> clazz4 = Class.class;
+        Class<?> clazz5 = SimpleCDI.class;
+        Class<?> clazz6 = Foo.class;
+        Class<?> clazz7 = Quax.class;
+
+        if (sorted) {
+            list.add(clazz6);
+            list.add(clazz7);
+            list.add(clazz5);
+            list.add(clazz3);
+            list.add(clazz2);
+            list.add(clazz4);
+            list.add(clazz1);
+        } else {
+            list.add(clazz1);
+            list.add(clazz2);
+            list.add(clazz3);
+            list.add(clazz4);
+            list.add(clazz5);
+            list.add(clazz6);
+            list.add(clazz7);
+        }
+        return list;
+    }
+
+    // compare based on class names as class itself doesn't implement equals
+    private void assertListsEqual(List<Class<?>> expected, List<Class<?>> actual) {
+        Assert.assertEquals(expected.size(), actual.size());
+        for (int i = 0; i < expected.size(); i++) {
+            Assert.assertEquals(expected.get(i).getName(), actual.get(i).getName());
+        }
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/ClassDefiningWithProducerTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/ClassDefiningWithProducerTest.java
@@ -34,7 +34,7 @@ import javax.inject.Inject;
 
 /**
  * Tests that we are able to define a proxy class for producer method that returns a type from different package.
- * In JDK 11+ this means we need to perform lsookup in correct module.
+ * In JDK 11+ this means we need to perform lookup in correct module.
  */
 @RunWith(Arquillian.class)
 public class ClassDefiningWithProducerTest {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/AMuchBetterPrincipal.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/AMuchBetterPrincipal.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.inherited;
+
+import java.security.Principal;
+
+/**
+ * Naming is intentional, this class alphabetically precedes Principal
+ */
+public interface AMuchBetterPrincipal extends Principal {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/BeanProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/BeanProducer.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.inherited;
+
+import org.jboss.weld.tests.classDefining.inherited.extending.MyInterface;
+import org.jboss.weld.tests.classDefining.inherited.base.AncestorInterface;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class BeanProducer {
+
+    // produce a proxied bean for a type with interface hierarchy
+    @Produces
+    @ApplicationScoped
+    public MyInterface produceBean() {
+        return new MyInterface() {
+            @Override
+            public String anotherPing() {
+                return MyInterface.class.getSimpleName();
+            }
+
+            @Override
+            public String ping() {
+                return AncestorInterface.class.getSimpleName();
+            }
+        };
+    }
+
+    @Produces
+    @ApplicationScoped
+    public AMuchBetterPrincipal producePrincipal() {
+        return new AMuchBetterPrincipal() {
+            @Override
+            public String getName() {
+                return AMuchBetterPrincipal.class.getSimpleName();
+            }
+        };
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/ConsumerBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/ConsumerBean.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.inherited;
+
+import org.jboss.weld.tests.classDefining.inherited.extending.MyInterface;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ConsumerBean {
+
+    @Inject
+    MyInterface bean;
+
+    @Inject
+    AMuchBetterPrincipal principal;
+
+    public MyInterface getProducedInterfaceBean() {
+        return bean;
+    }
+
+    public AMuchBetterPrincipal getPrincipal() {
+        return principal;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/ProxyForHierarchicalInterfaceTypeTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/ProxyForHierarchicalInterfaceTypeTest.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.inherited;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.classDefining.inherited.base.AncestorInterface;
+import org.jboss.weld.tests.classDefining.inherited.extending.MyInterface;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Inject;
+
+/**
+ * Tests that you can create a proxy (specifically under JDK 11) from producer that returns a hierarchical interface
+ * type. E.g. tests that the resulting proxy name has package corresponding to its class name.
+ *
+ * One of the proxies is built on an interface extending Principal, this is deliberate as that lies in java.* package
+ * which gets special treatment.
+ */
+@RunWith(Arquillian.class)
+public class ProxyForHierarchicalInterfaceTypeTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ProxyForHierarchicalInterfaceTypeTest.class))
+                .addClass(AncestorInterface.class)
+                .addClass(MyInterface.class)
+                .addClass(ConsumerBean.class)
+                .addClass(BeanProducer.class)
+                .addClass(AMuchBetterPrincipal.class);
+    }
+
+    @Inject
+    ConsumerBean bean;
+
+    @Test
+    public void testProxyDefinitionWorks() {
+        // invoke the method, the verification lies mainly in not getting errors when creating proxy
+        MyInterface interfaceBean = this.bean.getProducedInterfaceBean();
+        Assert.assertEquals(MyInterface.class.getSimpleName(), interfaceBean.anotherPing());
+        Assert.assertEquals(AncestorInterface.class.getSimpleName(), interfaceBean.ping());
+        // assert that the proxy from hierarchical interface start with package based on alphabetical ordering of partaking classes
+        Assert.assertTrue(interfaceBean.getClass().getName().startsWith("org.jboss.weld.tests.classDefining.inherited.base.AncestorInterface"));
+
+        AMuchBetterPrincipal principal = this.bean.getPrincipal();
+        Assert.assertEquals(AMuchBetterPrincipal.class.getSimpleName(), principal.getName());
+        // assert that the proxy created from Principal and custom class has the package of custom class even though it is alphabetically reversed
+        Assert.assertTrue(principal.getClass().getName().startsWith("org.jboss.weld.tests.classDefining.inherited.AMuchBetterPrincipal"));
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/base/AncestorInterface.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/base/AncestorInterface.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.inherited.base;
+
+/**
+ * Name matters - it deliberately alphabetically precedes MyInterface to verify correct proxy name
+ */
+public interface AncestorInterface {
+
+    String ping();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/extending/MyInterface.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/inherited/extending/MyInterface.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.classDefining.inherited.extending;
+
+import org.jboss.weld.tests.classDefining.inherited.base.AncestorInterface;
+
+public interface MyInterface extends AncestorInterface {
+
+    String anotherPing();
+}


### PR DESCRIPTION
…ce-based beans.

This PR attempts to address the issue that we sometimes create a non-existent combination of proxy package and it's classes. This leads to issues when doing JDK 11 lookup. The fix here lies in choosing the class sequence first and attaching the respective package of the first class chosen.

This should cover the two cases I and @darranl discovered.

However, there is one more TODO in the code where I would like @mkouba opinion.
It is a case of extending a `Principal` (or any other interface that comes from `java` package) - in current solution the `Principal.class.getName()` alphabetically precedes the extending interface which in proxy creation leads to a proxy such as `java.security.Principal$AMuchBetterPrincipal$....`.
This in turns means that we will have to use Weld custom class loader to define the class instead of `MethodHandles.Lookup`. So I was thinking if it's worth a shot at re-ordering the interfaces so that (if applicable) we always put a non `java.*` package classes first. WDYT Martin?