### PR TITLE
WELD-2673 Add automated test, make sure that even when several decora…

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/builtin/DecoratedBeanMetadataBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/DecoratedBeanMetadataBean.java
@@ -16,10 +16,13 @@
  */
 package org.jboss.weld.bean.builtin;
 
+import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.Collections;
 import java.util.Set;
 
+import javax.enterprise.context.spi.Contextual;
+import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.Decorated;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.Decorator;
@@ -27,8 +30,11 @@ import javax.enterprise.inject.spi.InjectionPoint;
 
 import org.jboss.weld.bean.BeanIdentifiers;
 import org.jboss.weld.bean.StringBeanIdentifier;
+import org.jboss.weld.contexts.WeldCreationalContext;
 import org.jboss.weld.literal.DecoratedLiteral;
+import org.jboss.weld.logging.InterceptorLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.util.bean.SerializableForwardingBean;
 
 /**
  * Allows a decorator to obtain information about the bean it decorates.
@@ -47,6 +53,32 @@ public class DecoratedBeanMetadataBean extends InterceptedBeanMetadataBean {
     protected void checkInjectionPoint(InjectionPoint ip) {
         if (!(ip.getBean() instanceof Decorator<?>)) {
             throw new IllegalArgumentException("@Decorated Bean<?> can only be injected into a decorator.");
+        }
+    }
+
+    @Override
+    protected Bean<?> newInstance(InjectionPoint ip, CreationalContext<Bean<?>> ctx) {
+        checkInjectionPoint(ip);
+
+        WeldCreationalContext<?> decoratorContext = getParentCreationalContext(ctx);
+        WeldCreationalContext<?> beanContext = getParentCreationalContext(decoratorContext);
+        // when there are more decorators present, a CreationalContext hierarchy is created between them
+        // we want to iterate over this hierarchy to make sure we return the original decorated bean
+        while (beanContext.getContextual() instanceof Decorator) {
+            beanContext = getParentCreationalContext(beanContext);
+        }
+        Contextual<?> decoratedContextual = beanContext.getContextual();
+
+        if (decoratedContextual instanceof Bean<?>) {
+            Bean<?> bean = (Bean<?>) decoratedContextual;
+            if (bean instanceof Serializable) {
+                return bean;
+            } else {
+                return SerializableForwardingBean.of(getBeanManager().getContextId(), bean);
+            }
+        } else {
+            InterceptorLogger.LOG.unableToDetermineInterceptedBean(ip);
+            return null;
         }
     }
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/ActualBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/ActualBean.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ActualBean implements SomeInterface {
+
+    @Override
+    @SomeBinding
+    public String ping() {
+        return "pong";
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorOne.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorOne.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import javax.annotation.Priority;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.inject.Decorated;
+import javax.enterprise.inject.spi.Bean;
+import javax.inject.Inject;
+
+@Decorator
+@Priority(1)
+public class DecoratorOne implements SomeInterface {
+
+    @Delegate
+    @Inject
+    SomeInterface delegate;
+
+    @Inject
+    @Decorated
+    Bean<SomeInterface> metadata;
+
+    @Override
+    public String ping() {
+        return metadata.getBeanClass().getSimpleName() + delegate.ping();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorTwo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/DecoratorTwo.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import javax.annotation.Priority;
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.enterprise.inject.Decorated;
+import javax.enterprise.inject.spi.Bean;
+import javax.inject.Inject;
+
+@Decorator
+@Priority(2)
+public class DecoratorTwo implements SomeInterface{
+
+    @Delegate
+    @Inject
+    SomeInterface delegate;
+
+    @Inject
+    @Decorated
+    Bean<SomeInterface> metadata;
+
+    @Override
+    public String ping() {
+        return metadata.getBeanClass().getSimpleName() + delegate.ping();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorOne.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorOne.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Intercepted;
+import javax.enterprise.inject.spi.Bean;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Interceptor
+@Priority(1)
+@SomeBinding
+public class InterceptorOne {
+
+    @Inject
+    @Intercepted
+    Bean<?> metadata;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed() + metadata.getBeanClass().getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorTwo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/InterceptorTwo.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import javax.annotation.Priority;
+import javax.enterprise.inject.Intercepted;
+import javax.enterprise.inject.spi.Bean;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+@Interceptor
+@Priority(1)
+@SomeBinding
+public class InterceptorTwo {
+
+    @Inject
+    @Intercepted
+    Bean<?> metadata;
+
+    @AroundInvoke
+    public Object intercept(InvocationContext ctx) throws Exception {
+        return ctx.proceed() + metadata.getBeanClass().getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/MultipleDecoratorsMetadataTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/MultipleDecoratorsMetadataTest.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import javax.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class MultipleDecoratorsMetadataTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(MultipleDecoratorsMetadataTest.class))
+                .addPackage(MultipleDecoratorsMetadataTest.class.getPackage());
+    }
+
+    @Inject
+    SomeInterface bean;
+
+    @Test
+    public void beanMetadataAvailableTest(){
+        String beanClass = ActualBean.class.getSimpleName();
+        String expected = beanClass + beanClass + "pong" + beanClass + beanClass;
+        Assert.assertEquals(expected, bean.ping());
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeBinding.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeBinding.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import javax.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@InterceptorBinding
+@Inherited
+@Target({ TYPE, METHOD })
+@Retention(RUNTIME)
+public @interface SomeBinding {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeInterface.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/builtinBeans/metadata/multiple/decorators/interceptors/SomeInterface.java
@@ -1,0 +1,23 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.builtinBeans.metadata.multiple.decorators.interceptors;
+
+public interface SomeInterface {
+
+    String ping();
+}


### PR DESCRIPTION
…tors are present, they are always getting metadata of the bean they decorate.

A 3.1 variant of https://github.com/weld/core/pull/2365 where we agreed on this approach.