### PR TITLE
Embedded TCK execution should use suite XML file.

### DIFF
--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -348,6 +348,9 @@
                                 <!-- Travis CI build workaround -->
                                 <argLine>${travis.surefire.argLine}</argLine>
                             </systemPropertyVariables>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>target/suites/tck-core-suite.xml</suiteXmlFile>
+                            </suiteXmlFiles>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <!-- Might be used to override the version declared in weld-parent -->
         <!-- build.config.version>9</build.config.version-->
         <!-- Version of the CDI 4.x release TCK -->
-        <cdi.tck-4-0.version>4.1.0.Alpha2</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.1.0.Alpha3</cdi.tck-4-0.version>
         <classfilewriter.version>1.2.5.Final</classfilewriter.version>
         <spotbugs-maven-plugin.version>4.3.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.3.0</spotbugs-annotations-version>


### PR DESCRIPTION
Fixes an issue where TCK tests that weren't properly named weren't executed in embedded container. See https://github.com/eclipse-ee4j/cdi-tck/issues/273#issuecomment-927090230