### PR TITLE
WELD-2701 Changes for JDK 17 test execution. Additional arglines, removal of unused parameters, add JDK 17 to CI matrix.

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -90,6 +90,10 @@ jobs:
             name: "11",
             java-version: 11,
           }
+          - {
+            name: "17",
+            java-version: 17,
+          }
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java.name }}
@@ -153,6 +157,10 @@ jobs:
             name: "11",
             java-version: 11,
           }
+          - {
+            name: "17",
+            java-version: 17,
+          }
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java.name }}
@@ -215,6 +223,10 @@ jobs:
           - {
             name: "11",
             java-version: 11,
+          }
+          - {
+            name: "17",
+            java-version: 17,
           }
     steps:
       - uses: actions/checkout@v2
@@ -316,6 +328,10 @@ jobs:
           - {
             name: "11",
             java-version: 11,
+          }
+          - {
+            name: "17",
+            java-version: 17,
           }
     steps:
       - uses: actions/checkout@v2

--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -165,13 +165,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>${surefire.plugin.jdk9.args}</argLine>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -190,7 +183,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${surefire.plugin.jdk9.args} ${jacoco.agent}</argLine>
+                            <argLine>${jacoco.agent}</argLine>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/environments/se/pom.xml
+++ b/environments/se/pom.xml
@@ -38,18 +38,4 @@
 
       </dependencies>
    </dependencyManagement>
-
-   <build>
-       <pluginManagement>
-           <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>${surefire.plugin.jdk9.args}</argLine>
-                    </configuration>
-                </plugin>
-           </plugins>
-       </pluginManagement>
-   </build>
 </project>

--- a/environments/se/tests/pom.xml
+++ b/environments/se/tests/pom.xml
@@ -125,7 +125,6 @@
                   <libPath>${project.build.outputDirectory}</libPath>
                   <jacoco.agent>${jacoco.agent}</jacoco.agent>
                   <weld.se.debug>false</weld.se.debug>
-                  <surefire.plugin.jdk9.args>${surefire.plugin.jdk9.args}</surefire.plugin.jdk9.args>
                </systemProperties>
             </configuration>
          </plugin>

--- a/environments/se/tests/src/test/resources/arquillian.xml
+++ b/environments/se/tests/src/test/resources/arquillian.xml
@@ -14,7 +14,8 @@
          <property name="debug">${weld.se.debug}</property>
          <property name="logLevel">INFO</property>
          <property name="keepDeploymentArchives">false</property>
-         <property name="additionalJavaOpts">${surefire.plugin.jdk9.args} ${jacoco.agent}</property>
+         <!-- additionalJavaOpts can be used to pass in JDK add-opens formulas contained in ${surefire.plugin.jdk17.args}  -->
+         <property name="additionalJavaOpts">${jacoco.agent}</property>
          <property name="waitTime">${connection.wait.time:15}</property>
       </configuration>
    </container>

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -129,18 +129,4 @@
 
         </dependencies>
     </dependencyManagement>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <argLine>${surefire.plugin.jdk9.args}</argLine>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -131,7 +131,6 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
-                    <argLine>${surefire.plugin.jdk9.args}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/inject-tck-runner/pom.xml
+++ b/inject-tck-runner/pom.xml
@@ -82,7 +82,6 @@
                     <includes>
                         <include>**/AtInjectTCK.java</include>
                     </includes>
-                    <argLine>${surefire.plugin.jdk9.args}</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -162,7 +162,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <!-- http://bugs.java.com/bugdatabase/view_bug.do?bug_id=4425695 -->
-                    <argLine>-Xmx768m -Dsun.zip.disableMemoryMapping=true ${surefire.plugin.jdk9.args}</argLine>
+                    <argLine>-Xmx768m -Dsun.zip.disableMemoryMapping=true</argLine>
                     <forkMode>once</forkMode>
                     <properties>
                         <property>
