### PR TITLE
**DO NOT MERGE** CI test

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -43,7 +43,7 @@ jobs:
 #          # after the job is done. In this case we refresh the cache monthly (by changing key) to avoid unlimited growth.
 #          key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build Weld SNAPSHOT
-        run: mvn clean install -DskipTests -B -V
+        run: mvn clean install -DskipTests -B -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Patch WildFly
         run: |
           JBOSS_HOME=`pwd`'/container/*'
@@ -115,7 +115,7 @@ jobs:
         run: |
           JBOSS_HOME=`pwd`'/wildfly'
           export JBOSS_HOME=`echo $JBOSS_HOME`
-          mvn clean verify -Dincontainer -pl '!jboss-tck-runner,!impl'
+          mvn clean verify -Dincontainer -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -pl '!jboss-tck-runner,!impl'
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -178,7 +178,7 @@ jobs:
         run: |
           JBOSS_HOME=`pwd`'/wildfly'
           export JBOSS_HOME=`echo $JBOSS_HOME`
-          mvn clean verify -Dincontainer -f jboss-tck-runner/pom.xml
+          mvn clean verify -Dincontainer -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -f jboss-tck-runner/pom.xml
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -233,7 +233,7 @@ jobs:
       - name: Build with Maven
         # avoid building impl as that can only be done with JDK 11
         run: |
-          mvn clean verify -pl '!impl'
+          mvn clean verify -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -pl '!impl'
       - name: Test core-impl separately
         run: |
           mvn surefire:test -f impl/pom.xml
@@ -279,7 +279,7 @@ jobs:
         run: |
           JBOSS_HOME=`pwd`'/wildfly'
           export JBOSS_HOME=`echo $JBOSS_HOME`
-          mvn clean verify -Darquillian=wildfly-managed -f examples/pom.xml
+          mvn clean verify -Darquillian=wildfly-managed -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -f examples/pom.xml
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -333,7 +333,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
-          mvn clean verify -Dincontainer=se -f jboss-tck-runner/pom.xml
+          mvn clean verify -Dincontainer=se -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -f jboss-tck-runner/pom.xml
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash
@@ -367,7 +367,7 @@ jobs:
         run: tar -xzf maven-repo.tgz -C ~
       - name: Build with Maven
         run: |
-          mvn clean verify -Dincontainer=weld-se-coop -f environments/servlet/tests/jetty/pom.xml
+          mvn clean verify -Dincontainer=weld-se-coop -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -f environments/servlet/tests/jetty/pom.xml
       - name: Prepare failure archive (if maven failed)
         if: failure()
         shell: bash

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -34,14 +34,14 @@ jobs:
         run: |
           echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
         shell: bash
-      - name: Cache Maven Repository
-        id: cache-maven
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          # Caching is an automated pre/post action that installs the cache if the key exists and exports the cache
-          # after the job is done. In this case we refresh the cache monthly (by changing key) to avoid unlimited growth.
-          key: q2maven-${{ steps.get-date.outputs.date }}
+#      - name: Cache Maven Repository
+#        id: cache-maven
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/.m2/repository
+#          # Caching is an automated pre/post action that installs the cache if the key exists and exports the cache
+#          # after the job is done. In this case we refresh the cache monthly (by changing key) to avoid unlimited growth.
+#          key: q2maven-${{ steps.get-date.outputs.date }}
       - name: Build Weld SNAPSHOT
         run: mvn clean install -DskipTests -B -V
       - name: Patch WildFly


### PR DESCRIPTION
CI test, disables caching (for increased error rate) and adds bunch of magical options that may or may not solve the timeout error that GH actions keep getting.