### PR TITLE
WELD-2673 @Decorated Bean<> injection point can get populated with wrong meta data

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/ActualBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/ActualBean.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ActualBean implements SomeInterface {
+
+    @Override
+    @SomeBinding
+    public String ping() {
+        return "pong";
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorOne.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorOne.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Decorated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
+
+@Decorator
+@Priority(1)
+public class DecoratorOne implements SomeInterface {
+
+    @Delegate
+    @Inject
+    SomeInterface delegate;
+
+    @Inject
+    @Decorated
+    Bean<SomeInterface> metadata;
+
+    @Override
+    public String ping() {
+        return metadata.getBeanClass().getSimpleName() + delegate.ping();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorTwo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorTwo.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import jakarta.annotation.Priority;
+import jakarta.decorator.Decorator;
+import jakarta.decorator.Delegate;
+import jakarta.enterprise.inject.Decorated;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
+
+@Decorator
+@Priority(2)
+public class DecoratorTwo implements SomeInterface{
+
+    @Delegate
+    @Inject
+    SomeInterface delegate;
+
+    @Inject
+    @Decorated
+    Bean<SomeInterface> metadata;
+
+    @Override
+    public String ping() {
+        return metadata.getBeanClass().getSimpleName() + delegate.ping();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorOne.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorOne.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@Priority(1)
+@SomeBinding
+public class InterceptorOne {
+
+    @Inject
+    @Intercepted
+    Bean<?> metadata;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed() + metadata.getBeanClass().getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorTwo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorTwo.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Intercepted;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.inject.Inject;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@Priority(1)
+@SomeBinding
+public class InterceptorTwo {
+
+    @Inject
+    @Intercepted
+    Bean<?> metadata;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed() + metadata.getBeanClass().getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/MultipleDecoratorsMetadataTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/MultipleDecoratorsMetadataTest.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class MultipleDecoratorsMetadataTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(MultipleDecoratorsMetadataTest.class))
+                .addPackage(MultipleDecoratorsMetadataTest.class.getPackage());
+    }
+
+    @Inject
+    SomeInterface bean;
+
+    @Test
+    public void beanMetadataAvailableTest(){
+        String beanClass = ActualBean.class.getSimpleName();
+        String expected = beanClass + beanClass + "pong" + beanClass + beanClass;
+        Assert.assertEquals(expected, bean.ping());
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeBinding.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeBinding.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface SomeBinding {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeInterface.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeInterface.java
@@ -1,0 +1,23 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+public interface SomeInterface {
+
+    String ping();
+}


### PR DESCRIPTION
Automated test includes two decorators (which are the issue) and two interceptors (which seem to work fine), both of which use injected metadata, applied to a single bean method invocation.

The issue seems to be that decorators create a different creational context hierarchy than interceptors,
Interceptors always have a parent CC of the bean the intercept whereas with multiple decorators, that doesn't seem to be true.
With interceptors the CC hierarchy is: `ActualBean` -> [`DecoratorOne`, `DecoratorTwo`]
With decorators the CC hierarchy is: `ActualBean` -> `DecoratorOne` -> `DecoratorTwo`

The current "fix" here is really just a workaround. I need to figure out why are the CCs created differently for decorators in the first place.