@@ -419,17 +419,6 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludedGroups>${excluded.groups}</excludedGroups>
-                            <argLine>
-                                --add-exports=java.desktop/sun.awt=ALL-UNNAMED
-                                --add-opens=java.base/java.io=ALL-UNNAMED
-                                --add-opens=java.base/java.lang=ALL-UNNAMED
-                                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-                                --add-opens=java.base/java.security=ALL-UNNAMED
-                                --add-opens=java.base/java.util=ALL-UNNAMED
-                                --add-opens=java.management/javax.management=ALL-UNNAMED
-                                --add-opens=java.naming/javax.naming=ALL-UNNAMED
-                            </argLine>
-
                             <systemPropertyVariables>
                                 <!-- Silencing the broken code in getActiveConfiguration(),
                                     see https://github.com/arquillian/arquillian/blob/master/impl-base/src/main/java/org/jboss/arquillian/impl/client/container/ContainerRegistryCreator.java -->
@@ -443,17 +432,8 @@
                                 <jacoco.agent>${jacoco.agent}</jacoco.agent>
                                 <!-- This property propagates to the javaVmArguments in arquillian.xml -->
                                 <additional.vm.args>
-                                    --add-exports=java.desktop/sun.awt=ALL-UNNAMED
-                                    --add-opens=java.base/java.io=ALL-UNNAMED
-                                    --add-opens=java.base/java.lang=ALL-UNNAMED
-                                    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-                                    --add-opens=java.base/java.security=ALL-UNNAMED
-                                    --add-opens=java.base/java.util=ALL-UNNAMED
-                                    --add-opens=java.management/javax.management=ALL-UNNAMED
-                                    --add-opens=java.naming/javax.naming=ALL-UNNAMED
+                                    ${surefire.plugin.jdk17.args}
                                 </additional.vm.args>
-
-                                <illegal.access.option>${surefire.plugin.jdk9.args}</illegal.access.option>
                             </systemProperties>
                         </configuration>
                     </plugin>
@@ -523,7 +503,6 @@
                             <systemPropertyVariables>
                                 <arquillian.launch>weld-se</arquillian.launch>
                                 <libPath>${project.build.outputDirectory}</libPath>
-                                <surefire.plugin.jdk9.args>${surefire.plugin.jdk9.args}</surefire.plugin.jdk9.args>
                             </systemPropertyVariables>
                         </configuration>
                     </plugin>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -419,6 +419,17 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
                             <excludedGroups>${excluded.groups}</excludedGroups>
+                            <argLine>
+                                --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                                --add-opens=java.base/java.io=ALL-UNNAMED
+                                --add-opens=java.base/java.lang=ALL-UNNAMED
+                                --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                                --add-opens=java.base/java.security=ALL-UNNAMED
+                                --add-opens=java.base/java.util=ALL-UNNAMED
+                                --add-opens=java.management/javax.management=ALL-UNNAMED
+                                --add-opens=java.naming/javax.naming=ALL-UNNAMED"
+                            </argLine>
+
                             <systemPropertyVariables>
                                 <!-- Silencing the broken code in getActiveConfiguration(),
                                     see https://github.com/arquillian/arquillian/blob/master/impl-base/src/main/java/org/jboss/arquillian/impl/client/container/ContainerRegistryCreator.java -->
@@ -430,7 +441,18 @@
                             </systemPropertyVariables>
                             <systemProperties>
                                 <jacoco.agent>${jacoco.agent}</jacoco.agent>
-                                <additional.vm.args>${additional.vm.args}</additional.vm.args>
+                                <!-- This property propagates to the javaVmArguments in arquillian.xml -->
+                                <additional.vm.args>
+                                    --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                                    --add-opens=java.base/java.io=ALL-UNNAMED
+                                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                                    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                                    --add-opens=java.base/java.security=ALL-UNNAMED
+                                    --add-opens=java.base/java.util=ALL-UNNAMED
+                                    --add-opens=java.management/javax.management=ALL-UNNAMED
+                                    --add-opens=java.naming/javax.naming=ALL-UNNAMED"
+                                </additional.vm.args>
+
                                 <illegal.access.option>${surefire.plugin.jdk9.args}</illegal.access.option>
                             </systemProperties>
                         </configuration>

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -427,7 +427,7 @@
                                 --add-opens=java.base/java.security=ALL-UNNAMED
                                 --add-opens=java.base/java.util=ALL-UNNAMED
                                 --add-opens=java.management/javax.management=ALL-UNNAMED
-                                --add-opens=java.naming/javax.naming=ALL-UNNAMED"
+                                --add-opens=java.naming/javax.naming=ALL-UNNAMED
                             </argLine>
 
                             <systemPropertyVariables>
