### PR TITLE
WELD-2688 Allow usage of @Priority on stereotypes, add tests.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
@@ -342,4 +342,7 @@ public interface BootstrapLogger extends WeldLogger {
     @Message(id = 182, value= "Provided implementation of org.jboss.weld.serialization.spi.ProxyServices ({0}) does not support class defining. This functionality is required in order to be able to define proxy classes.", format = Format.MESSAGE_FORMAT)
     IllegalStateException proxyServicesWithoutClassDefining(Object services);
 
+    @Message(id = 183, value= "Multiple different @Priority values derived from stereotype annotations for annotated type - {0}", format = Format.MESSAGE_FORMAT)
+    DefinitionException multiplePriorityValuesDeclared(Object annotatedType);
+
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/AlternativePriorityStereotype.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/AlternativePriorityStereotype.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Makes the bean {@code @Alternative} and declares {@code @SomeStereotype} so it inherits has {@code @Priority}
+ */
+@Stereotype
+@Alternative
+@PriorityStereotype
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AlternativePriorityStereotype {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Bar.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Bar.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Bar {
+
+    public String ping() {
+        return Bar.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/BarExtended.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/BarExtended.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+// alternative and priority gained via stereotype
+@AlternativePriorityStereotype
+public class BarExtended extends Bar {
+
+    public String ping() {
+        return BarExtended.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Baz.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Baz.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+public class Baz {
+
+    public String ping() {
+        return Baz.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/BazAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/BazAlternative.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+@Dependent
+@Alternative
+@Priority(1)
+// enabled alternative, should be overriden by BazAlternative2
+public class BazAlternative extends Baz {
+
+    public String ping() {
+        return BazAlternative.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/BazAlternative2.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/BazAlternative2.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+@Dependent
+@Alternative
+@PriorityStereotype
+public class BazAlternative2 extends Baz {
+
+    public String ping() {
+        return BazAlternative2.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Charlie.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Charlie.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class Charlie {
+
+    public String ping() {
+        return Charlie.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/CharlieAltStereotype.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/CharlieAltStereotype.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+@Dependent
+@Alternative
+@Priority(1)
+@PriorityStereotype // stereotype has @Priority(100)
+public class CharlieAltStereotype extends Charlie {
+
+    public String ping() {
+        return CharlieAltStereotype.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/CharlieAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/CharlieAlternative.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+@Dependent
+@Alternative
+@Priority(50)
+public class CharlieAlternative extends Charlie {
+
+    public String ping() {
+        return CharlieAlternative.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/Foo.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class Foo {
+
+    public String ping() {
+        return Foo.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/FooAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/FooAlternative.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+
+@ApplicationScoped
+@Alternative
+// enabled through priority from stereotype
+@PriorityStereotype
+public class FooAlternative extends Foo {
+
+    public String ping() {
+        return FooAlternative.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/PriorityStereotype.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/PriorityStereotype.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Simple stereotype with @Priority
+ */
+@Stereotype
+@Priority(100)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PriorityStereotype {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/StereotypeWithPriorityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/StereotypeWithPriorityTest.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority;
+
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class StereotypeWithPriorityTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(StereotypeWithPriorityTest.class))
+                .addPackage(StereotypeWithPriorityTest.class.getPackage());
+    }
+
+    @Inject
+    Foo foo;
+
+    @Inject
+    Bar bar;
+
+    @Inject
+    Baz baz;
+
+    @Inject
+    Charlie charlie;
+
+    @Test
+    public void testStereotypeWithPriority() {
+        // injected Foo should be FooAlternative
+        Assert.assertEquals(FooAlternative.class.getSimpleName(), foo.ping());
+    }
+
+    @Test
+    public void testStereotypeWithAlternativeAndPriority() {
+        // injected Bar should be instance of BarExtended
+        Assert.assertEquals(BarExtended.class.getSimpleName(), bar.ping());
+    }
+
+    @Test
+    public void testBeanPriorityFromStereotypeOverridesOtherAlternative() {
+        // injected Baz should be instance of BazAlternative2
+        Assert.assertEquals(BazAlternative2.class.getSimpleName(), baz.ping());
+    }
+
+    @Test
+    public void testBeanOverridesPriorityFromStereotype() {
+        // injected Charlie should be instance of CharlieAlternative
+        Assert.assertEquals(CharlieAlternative.class.getSimpleName(), charlie.ping());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/ConflictingInheritedPriorityStereotypesTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/ConflictingInheritedPriorityStereotypesTest.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.conflicting;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * A bean that declares no priority but has a stereotype which declares more than one value of priority in its hierarchy.
+ */
+@RunWith(Arquillian.class)
+public class ConflictingInheritedPriorityStereotypesTest {
+
+    @Deployment
+    @ShouldThrowException(DefinitionException.class)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ConflictingInheritedPriorityStereotypesTest.class))
+                .addClasses(PriorityStereotype2.class, SomeOtherBean.class, DualPriorityStereotype.class);
+    }
+
+    @Test
+    public void testConflictingPrioritiesFromStereotypes() {
+        // test should throw an exception
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/ConflictingPriorityStereotypesTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/ConflictingPriorityStereotypesTest.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.conflicting;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.stereotypes.priority.PriorityStereotype;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Bean which has two stereotypes both of which declare {@code @Priority} with different values.
+ */
+@RunWith(Arquillian.class)
+public class ConflictingPriorityStereotypesTest {
+
+
+    @Deployment
+    @ShouldThrowException(DefinitionException.class)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ConflictingPriorityStereotypesTest.class))
+                .addClasses(PriorityStereotype2.class, SomeBean.class, PriorityStereotype.class);
+    }
+
+    @Test
+    public void testConflictingPrioritiesFromStereotypes() {
+        // test should throw an exception
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/DualPriorityStereotype.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/DualPriorityStereotype.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.conflicting;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Stereotype
+@PriorityStereotype2
+@Priority(258)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DualPriorityStereotype {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/PriorityStereotype2.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/PriorityStereotype2.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.conflicting;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Stereotype;
+import org.jboss.weld.tests.stereotypes.priority.PriorityStereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Simple stereotype with priority different than {@link PriorityStereotype}.
+ */
+@Stereotype
+@Priority(200)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PriorityStereotype2 {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/SomeBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/SomeBean.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.conflicting;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+import org.jboss.weld.tests.stereotypes.priority.PriorityStereotype;
+
+@Dependent
+@Alternative
+@PriorityStereotype
+@PriorityStereotype2
+public class SomeBean {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/SomeOtherBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/conflicting/SomeOtherBean.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.conflicting;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+@Dependent
+@Alternative
+@DualPriorityStereotype
+public class SomeOtherBean {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/DumbStereotype.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/DumbStereotype.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Doesn't add anything but declares another stereotype with priority.
+ */
+@Stereotype
+@StereotypeWithPriority
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DumbStereotype {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/Foo.java
@@ -1,0 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited;
+
+public class Foo extends FooAncestor {
+
+    public String ping() {
+        return Foo.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/FooAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/FooAlternative.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+@Dependent
+@Alternative
+public class FooAlternative extends Foo {
+
+    public String ping() {
+        return FooAlternative.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/FooAncestor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/FooAncestor.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited;
+
+@DumbStereotype
+public class FooAncestor {
+
+    public String ping() {
+        return FooAncestor.class.getSimpleName();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/StereotypeInheritedPriorityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/StereotypeInheritedPriorityTest.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class StereotypeInheritedPriorityTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(StereotypeInheritedPriorityTest.class))
+                .beanDiscoveryMode(BeanDiscoveryMode.ANNOTATED)
+                .addPackage(StereotypeInheritedPriorityTest.class.getPackage());
+    }
+
+    @Inject
+    BeanManager bm;
+
+    @Test
+    public void testPriorityWasInherited() {
+        // if the inheritance works, FooAlternative will inherit the priority and therefore will be enabled
+        Instance<FooAlternative> fooInstance = bm.createInstance().select(FooAlternative.class);
+        Assert.assertTrue(fooInstance.isResolvable());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/StereotypeWithPriority.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/StereotypeWithPriority.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Stereotype
+@Priority(100)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface StereotypeWithPriority {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/AnotherDumbStereotype.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/AnotherDumbStereotype.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited.conflicting;
+
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Stereotype
+@AnotherStereotypeWithPriority
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface AnotherDumbStereotype {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/AnotherStereotypeWithPriority.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/AnotherStereotypeWithPriority.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2019, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited.conflicting;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.Stereotype;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Stereotype
+@Priority(200)
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface AnotherStereotypeWithPriority {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/Foo.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited.conflicting;
+
+@AnotherDumbStereotype
+public class Foo extends FooAncestor {
+
+    public String ping() {
+        return Foo.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/FooAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/FooAlternative.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited.conflicting;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Alternative;
+
+@Dependent
+@Alternative
+public class FooAlternative extends Foo {
+
+    public String ping() {
+        return FooAlternative.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/FooAncestor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/FooAncestor.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited.conflicting;
+
+import org.jboss.weld.tests.stereotypes.priority.inherited.DumbStereotype;
+
+@DumbStereotype
+public class FooAncestor {
+
+    public String ping() {
+        return FooAncestor.class.getSimpleName();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/StereotypeInheritedPriorityConflictTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/stereotypes/priority/inherited/conflicting/StereotypeInheritedPriorityConflictTest.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.stereotypes.priority.inherited.conflicting;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.stereotypes.priority.inherited.DumbStereotype;
+import org.jboss.weld.tests.stereotypes.priority.inherited.StereotypeWithPriority;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class StereotypeInheritedPriorityConflictTest {
+
+    @Deployment
+    @ShouldThrowException(DefinitionException.class)
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(StereotypeInheritedPriorityConflictTest.class))
+                .beanDiscoveryMode(BeanDiscoveryMode.ANNOTATED)
+                .addPackage(StereotypeInheritedPriorityConflictTest.class.getPackage())
+                .addClasses(DumbStereotype.class, StereotypeWithPriority.class);
+    }
+
+    @Test
+    public void testInheritedStereotypesAreConflicting() {
+        // test should throw an exception
+    }
+}


### PR DESCRIPTION
Allows usage of `@Priority` on stereotypes - implements a recursive search of stereotypes for priority annotation in order to register globally enabled alternatives.