### PR TITLE
WELD-2677 - Implement a backward compatibility option that allows to …

### DIFF
--- a/docs/reference/src/main/asciidoc/configure.asciidoc
+++ b/docs/reference/src/main/asciidoc/configure.asciidoc
@@ -345,6 +345,30 @@ The following properties can be used to restrict the set of beans Weld is going 
 |`org.jboss.weld.bootstrap.unusedBeans.excludeAnnotation` |`javax\\.ws\\.rs.*`| A regular expression. A bean is not removed if the corresponding `AnnotatedType`, or any member, is annotated with an annotation which matches this pattern. By default, a type annotated with any JAX-RS annotation is excluded from removal.
 |=======================================================================
 
+[[legacy-empty-beans-xml]]
+==== Legacy mode for treatment of empty `beans.xml` files
+
+Starting with CDI 4.0, bean archives with empty `beans.xml` have discovery mode `annotated`.
+However, CDI mandates that there is a compatibility configuration option that users can leverage to switch this back to `all` discovery mode. Since this option is temporary and serves to ease the migration process to new CDI version, users are strongly encouraged to adapt their bean archives accordingly.
+
+Every platform and container needs to provide their own way to configure this and users should look into their respective documentation for guidance.
+
+For Weld SE, users can start Weld container with following property:
+
+[source.JAVA, java]
+--------------------------------------------------------------------------
+try (WeldContainer container = new Weld()
+    // LEGACY_EMPTY_BEANS_XML_TREATMENT = "org.jboss.weld.se.discovery.emptyBeansXmlModeAll"
+    .property(Weld.LEGACY_EMPTY_BEANS_XML_TREATMENT, true)
+    .initialize()) {
+      performAppLogic();
+}
+--------------------------------------------------------------------------
+
+For Weld Servlet, there is a `ServletContext` parameter with `String` key `org.jboss.weld.environment.servlet.emptyBeansXmlModeAll` that, if set to `true`, triggers this legacy behavior.
+
+WARNING: Since this configuration has to be known prior to Weld discovery, it cannot be defined through standard means! Furthermore, this option will act as a global configuration affecting all of your bean archives in the deployed application!
+
 [[external_config]]
 === Defining external configuration
 

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractBeanArchiveScanner.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractBeanArchiveScanner.java
@@ -29,13 +29,16 @@ import org.jboss.weld.bootstrap.spi.BeansXml;
 public abstract class AbstractBeanArchiveScanner implements BeanArchiveScanner {
 
     protected final Bootstrap bootstrap;
+    // Allow to treat empty beans.xml as having discovery mode other than default (which is ANNOTATED from CDI 4.0)
+    protected final BeanDiscoveryMode emptyBeansXmlDiscoveryMode;
 
     /**
      *
      * @param bootstrap
      */
-    public AbstractBeanArchiveScanner(Bootstrap bootstrap) {
+    public AbstractBeanArchiveScanner(Bootstrap bootstrap, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
         this.bootstrap = bootstrap;
+        this.emptyBeansXmlDiscoveryMode = emptyBeansXmlDiscoveryMode;
     }
 
     protected boolean accept(BeansXml beansXml) {
@@ -43,7 +46,7 @@ public abstract class AbstractBeanArchiveScanner implements BeanArchiveScanner {
     }
 
     protected BeansXml parseBeansXml(URL beansXmlUrl) {
-        return bootstrap.parse(beansXmlUrl);
+        return bootstrap.parse(beansXmlUrl, emptyBeansXmlDiscoveryMode);
     }
 
 }

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/AbstractDiscoveryStrategy.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import jakarta.annotation.Priority;
 
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.bootstrap.spi.Metadata;
 import org.jboss.weld.environment.deployment.WeldBeanDeploymentArchive;
@@ -62,8 +63,11 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
 
     private final List<BeanArchiveHandler> handlers;
 
+    private final BeanDiscoveryMode emptyBeansXmlDiscoveryMode;
+
     protected AbstractDiscoveryStrategy() {
         handlers = new LinkedList<BeanArchiveHandler>();
+        this.emptyBeansXmlDiscoveryMode = BeanDiscoveryMode.ANNOTATED;
     }
 
     /**
@@ -71,12 +75,16 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
      * @param resourceLoader
      * @param bootstrap
      * @param initialBeanDefiningAnnotations
+     * @param emptyBeansXmlDiscoveryMode
      */
-    public AbstractDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap, Set<Class<? extends Annotation>> initialBeanDefiningAnnotations) {
+    public AbstractDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap,
+                                     Set<Class<? extends Annotation>> initialBeanDefiningAnnotations,
+                                     BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
         handlers = new LinkedList<BeanArchiveHandler>();
         setResourceLoader(resourceLoader);
         setBootstrap(bootstrap);
         setInitialBeanDefiningAnnotations(initialBeanDefiningAnnotations);
+        this.emptyBeansXmlDiscoveryMode = emptyBeansXmlDiscoveryMode;
     }
 
     @Override
@@ -102,7 +110,7 @@ public abstract class AbstractDiscoveryStrategy implements DiscoveryStrategy {
     public Set<WeldBeanDeploymentArchive> performDiscovery() {
 
         if (scanner == null) {
-            scanner = new DefaultBeanArchiveScanner(resourceLoader, bootstrap);
+            scanner = new DefaultBeanArchiveScanner(resourceLoader, bootstrap, emptyBeansXmlDiscoveryMode);
         }
 
         final List<BeanArchiveBuilder> beanArchiveBuilders = new ArrayList<BeanArchiveBuilder>();

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/ClassPathBeanArchiveScanner.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/ClassPathBeanArchiveScanner.java
@@ -39,6 +39,7 @@ import jakarta.enterprise.inject.spi.Extension;
 
 import org.jboss.logging.Logger;
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.config.ConfigurationKey;
 import org.jboss.weld.environment.deployment.AbstractWeldDeployment;
@@ -75,8 +76,8 @@ public class ClassPathBeanArchiveScanner extends AbstractBeanArchiveScanner {
      *
      * @param bootstrap
      */
-    public ClassPathBeanArchiveScanner(Bootstrap bootstrap) {
-        super(bootstrap);
+    public ClassPathBeanArchiveScanner(Bootstrap bootstrap, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        super(bootstrap, emptyBeansXmlDiscoveryMode);
     }
 
     @Override

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DefaultBeanArchiveScanner.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DefaultBeanArchiveScanner.java
@@ -36,6 +36,7 @@ import java.util.zip.ZipFile;
 
 import org.jboss.logging.Logger;
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.environment.deployment.AbstractWeldDeployment;
 import org.jboss.weld.environment.deployment.WeldResourceLoader;
@@ -59,8 +60,8 @@ public class DefaultBeanArchiveScanner extends AbstractBeanArchiveScanner {
      * @param resourceLoader
      * @param bootstrap
      */
-    public DefaultBeanArchiveScanner(ResourceLoader resourceLoader, Bootstrap bootstrap) {
-        super(bootstrap);
+    public DefaultBeanArchiveScanner(ResourceLoader resourceLoader, Bootstrap bootstrap, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        super(bootstrap, emptyBeansXmlDiscoveryMode);
         this.resourceLoader = resourceLoader;
     }
 

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyFactory.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.Metadata;
 import org.jboss.weld.environment.deployment.discovery.jandex.Jandex;
 import org.jboss.weld.environment.logging.CommonLogger;
@@ -46,7 +47,8 @@ public final class DiscoveryStrategyFactory {
      * @return the discovery strategy
      */
     public static DiscoveryStrategy create(ResourceLoader resourceLoader, Bootstrap bootstrap,
-        Set<Class<? extends Annotation>> initialBeanDefiningAnnotations, boolean jandexStrategyDisabled) {
+        Set<Class<? extends Annotation>> initialBeanDefiningAnnotations, boolean jandexStrategyDisabled,
+        BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
         DiscoveryStrategy returnValue = null;
         final Iterator<Metadata<DiscoveryStrategy>> iterator = ServiceLoader.load(DiscoveryStrategy.class, resourceLoader).iterator();
         if (iterator != null && iterator.hasNext()) {
@@ -64,15 +66,18 @@ public final class DiscoveryStrategyFactory {
             } else {
                 CommonLogger.LOG.usingJandex();
                 try {
-                    returnValue = Jandex.createJandexDiscoveryStrategy(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
+                    returnValue = Jandex.createJandexDiscoveryStrategy(resourceLoader, bootstrap,
+                            initialBeanDefiningAnnotations, emptyBeansXmlDiscoveryMode);
                 } catch (Exception e) {
                     throw CommonLogger.LOG.unableToInstantiate(Jandex.JANDEX_DISCOVERY_STRATEGY_CLASS_NAME,
-                        Arrays.toString(new Object[] { resourceLoader, bootstrap, initialBeanDefiningAnnotations }), e);
+                        Arrays.toString(new Object[] { resourceLoader, bootstrap,
+                                initialBeanDefiningAnnotations, emptyBeansXmlDiscoveryMode }), e);
                 }
             }
         }
         if (returnValue == null) {
-            returnValue = new ReflectionDiscoveryStrategy(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
+            returnValue = new ReflectionDiscoveryStrategy(resourceLoader, bootstrap, initialBeanDefiningAnnotations,
+                    emptyBeansXmlDiscoveryMode);
         }
         return returnValue;
     }

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/ReflectionDiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/ReflectionDiscoveryStrategy.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.environment.deployment.WeldBeanDeploymentArchive;
 import org.jboss.weld.environment.logging.CommonLogger;
 import org.jboss.weld.environment.util.Reflections;
@@ -37,8 +38,10 @@ public class ReflectionDiscoveryStrategy extends AbstractDiscoveryStrategy {
 
     private final AtomicBoolean annotatedDiscoveryProcessed;
 
-    public ReflectionDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap, Set<Class<? extends Annotation>> initialBeanDefiningAnnotations) {
-        super(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
+    public ReflectionDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap,
+                                       Set<Class<? extends Annotation>> initialBeanDefiningAnnotations,
+                                       BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        super(resourceLoader, bootstrap, initialBeanDefiningAnnotations, emptyBeansXmlDiscoveryMode);
         this.annotatedDiscoveryProcessed = new AtomicBoolean(false);
         registerHandler(new FileSystemBeanArchiveHandler());
     }

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/Jandex.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/Jandex.java
@@ -5,6 +5,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Set;
 
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.environment.util.Reflections;
 import org.jboss.weld.resources.spi.ResourceLoader;
 
@@ -33,13 +34,13 @@ public class Jandex {
     }
 
     public static JandexDiscoveryStrategy createJandexDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap,
-            Set<Class<? extends Annotation>> initialBeanDefiningAnnotations)
+            Set<Class<? extends Annotation>> initialBeanDefiningAnnotations, BeanDiscoveryMode emptyBeansXmlDiscoveryMode)
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
 
         Class<JandexDiscoveryStrategy> strategyClass = Reflections.loadClass(resourceLoader, JANDEX_DISCOVERY_STRATEGY_CLASS_NAME);
         return SecurityActions
-                .newConstructorInstance(strategyClass, new Class<?>[] { ResourceLoader.class, Bootstrap.class, Set.class }, resourceLoader, bootstrap,
-                        initialBeanDefiningAnnotations);
+                .newConstructorInstance(strategyClass, new Class<?>[] { ResourceLoader.class, Bootstrap.class, Set.class, BeanDiscoveryMode.class }, resourceLoader, bootstrap,
+                        initialBeanDefiningAnnotations, emptyBeansXmlDiscoveryMode);
 
     }
 

--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/JandexDiscoveryStrategy.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/JandexDiscoveryStrategy.java
@@ -34,6 +34,7 @@ import org.jboss.jandex.CompositeIndex;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.environment.deployment.WeldBeanDeploymentArchive;
 import org.jboss.weld.environment.deployment.discovery.AbstractDiscoveryStrategy;
 import org.jboss.weld.environment.deployment.discovery.BeanArchiveBuilder;
@@ -59,8 +60,10 @@ public class JandexDiscoveryStrategy extends AbstractDiscoveryStrategy {
 
     private JandexClassFileServices classFileServices;
 
-    public JandexDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap, Set<Class<? extends Annotation>> initialBeanDefiningAnnotations) {
-        super(resourceLoader, bootstrap, initialBeanDefiningAnnotations);
+    public JandexDiscoveryStrategy(ResourceLoader resourceLoader, Bootstrap bootstrap,
+                                   Set<Class<? extends Annotation>> initialBeanDefiningAnnotations,
+                                   BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        super(resourceLoader, bootstrap, initialBeanDefiningAnnotations, emptyBeansXmlDiscoveryMode);
         registerHandler(new JandexIndexBeanArchiveHandler());
         registerHandler(new JandexFileSystemBeanArchiveHandler());
     }

--- a/environments/common/src/test/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyTest.java
+++ b/environments/common/src/test/java/org/jboss/weld/environment/deployment/discovery/DiscoveryStrategyTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collections;
 import java.util.List;
 
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.resources.ClassLoaderResourceLoader;
 import org.junit.Test;
 
@@ -34,7 +35,7 @@ public class DiscoveryStrategyTest {
     @Test
     public void testBeanArchiveHandlers() {
         AbstractDiscoveryStrategy strategy = (AbstractDiscoveryStrategy) DiscoveryStrategyFactory
-                .create(new ClassLoaderResourceLoader(getClass().getClassLoader()), null, Collections.emptySet(), true);
+                .create(new ClassLoaderResourceLoader(getClass().getClassLoader()), null, Collections.emptySet(), true, BeanDiscoveryMode.ANNOTATED);
         strategy.registerHandler(new TestHandler2());
         List<BeanArchiveHandler> handlers = strategy.initBeanArchiveHandlers();
         assertEquals(3, handlers.size());

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/discovery/beansXml/empty/legacy/Bar.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/discovery/beansXml/empty/legacy/Bar.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.discovery.beansXml.empty.legacy;
+
+// no bean defining annotation - only discovered in "all" discovery mode
+public class Bar {
+    public void ping(){
+        // empty
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/discovery/beansXml/empty/legacy/Foo.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/discovery/beansXml/empty/legacy/Foo.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.discovery.beansXml.empty.legacy;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+// annotated therefore always discovered
+@ApplicationScoped
+public class Foo {
+
+    public void ping(){
+      // empty
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/discovery/beansXml/empty/legacy/LegacyEmptyBeansXmlTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/discovery/beansXml/empty/legacy/LegacyEmptyBeansXmlTest.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.environment.se.test.discovery.beansXml.empty.legacy;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests behavior if there is an empty beans.xml along with system property setting for legacy treatment.
+ * See {@link Weld#EMPTY_BEANS_XML_DISCOVERY_MODE_ALL}
+ *
+ * @author Matej Novotny
+ */
+@RunWith(Arquillian.class)
+public class LegacyEmptyBeansXmlTest {
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ClassPath.builder().add(ShrinkWrap.create(JavaArchive.class)
+                        .addPackage(LegacyEmptyBeansXmlTest.class.getPackage())
+                        // make sure we add empty beans.xml
+                        .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml"))
+                .build();
+    }
+
+    @Test
+    public void testBeanDiscoveryIsAll() {
+        try (WeldContainer container = new Weld()
+                .property(Weld.EMPTY_BEANS_XML_DISCOVERY_MODE_ALL, true)
+                .initialize()) {
+            // Foo is annotated and as such should be always discovered
+            Assert.assertTrue(container.select(Foo.class).isResolvable());
+            // Bar has no annotation and so it should only be picked up in all discovery mode
+            Assert.assertTrue(container.select(Bar.class).isResolvable());
+        }
+    }
+}

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/WeldServletLifecycle.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/WeldServletLifecycle.java
@@ -38,6 +38,7 @@ import org.jboss.weld.bootstrap.api.CDI11Bootstrap;
 import org.jboss.weld.bootstrap.api.Environments;
 import org.jboss.weld.bootstrap.api.TypeDiscoveryConfiguration;
 import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.CDI11Deployment;
 import org.jboss.weld.bootstrap.spi.EEModuleDescriptor;
 import org.jboss.weld.bootstrap.spi.EEModuleDescriptor.ModuleType;
@@ -94,6 +95,9 @@ public class WeldServletLifecycle {
     private static final String CONTEXT_PARAM_ARCHIVE_ISOLATION = WeldServletLifecycle.class.getPackage().getName() + ".archive.isolation";
 
     private static final String JANDEX_SERVLET_CONTEXT_BEAN_ARCHIVE_HANDLER = "org.jboss.weld.environment.servlet.deployment.JandexServletContextBeanArchiveHandler";
+
+    // allows to handle empty beans.xml as having discovery mode ALL
+    private static final String LEGACY_EMPTY_BEANS_XML_TREATMENT = WeldServletLifecycle.class.getPackage().getName() + ".emptyBeansXmlModeAll";
 
     // This context param is used to activate the development mode
     private static final String CONTEXT_PARAM_DEV_MODE = "org.jboss.weld.development";
@@ -285,8 +289,9 @@ public class WeldServletLifecycle {
         final TypeDiscoveryConfiguration typeDiscoveryConfiguration = bootstrap.startExtensions(extensions);
         final EEModuleDescriptor eeModule = new EEModuleDescriptorImpl(context.getContextPath(), ModuleType.WEB);
 
+        final BeanDiscoveryMode emptyBeansXmlDiscoveryMode = Boolean.parseBoolean(context.getInitParameter(LEGACY_EMPTY_BEANS_XML_TREATMENT)) ? BeanDiscoveryMode.ALL : BeanDiscoveryMode.ANNOTATED;
         final DiscoveryStrategy strategy = DiscoveryStrategyFactory.create(resourceLoader, bootstrap, typeDiscoveryConfiguration.getKnownBeanDefiningAnnotations(),
-            Boolean.parseBoolean(context.getInitParameter(Jandex.DISABLE_JANDEX_DISCOVERY_STRATEGY)));
+            Boolean.parseBoolean(context.getInitParameter(Jandex.DISABLE_JANDEX_DISCOVERY_STRATEGY)), emptyBeansXmlDiscoveryMode);
 
         if (Jandex.isJandexAvailable(resourceLoader)) {
             try {
@@ -298,7 +303,7 @@ public class WeldServletLifecycle {
         } else {
             strategy.registerHandler(new ServletContextBeanArchiveHandler(context));
         }
-        strategy.setScanner(new WebAppBeanArchiveScanner(resourceLoader, bootstrap, context));
+        strategy.setScanner(new WebAppBeanArchiveScanner(resourceLoader, bootstrap, context, emptyBeansXmlDiscoveryMode));
         Set<WeldBeanDeploymentArchive> beanDeploymentArchives = strategy.performDiscovery();
 
         String isolation = context.getInitParameter(CONTEXT_PARAM_ARCHIVE_ISOLATION);

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/deployment/WebAppBeanArchiveScanner.java
@@ -26,6 +26,7 @@ import java.util.List;
 import jakarta.servlet.ServletContext;
 
 import org.jboss.weld.bootstrap.api.Bootstrap;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.environment.deployment.discovery.DefaultBeanArchiveScanner;
 import org.jboss.weld.environment.servlet.logging.WeldServletLogger;
@@ -60,8 +61,9 @@ public class WebAppBeanArchiveScanner extends DefaultBeanArchiveScanner {
      * @param bootstrap
      * @param servletContext
      */
-    public WebAppBeanArchiveScanner(ResourceLoader resourceLoader, Bootstrap bootstrap, ServletContext servletContext) {
-        super(resourceLoader, bootstrap);
+    public WebAppBeanArchiveScanner(ResourceLoader resourceLoader, Bootstrap bootstrap, ServletContext servletContext,
+                                    BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        super(resourceLoader, bootstrap, emptyBeansXmlDiscoveryMode);
         this.servletContext = servletContext;
     }
 

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldBootstrap.java
@@ -26,6 +26,7 @@ import org.jboss.weld.bootstrap.api.Environment;
 import org.jboss.weld.bootstrap.api.TypeDiscoveryConfiguration;
 import org.jboss.weld.bootstrap.api.helpers.RegistrySingletonProvider;
 import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
+import org.jboss.weld.bootstrap.spi.BeanDiscoveryMode;
 import org.jboss.weld.bootstrap.spi.BeansXml;
 import org.jboss.weld.bootstrap.spi.Deployment;
 import org.jboss.weld.bootstrap.spi.Metadata;
@@ -125,15 +126,29 @@ public class WeldBootstrap implements CDI11Bootstrap {
 
     @Override
     public BeansXml parse(Iterable<URL> urls, boolean removeDuplicates) {
-        return BeansXmlParser.merge(urls, this::parse, removeDuplicates);
+        return parse(urls, removeDuplicates, BeanDiscoveryMode.ANNOTATED);
     }
 
     @Override
     public BeansXml parse(URL url) {
+        return parse(url, BeanDiscoveryMode.ANNOTATED);
+    }
+
+    @Override
+    public BeansXml parse(URL url, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
         if (beansXmlValidator != null) {
             beansXmlValidator.validate(url);
         }
-        return new BeansXmlStreamParser(url).parse();
+        return new BeansXmlStreamParser(url, emptyBeansXmlDiscoveryMode).parse();    }
+
+    @Override
+    public BeansXml parse(Iterable<URL> urls, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        return parse(urls, false, emptyBeansXmlDiscoveryMode);
+    }
+
+    @Override
+    public BeansXml parse(Iterable<URL> urls, boolean removeDuplicates, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        return BeansXmlParser.merge(urls, url -> parse(url, emptyBeansXmlDiscoveryMode), removeDuplicates);
     }
 
     @Override

--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlParser.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlParser.java
@@ -44,9 +44,20 @@ import org.jboss.weld.metadata.ScanningImpl;
 public class BeansXmlParser {
 
     private final BeansXmlValidator beansXmlValidator;
+    // having this information here allows WFLY to create appropriate parser
+    private final BeanDiscoveryMode emptyBeansXmlDiscoveryModeAll;
 
     public BeansXmlParser() {
+        this(false);
+    }
+
+    public BeansXmlParser(boolean emptyBeansXmlDiscoveryModeAll) {
         beansXmlValidator = SystemPropertiesConfiguration.INSTANCE.isXmlValidationDisabled() ? null : new BeansXmlValidator();
+        if (emptyBeansXmlDiscoveryModeAll) {
+            this.emptyBeansXmlDiscoveryModeAll = BeanDiscoveryMode.ALL;
+        } else {
+            this.emptyBeansXmlDiscoveryModeAll = BeanDiscoveryMode.ANNOTATED;
+        }
     }
 
     public BeansXml parse(final URL beansXml) {
@@ -54,7 +65,7 @@ public class BeansXmlParser {
         if (beansXmlValidator != null) {
             beansXmlValidator.validate(beansXml, handler);
         }
-        return handler != null ? new BeansXmlStreamParser(beansXml, text -> handler.interpolate(text)).parse() : new BeansXmlStreamParser(beansXml).parse();
+        return handler != null ? new BeansXmlStreamParser(beansXml, text -> handler.interpolate(text), emptyBeansXmlDiscoveryModeAll).parse() : new BeansXmlStreamParser(beansXml, emptyBeansXmlDiscoveryModeAll).parse();
     }
 
     public BeansXml parse(Iterable<URL> urls) {

--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlStreamParser.java
@@ -16,7 +16,9 @@
  */
 package org.jboss.weld.xml;
 
+import static java.util.Collections.emptyList;
 import static org.jboss.weld.bootstrap.spi.BeansXml.EMPTY_BEANS_XML;
+import static org.jboss.weld.bootstrap.spi.Scanning.EMPTY_SCANNING;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -105,12 +107,14 @@ public class BeansXmlStreamParser {
 
     private final Function<String, String> interpolator;
 
+    private final BeanDiscoveryMode emptyBeansXmlDiscoveryMode;
+
     /**
      *
      * @param beansXml
      */
     public BeansXmlStreamParser(URL beansXml) {
-        this(beansXml, Function.identity());
+        this(beansXml, Function.identity(), BeanDiscoveryMode.ANNOTATED);
     }
 
     /**
@@ -119,8 +123,17 @@ public class BeansXmlStreamParser {
      * @param interpolator
      */
     public BeansXmlStreamParser(URL beansXml, Function<String, String> interpolator) {
+        this(beansXml, interpolator, BeanDiscoveryMode.ANNOTATED);
+    }
+
+    public BeansXmlStreamParser(URL beansXml, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
+        this(beansXml, Function.identity(), emptyBeansXmlDiscoveryMode);
+    }
+
+    public BeansXmlStreamParser(URL beansXml, Function<String, String> interpolator, BeanDiscoveryMode emptyBeansXmlDiscoveryMode) {
         this.beansXml = beansXml;
         this.interpolator = interpolator;
+        this.emptyBeansXmlDiscoveryMode = emptyBeansXmlDiscoveryMode;
     }
 
     @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
@@ -132,7 +145,13 @@ public class BeansXmlStreamParser {
         try (InputStream in = beansXml.openStream()) {
             if (in.available() == 0) {
                 // The file is just acting as a marker file
-                return EMPTY_BEANS_XML;
+                // if the legacy treatment is on, we use discovery mode as specified, otherwise we default to annotated mode
+                if (emptyBeansXmlDiscoveryMode.equals(BeanDiscoveryMode.ANNOTATED)) {
+                    return EMPTY_BEANS_XML;
+                } else {
+                    return new BeansXmlImpl(emptyList(), emptyList(), emptyList(), emptyList(), EMPTY_SCANNING,
+                            null, emptyBeansXmlDiscoveryMode, null, false);
+                }
             }
             XMLInputFactory factory = XMLInputFactory.newInstance();
             XMLEventReader reader = factory.createXMLEventReader(in);

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <shrinkwrap.resolver.version>3.1.4</shrinkwrap.resolver.version>
         <testng.version>7.4.0</testng.version>
         <testng.jcommander.version>1.81</testng.jcommander.version>
-        <weld.api.version>5.0.Alpha2</weld.api.version>
+        <weld.api.version>5.0.Alpha3</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>3.0.1.Final</wildfly.arquillian.version>
     </properties>


### PR DESCRIPTION
…treat empty beans.xml as discovery mode ALL.

EDIT: note that TCK tests will currently blow up as we are running with the empty beans.xml changes against a TCK that wasn't yet adapted.