@@ -450,7 +450,7 @@
                                     --add-opens=java.base/java.security=ALL-UNNAMED
                                     --add-opens=java.base/java.util=ALL-UNNAMED
                                     --add-opens=java.management/javax.management=ALL-UNNAMED
-                                    --add-opens=java.naming/javax.naming=ALL-UNNAMED"
+                                    --add-opens=java.naming/javax.naming=ALL-UNNAMED
                                 </additional.vm.args>
 
                                 <illegal.access.option>${surefire.plugin.jdk9.args}</illegal.access.option>

--- a/jboss-tck-runner/src/test/weld-se/arquillian.xml
+++ b/jboss-tck-runner/src/test/weld-se/arquillian.xml
@@ -11,7 +11,7 @@
         <protocol type="simple-jmx"/>
         <configuration>
             <property name="librariesPath">${libPath}</property>
-            <property name="additionalJavaOpts">${surefire.plugin.jdk9.args}</property>
+            <!--<property name="additionalJavaOpts">${surefire.plugin.jdk17.args}</property>-->
             <!--<property name="debug">true</property>-->
             <!--<property name="logLevel">FINE</property>-->
             <!--<property name="keepDeploymentArchives">true</property>-->

--- a/jboss-tck-runner/src/test/wildfly8/arquillian.xml
+++ b/jboss-tck-runner/src/test/wildfly8/arquillian.xml
@@ -12,7 +12,7 @@
         <configuration>
             <!-- This config file includes embedded JMS broker and is copied into WFLY dir from ${JBOSS_HOME}/docs/examples/configs -->
             <property name="serverConfig">standalone-activemq-embedded.xml</property>
-            <property name="javaVmArguments">-Xms128m -Xmx1g -XX:MaxPermSize=512m -ea -DcdiTckExcludeDummy=true ${illegal.access.option} ${additional.vm.args} ${jacoco.agent}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx1g -ea -DcdiTckExcludeDummy=true ${illegal.access.option} ${additional.vm.args} ${jacoco.agent}</property>
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>

--- a/jboss-tck-runner/src/test/wildfly8/arquillian.xml
+++ b/jboss-tck-runner/src/test/wildfly8/arquillian.xml
@@ -12,7 +12,7 @@
         <configuration>
             <!-- This config file includes embedded JMS broker and is copied into WFLY dir from ${JBOSS_HOME}/docs/examples/configs -->
             <property name="serverConfig">standalone-activemq-embedded.xml</property>
-            <property name="javaVmArguments">-Xms128m -Xmx1g -ea -DcdiTckExcludeDummy=true ${illegal.access.option} ${additional.vm.args} ${jacoco.agent}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx1g -ea -DcdiTckExcludeDummy=true ${additional.vm.args} ${jacoco.agent}</property>
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="startupTimeoutInSeconds">${server.startup.timeout:60}</property>

--- a/pom.xml
+++ b/pom.xml
@@ -32,11 +32,9 @@
         <jdk.min.version>11</jdk.min.version>
 
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
-        <!-- Travis CI build workaround -->
-        <travis.surefire.argLine>-Xmx1024m</travis.surefire.argLine>
 
         <!-- Only initialized in JDK 9 profile to provide extra CMD args to surefire -->
-        <surefire.plugin.jdk9.args />
+        <surefire.plugin.jdk17.args />
         <!-- Jakarta JAX/JWS api and implementation -->
         <jax.api.version>3.0.1</jax.api.version>
         <jws.api.version>3.0.0</jws.api.version>
@@ -758,15 +756,22 @@
             </build>
         </profile>
         <profile>
-            <!-- Auto-activated profile for any JDK 9 or newer -->
-            <!-- Should contain all JDK 9+ related versions and/or test setup such as illegal-access=deny -->
-            <id>jdk9+</id>
+            <!-- Auto-activated profile for JDK 17 or newer -->
+            <id>jdk17+</id>
             <activation>
-                <jdk>(9,)</jdk>
+                <jdk>[17,)</jdk>
             </activation>
             <properties>
-                <!--In the future we will want to test with illegal access denied. As of WFLY 13 Alpha, it is not yet possible-->
-                <!--Once working, set "surefire.plugin.jdk9.args" to "[double-hyphen]illegal-access=deny"-->
+                <surefire.plugin.jdk17.args>
+                    --add-exports=java.desktop/sun.awt=ALL-UNNAMED
+                    --add-opens=java.base/java.io=ALL-UNNAMED
+                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                    --add-opens=java.base/java.security=ALL-UNNAMED
+                    --add-opens=java.base/java.util=ALL-UNNAMED
+                    --add-opens=java.management/javax.management=ALL-UNNAMED
+                    --add-opens=java.naming/javax.naming=ALL-UNNAMED
+                </surefire.plugin.jdk17.args>
             </properties>
         </profile>
     </profiles>

--- a/probe/tests/pom.xml
+++ b/probe/tests/pom.xml
@@ -161,7 +161,7 @@
                             <systemProperties>
                                 <arquillian.xml>arquillian.xml</arquillian.xml>
                                 <jacoco.agent>${jacoco.agent}</jacoco.agent>
-                                <additional.vm.args>${additional.vm.args}</additional.vm.args>
+                                <additional.vm.args>${surefire.plugin.jdk17.args}</additional.vm.args>
                                 <org.jboss.remoting-jmx.timeout>360</org.jboss.remoting-jmx.timeout>
                             </systemProperties>
                             <test>${test}</test>

--- a/probe/tests/src/test/resources/arquillian.xml
+++ b/probe/tests/src/test/resources/arquillian.xml
@@ -16,7 +16,7 @@
             <!-- ARQ-649 workaround -->
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m ${jacoco.agent} ${additional.vm.args}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx768m ${additional.vm.args} ${jacoco.agent}</property>
         </configuration>
     </container>
 

--- a/tests-arquillian/pom.xml
+++ b/tests-arquillian/pom.xml
@@ -214,7 +214,7 @@
 
         <!-- Arquillian container adapter profiles -->
 
-        <!-- Weld EE 1.1 - Embedded -->
+        <!-- Weld Arq. Container - embedded testing -->
         <profile>
             <id>default</id>
             <activation>
@@ -241,8 +241,6 @@
                                 <arquillian.xml>arquillian.xml</arquillian.xml>
                             </systemProperties>
                             <test>${test}</test>
-                            <!-- Travis CI build workaround -->
-                            <argLine>${surefire.plugin.jdk9.args} ${travis.surefire.argLine}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -336,9 +334,8 @@
                                 <arquillian.xml>wildfly-arquillian.xml</arquillian.xml>
                                 <jacoco.agent>${jacoco.agent}</jacoco.agent>
                                 <node.address>${node.address}</node.address>
-                                <additional.vm.args>${additional.vm.args}</additional.vm.args>
+                                <additional.vm.args>${surefire.plugin.jdk17.args}</additional.vm.args>
                                 <additional.jboss.args>${additional.jboss.args}</additional.jboss.args>
-                                <illegal.access.option>${surefire.plugin.jdk9.args}</illegal.access.option>
                                 <org.jboss.remoting-jmx.timeout>360</org.jboss.remoting-jmx.timeout>
                             </systemProperties>
                             <test>${test}</test>

--- a/tests-arquillian/src/test/resources/wildfly-arquillian.xml
+++ b/tests-arquillian/src/test/resources/wildfly-arquillian.xml
@@ -17,7 +17,7 @@
             <!-- ARQ-649 workaround -->
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>
-            <property name="javaVmArguments">-Xms128m -Xmx768m -XX:MaxPermSize=256m ${illegal.access.option} ${jacoco.agent} ${additional.vm.args}</property>
+            <property name="javaVmArguments">-Xms128m -Xmx768m ${additional.vm.args} ${jacoco.agent}</property>
             <property name="jbossArguments">${additional.jboss.args}</property>
             <property name="managementAddress">${node.address}</property>
         </configuration>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -141,7 +141,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <argLine>${surefire.plugin.jdk9.args} -Xmx128m</argLine>
+                            <argLine>
+                                ${surefire.plugin.jdk17.args}
+                            </argLine>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
Should we add a jdk17 profile for activating the JDK17 settings included in this PR?
Signed-off-by: Scott Marlow <smarlow@redhat.com>