### PR TITLE
WELD-2678 Add implementation of Lite extension translator

### DIFF
--- a/environments/se/core/pom.xml
+++ b/environments/se/core/pom.xml
@@ -45,6 +45,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-lite-extension-translator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.weld.probe</groupId>
             <artifactId>weld-probe-core</artifactId>
         </dependency>

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
@@ -89,6 +89,7 @@ import org.jboss.weld.environment.util.BeanArchives;
 import org.jboss.weld.environment.util.DevelopmentMode;
 import org.jboss.weld.environment.util.Files;
 import org.jboss.weld.environment.util.Reflections;
+import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
 import org.jboss.weld.metadata.BeansXmlImpl;
 import org.jboss.weld.resources.ClassLoaderResourceLoader;
 import org.jboss.weld.resources.spi.ClassFileServices;
@@ -1090,6 +1091,13 @@ public class Weld extends SeContainerInitializer implements ContainerInstanceFac
         if (isEnabled(DEV_MODE_SYSTEM_PROPERTY, false)) {
             // The development mode is enabled - register the Probe extension
             result.add(new MetadataImpl<Extension>(DevelopmentMode.getProbeExtension(resourceLoader), "N/A"));
+        }
+        // Register org.jboss.weld.lite.extension.translator.LiteExtensionTranslator in order to be able to execute build compatible extensions
+        try {
+            result.add(new MetadataImpl<Extension>(SecurityActions.newInstance(LiteExtensionTranslator.class),
+                    SYNTHETIC_LOCATION_PREFIX + LiteExtensionTranslator.class.getName()));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
         if (!containerLifecycleObservers.isEmpty()) {
             result.add(new MetadataImpl<Extension>(new ContainerLifecycleObserverExtension(containerLifecycleObservers),

--- a/environments/servlet/core/pom.xml
+++ b/environments/servlet/core/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-lite-extension-translator</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.weld.probe</groupId>
             <artifactId>weld-probe-core</artifactId>
         </dependency>

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/WeldServletLifecycle.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/WeldServletLifecycle.java
@@ -48,6 +48,7 @@ import org.jboss.weld.bootstrap.spi.helpers.MetadataImpl;
 import org.jboss.weld.configuration.spi.ExternalConfiguration;
 import org.jboss.weld.configuration.spi.helpers.ExternalConfigurationBuilder;
 import org.jboss.weld.environment.jetty.JettyLegacyContainer;
+import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
 import org.jboss.weld.module.web.el.WeldELContextListener;
 import org.jboss.weld.environment.ContainerInstance;
 import org.jboss.weld.environment.ContainerInstanceFactory;
@@ -278,11 +279,18 @@ public class WeldServletLifecycle {
      * @return new servlet deployment
      */
     protected CDI11Deployment createDeployment(ServletContext context, CDI11Bootstrap bootstrap) {
-
         ImmutableSet.Builder<Metadata<Extension>> extensionsBuilder = ImmutableSet.builder();
         extensionsBuilder.addAll(bootstrap.loadExtensions(WeldResourceLoader.getClassLoader()));
         if (isDevModeEnabled) {
             extensionsBuilder.add(new MetadataImpl<Extension>(DevelopmentMode.getProbeExtension(resourceLoader), "N/A"));
+        }
+
+        // Register org.jboss.weld.lite.extension.translator.LiteExtensionTranslator in order to be able to execute build compatible extensions
+        try {
+            extensionsBuilder.add(new MetadataImpl<Extension>(SecurityActions.newInstance(LiteExtensionTranslator.class),
+                    "synthetic:" + LiteExtensionTranslator.class.getName()));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
         }
 
         final Iterable<Metadata<Extension>> extensions = extensionsBuilder.build();

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/BeanConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/BeanConfiguratorImpl.java
@@ -44,6 +44,7 @@ import org.jboss.weld.bean.StringBeanIdentifier;
 import org.jboss.weld.bean.WeldBean;
 import org.jboss.weld.bootstrap.BeanDeploymentFinder;
 import org.jboss.weld.bootstrap.event.WeldBeanConfigurator;
+import org.jboss.weld.contexts.CreationalContextImpl;
 import org.jboss.weld.inject.WeldInstance;
 import org.jboss.weld.logging.BeanLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
@@ -343,6 +344,8 @@ public class BeanConfiguratorImpl<T> implements WeldBeanConfigurator<T>, Configu
 
         private final Function<Instance<Object>, T> instance;
 
+        private CreationalContext<T> creationalContext;
+
         static <T> CreateCallback<T> fromProduceWith(Function<Instance<Object>, T> callback) {
             return new CreateCallback<T>(null, null, callback);
         }
@@ -362,6 +365,7 @@ public class BeanConfiguratorImpl<T> implements WeldBeanConfigurator<T>, Configu
         }
 
         private T create(Bean<?> bean, CreationalContext<T> ctx, BeanManagerImpl beanManager) {
+            this.creationalContext = ctx;
             if (simple != null) {
                 return simple.get();
             } else if (instance != null) {
@@ -377,6 +381,10 @@ public class BeanConfiguratorImpl<T> implements WeldBeanConfigurator<T>, Configu
                 return instance;
             }
             return new GuardedInstance<>(bean, instance);
+        }
+
+        CreationalContext<T> getCreationalContext() {
+            return creationalContext;
         }
 
     }
@@ -508,7 +516,18 @@ public class BeanConfiguratorImpl<T> implements WeldBeanConfigurator<T>, Configu
             if (destroyCallback != null) {
                 destroyCallback.destroy(instance, creationalContext, beanManager);
             }
-            creationalContext.release();
+            // release dependent beans from create/destroy callbacks
+            if (creationalContext instanceof CreationalContextImpl) {
+                // release dependent instances linked with this bean but avoid double invocation
+                ((CreationalContextImpl<T>) creationalContext).release(this, instance);
+                // in some cases, the CC for create and destroy callbacks might differ; hence this special handling
+                CreationalContext<T> createCallbackCreationalContext = createCallback.getCreationalContext();
+                if (createCallbackCreationalContext != null && createCallbackCreationalContext != creationalContext) {
+                    createCallbackCreationalContext.release();
+                }
+            } else {
+                creationalContext.release();
+            }
         }
 
         @Override

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/BeanConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/BeanConfiguratorImpl.java
@@ -508,6 +508,7 @@ public class BeanConfiguratorImpl<T> implements WeldBeanConfigurator<T>, Configu
             if (destroyCallback != null) {
                 destroyCallback.destroy(instance, creationalContext, beanManager);
             }
+            creationalContext.release();
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <arquillian.drone.version>2.5.2</arquillian.drone.version>
         <arquillian.graphene.version>2.3.2</arquillian.graphene.version>
-        <arquillian.weld.version>3.0.0.Final</arquillian.weld.version>
+        <arquillian.weld.version>3.0.1.Final</arquillian.weld.version>
         <arquillian.se.container.version>1.0.2.Final</arquillian.se.container.version>
         <arquillian.tomcat.version>1.2.0.Alpha1</arquillian.tomcat.version>
         <arquillian.jetty.version>1.0.0.CR3</arquillian.jetty.version>
@@ -64,7 +64,7 @@
         <!-- Might be used to override the version declared in weld-parent -->
         <!-- build.config.version>9</build.config.version-->
         <!-- Version of the CDI 4.x release TCK -->
-        <cdi.tck-4-0.version>4.1.0.Alpha3</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.0.Alpha4</cdi.tck-4-0.version>
         <classfilewriter.version>1.2.5.Final</classfilewriter.version>
         <spotbugs-maven-plugin.version>4.4.1</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.4.1</spotbugs-annotations-version>
@@ -91,7 +91,7 @@
         <shrinkwrap.resolver.version>3.1.4</shrinkwrap.resolver.version>
         <testng.version>7.4.0</testng.version>
         <testng.jcommander.version>1.81</testng.jcommander.version>
-        <weld.api.version>5.0.Beta1</weld.api.version>
+        <weld.api.version>5.0.Beta2</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>3.0.1.Final</wildfly.arquillian.version>
     </properties>
@@ -104,6 +104,7 @@
         <module>modules/web</module>
         <module>probe</module>
         <module>bom</module>
+        <module>weld-lite-extension-translator</module>
     </modules>
 
     <!-- Dependency management. KEEP IN ALPHABETICAL ORDER -->
@@ -349,6 +350,12 @@
             <dependency>
                 <groupId>org.jboss.weld</groupId>
                 <artifactId>weld-core-impl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.weld</groupId>
+                <artifactId>weld-lite-extension-translator</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanInjectingSyntheticInteger.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BeanInjectingSyntheticInteger.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.extensions.custombeans;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+
+@Dependent
+public class BeanInjectingSyntheticInteger {
+
+    @Random
+    @Inject
+    Integer injectedBean;
+
+    public Integer getNumber() {
+        return injectedBean;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BuilderExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/BuilderExtension.java
@@ -68,7 +68,14 @@ public class BuilderExtension implements Extension {
 
         // Test simple produceWith callback
         event.addBean().addType(Integer.class).addQualifier(Random.Literal.INSTANCE)
-                .produceWith((i) -> new java.util.Random().nextInt(1000)).disposeWith((beanInstance, instance) -> DISPOSED.set(true));
+                .produceWith((i) -> {
+                    i.select(DependentBean.class).get(); // create dependent instance
+                    return new java.util.Random().nextInt(1000);
+                })
+                .disposeWith((beanInstance, instance) -> {
+                    instance.select(DependentBean.class).get(); // create dependent instance
+                    DISPOSED.set(true);
+                });
 
         // Test produceWith callback with Instance<Object> param
         event.addBean().addType(Long.class).addQualifier(AnotherRandom.Literal.INSTANCE)

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/DependentBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/custombeans/DependentBean.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2021, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.weld.tests.extensions.custombeans;
+
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.Dependent;
+
+/**
+ * Serves as a counter of how many times a pre-destroy was called.
+ * Initialized only from within extension's produceWith and disposeWith methods via Instance
+ */
+@Dependent
+public class DependentBean {
+
+    public static int TIMES_DESTROY_INVOKED = 0;
+
+    public static void resetCounter() {
+        TIMES_DESTROY_INVOKED = 0;
+    }
+
+    @PreDestroy
+    public void destroy() {
+        TIMES_DESTROY_INVOKED++;
+    }
+}

--- a/weld-lite-extension-translator/pom.xml
+++ b/weld-lite-extension-translator/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>weld-core-parent</artifactId>
+        <groupId>org.jboss.weld</groupId>
+        <version>5.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>CDI Lite Extension Translator</name>
+    <artifactId>weld-lite-extension-translator</artifactId>
+
+    <properties>
+        <!-- TODO do we want source 11? -->
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationBuilderFactoryImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationBuilderFactoryImpl.java
@@ -1,0 +1,19 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.AnnotationBuilder;
+import jakarta.enterprise.inject.build.compatible.spi.AnnotationBuilderFactory;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+import java.lang.annotation.Annotation;
+
+final class AnnotationBuilderFactoryImpl implements AnnotationBuilderFactory {
+    @Override
+    public AnnotationBuilder create(Class<? extends Annotation> annotationType) {
+        return new AnnotationBuilderImpl(annotationType);
+    }
+
+    @Override
+    public AnnotationBuilder create(ClassInfo annotationType) {
+        return new AnnotationBuilderImpl((Class<? extends Annotation>) ((ClassInfoImpl) annotationType).cdiDeclaration.getJavaClass());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationBuilderImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationBuilderImpl.java
@@ -1,0 +1,287 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.AnnotationBuilder;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.AnnotationMember;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.types.ArrayType;
+import jakarta.enterprise.lang.model.types.Type;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+
+class AnnotationBuilderImpl implements AnnotationBuilder {
+    private final Class<? extends Annotation> clazz;
+    private final Map<String, AnnotationMember> members = new HashMap<>();
+
+    AnnotationBuilderImpl(Class<? extends Annotation> clazz) {
+        this.clazz = clazz;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, AnnotationMember value) {
+        members.put(name, value);
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, boolean value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, boolean[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, byte value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, byte[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, short value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, short[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, int value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, int[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, long value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, long[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, float value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, float[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, double value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, double[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, char value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, char[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, String value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, String[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Enum<?> value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Enum<?>[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Class<? extends Enum<?>> enumType, String enumValue) {
+        Enum<?> enumConstant = Enum.valueOf((Class) enumType, enumValue);
+        members.put(name, new AnnotationMemberImpl(enumConstant));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Class<? extends Enum<?>> enumType, String[] enumValues) {
+        Enum<?>[] enumConstants = new Enum[enumValues.length];
+        for (int i = 0; i < enumValues.length; i++) {
+            enumConstants[i] = Enum.valueOf((Class) enumType, enumValues[i]);
+        }
+        members.put(name, new AnnotationMemberImpl(enumConstants));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, ClassInfo enumType, String enumValue) {
+        Class enumClass = ((ClassInfoImpl) enumType).cdiDeclaration.getJavaClass();
+        Enum<?> enumConstant = Enum.valueOf(enumClass, enumValue);
+        members.put(name, new AnnotationMemberImpl(enumConstant));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, ClassInfo enumType, String[] enumValues) {
+        Class enumClass = ((ClassInfoImpl) enumType).cdiDeclaration.getJavaClass();
+        Enum<?>[] enumConstants = new Enum[enumValues.length];
+        for (int i = 0; i < enumValues.length; i++) {
+            enumConstants[i] = Enum.valueOf(enumClass, enumValues[i]);
+        }
+        members.put(name, new AnnotationMemberImpl(enumConstants));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Class<?> value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Class<?>[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, ClassInfo value) {
+        Class<?> clazz = ((ClassInfoImpl) value).cdiDeclaration.getJavaClass();
+        members.put(name, new AnnotationMemberImpl(clazz));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, ClassInfo[] values) {
+        Class<?>[] classes = new Class[values.length];
+        for (int i = 0; i < values.length; i++) {
+            classes[i] = ((ClassInfoImpl) values[i]).cdiDeclaration.getJavaClass();
+        }
+        members.put(name, new AnnotationMemberImpl(classes));
+        return this;
+    }
+
+    private Class<?> validateType(Type type) {
+        if (type instanceof VoidTypeImpl) {
+            return ((VoidTypeImpl) type).clazz;
+        } else if (type instanceof PrimitiveTypeImpl) {
+            return ((PrimitiveTypeImpl) type).clazz;
+        } else if (type instanceof ClassTypeImpl) {
+            return ((ClassTypeImpl) type).clazz;
+        } else if (type instanceof ArrayTypeImpl) {
+            ArrayType arrayType = type.asArray();
+            Type elementType = arrayType.componentType();
+            while (elementType.isArray()) {
+                elementType = elementType.asArray().componentType();
+            }
+            if (elementType instanceof PrimitiveTypeImpl) {
+                return ((PrimitiveTypeImpl) elementType).clazz;
+            } else if (elementType instanceof ClassTypeImpl) {
+                return ((ClassTypeImpl) elementType).clazz;
+            }
+        }
+
+        throw new IllegalArgumentException("Illegal type " + type);
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Type value) {
+        Class<?> clazz = validateType(value);
+        members.put(name, new AnnotationMemberImpl(clazz));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Type[] values) {
+        Class<?>[] classes = new Class[values.length];
+        for (int i = 0; i < values.length; i++) {
+            classes[i] = validateType(values[i]);
+        }
+        members.put(name, new AnnotationMemberImpl(classes));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, AnnotationInfo value) {
+        Annotation annotation = ((AnnotationInfoImpl) value).annotation;
+        members.put(name, new AnnotationMemberImpl(annotation));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, AnnotationInfo[] values) {
+        Annotation[] annotations = new Annotation[values.length];
+        for (int i = 0; i < values.length; i++) {
+            annotations[i] = ((AnnotationInfoImpl) values[i]).annotation;
+        }
+        members.put(name, new AnnotationMemberImpl(annotations));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Annotation value) {
+        members.put(name, new AnnotationMemberImpl(value));
+        return this;
+    }
+
+    @Override
+    public AnnotationBuilder member(String name, Annotation[] values) {
+        members.put(name, new AnnotationMemberImpl(values));
+        return this;
+    }
+
+    @Override
+    public AnnotationInfo build() {
+        Annotation annotation = AnnotationProxy.create(clazz, members);
+        return new AnnotationInfoImpl(annotation);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationInfoImpl.java
@@ -1,0 +1,86 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.AnnotationMember;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+class AnnotationInfoImpl implements AnnotationInfo {
+    final Annotation annotation;
+
+    AnnotationInfoImpl(Annotation annotation) {
+        this.annotation = annotation;
+    }
+
+    @Override
+    public ClassInfo declaration() {
+        return new ClassInfoImpl(BeanManagerAccess.createAnnotatedType(annotation.annotationType()));
+    }
+
+    @Override
+    public boolean hasMember(String name) {
+        try {
+            annotation.annotationType().getDeclaredMethod(name);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public AnnotationMember member(String name) {
+        try {
+            java.lang.reflect.Method member = annotation.annotationType().getDeclaredMethod(name);
+            member.setAccessible(true); // TODO!
+            Object value = member.invoke(annotation);
+            return new AnnotationMemberImpl(value);
+        } catch (NoSuchMethodException e) {
+            return null;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public Map<String, AnnotationMember> members() {
+        try {
+            java.lang.reflect.Method[] members = annotation.annotationType().getDeclaredMethods();
+            Map<String, AnnotationMember> result = new HashMap<>();
+            for (java.lang.reflect.Method member : members) {
+                member.setAccessible(true); // TODO!
+                String name = member.getName();
+                Object value = member.invoke(annotation);
+                result.put(name, new AnnotationMemberImpl(value));
+            }
+            return result;
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AnnotationInfoImpl that = (AnnotationInfoImpl) o;
+        return Objects.equals(annotation, that.annotation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(annotation);
+    }
+
+    @Override
+    public String toString() {
+        return annotation.toString();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationMemberImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationMemberImpl.java
@@ -1,0 +1,234 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.AnnotationMember;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+class AnnotationMemberImpl implements AnnotationMember {
+    final Kind kind;
+    final Object value;
+
+    AnnotationMemberImpl(Object value) {
+        this.kind = determineKind(value);
+        this.value = value;
+    }
+
+    private static Kind determineKind(Object value) {
+        if (value instanceof Boolean) {
+            return Kind.BOOLEAN;
+        } else if (value instanceof Byte) {
+            return Kind.BYTE;
+        } else if (value instanceof Short) {
+            return Kind.SHORT;
+        } else if (value instanceof Integer) {
+            return Kind.INT;
+        } else if (value instanceof Long) {
+            return Kind.LONG;
+        } else if (value instanceof Float) {
+            return Kind.FLOAT;
+        } else if (value instanceof Double) {
+            return Kind.DOUBLE;
+        } else if (value instanceof Character) {
+            return Kind.CHAR;
+        } else if (value instanceof String) {
+            return Kind.STRING;
+        } else if (value instanceof Enum) {
+            return Kind.ENUM;
+        } else if (value instanceof Class) {
+            return Kind.CLASS;
+        } else if (value instanceof Annotation) {
+            return Kind.NESTED_ANNOTATION;
+        } else if (value instanceof boolean[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof byte[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof short[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof int[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof long[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof float[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof double[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof char[]) {
+            return Kind.ARRAY;
+        } else if (value instanceof Object[]) {
+            return Kind.ARRAY;
+        } else {
+            throw new IllegalArgumentException("Unknown annotation member: " + value);
+        }
+    }
+
+    private void checkKind(Kind kind) {
+        if (this.kind != kind) {
+            throw new IllegalStateException("Not " + kind + ": " + value);
+        }
+    }
+
+    @Override
+    public Kind kind() {
+        return kind;
+    }
+
+    @Override
+    public boolean asBoolean() {
+        checkKind(Kind.BOOLEAN);
+        return (Boolean) value;
+    }
+
+    @Override
+    public byte asByte() {
+        checkKind(Kind.BYTE);
+        return (Byte) value;
+    }
+
+    @Override
+    public short asShort() {
+        checkKind(Kind.SHORT);
+        return (Short) value;
+    }
+
+    @Override
+    public int asInt() {
+        checkKind(Kind.INT);
+        return (Integer) value;
+    }
+
+    @Override
+    public long asLong() {
+        checkKind(Kind.LONG);
+        return (Long) value;
+    }
+
+    @Override
+    public float asFloat() {
+        checkKind(Kind.FLOAT);
+        return (Float) value;
+    }
+
+    @Override
+    public double asDouble() {
+        checkKind(Kind.DOUBLE);
+        return (Double) value;
+    }
+
+    @Override
+    public char asChar() {
+        checkKind(Kind.CHAR);
+        return (Character) value;
+    }
+
+    @Override
+    public String asString() {
+        checkKind(Kind.STRING);
+        return (String) value;
+    }
+
+    @Override
+    public <E extends Enum<E>> E asEnum(Class<E> enumType) {
+        checkKind(Kind.ENUM);
+        return enumType.cast(value);
+    }
+
+    @Override
+    public String asEnumConstant() {
+        checkKind(Kind.ENUM);
+        return ((Enum<?>) value).name();
+    }
+
+    @Override
+    public ClassInfo asEnumClass() {
+        checkKind(Kind.ENUM);
+        Class<?> enumType = ((Enum<?>) value).getDeclaringClass();
+        return new ClassInfoImpl(BeanManagerAccess.createAnnotatedType(enumType));
+    }
+
+    @Override
+    public Type asType() {
+        checkKind(Kind.CLASS);
+        Class<?> clazz = (Class<?>) value;
+        return TypeImpl.fromReflectionType(AnnotatedTypes.from(clazz));
+    }
+
+    @Override
+    public AnnotationInfo asNestedAnnotation() {
+        checkKind(Kind.NESTED_ANNOTATION);
+        return new AnnotationInfoImpl((Annotation) value);
+    }
+
+    @Override
+    public List<AnnotationMember> asArray() {
+        checkKind(Kind.ARRAY);
+        List<AnnotationMember> result = new ArrayList<>();
+        if (value instanceof boolean[]) {
+            for (boolean element : ((boolean[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof byte[]) {
+            for (byte element : ((byte[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof short[]) {
+            for (short element : ((short[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof int[]) {
+            for (int element : ((int[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof long[]) {
+            for (long element : ((long[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof float[]) {
+            for (float element : ((float[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof double[]) {
+            for (double element : ((double[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof char[]) {
+            for (char element : ((char[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        } else if (value instanceof Object[]) {
+            for (Object element : ((Object[]) value)) {
+                result.add(new AnnotationMemberImpl(element));
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AnnotationMemberImpl that = (AnnotationMemberImpl) o;
+        return Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return "" + value;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationPresence.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationPresence.java
@@ -1,0 +1,49 @@
+package org.jboss.weld.lite.extension.translator;
+
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+
+final class AnnotationPresence {
+
+    private AnnotationPresence(){
+    }
+
+    static Stream<Annotation> allAnnotations(jakarta.enterprise.inject.spi.AnnotatedType<?> cdiClassDeclaration) {
+        Stream<Annotation> classAnnotations = cdiClassDeclaration.getAnnotations().stream();
+        Stream<Annotation> fieldAnnotations = cdiClassDeclaration.getFields()
+                .stream()
+                .flatMap(it -> it.getAnnotations().stream());
+        Stream<Annotation> methodAnnotations = cdiClassDeclaration.getMethods()
+                .stream()
+                .flatMap(it -> it.getAnnotations().stream());
+        Stream<Annotation> constructorAnnotations = cdiClassDeclaration.getConstructors()
+                .stream()
+                .flatMap(it -> it.getAnnotations().stream());
+        Stream<Annotation> methodParameterAnnotations = cdiClassDeclaration.getMethods()
+                .stream()
+                .flatMap(it -> it.getParameters().stream())
+                .flatMap(it -> it.getAnnotations().stream());
+        Stream<Annotation> constructorParameterAnnotations = cdiClassDeclaration.getConstructors()
+                .stream()
+                .flatMap(it -> it.getParameters().stream())
+                .flatMap(it -> it.getAnnotations().stream());
+        // TODO meta-annotations
+
+        return Stream.concat(
+                classAnnotations,
+                Stream.concat(
+                        fieldAnnotations,
+                        Stream.concat(
+                                methodAnnotations,
+                                Stream.concat(
+                                        constructorAnnotations,
+                                        Stream.concat(
+                                                methodParameterAnnotations,
+                                                constructorParameterAnnotations
+                                        )
+                                )
+                        )
+                )
+        );
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationProxy.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationProxy.java
@@ -3,6 +3,7 @@ package org.jboss.weld.lite.extension.translator;
 import jakarta.enterprise.lang.model.AnnotationMember;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -18,6 +19,16 @@ final class AnnotationProxy {
         Map<String, Object> values = new HashMap<>();
         for (Map.Entry<String, AnnotationMember> member : members.entrySet()) {
             values.put(member.getKey(), ((AnnotationMemberImpl) member.getValue()).value);
+        }
+        // include default values methods where no values were specified
+        for (Method method : clazz.getDeclaredMethods()) {
+            String methodName = method.getName();
+            if (!values.containsKey(methodName)) {
+                Object value = method.getDefaultValue();
+                if (value != null) {
+                    values.put(methodName, value);
+                }
+            }
         }
         return (T) java.lang.reflect.Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(), interfaces,
                 new AnnotationInvocationHandler(clazz, values));

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationProxy.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationProxy.java
@@ -1,0 +1,75 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.AnnotationMember;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+final class AnnotationProxy {
+
+    private AnnotationProxy() {
+    }
+
+    static <T extends Annotation> T create(Class<T> clazz, Map<String, AnnotationMember> members) {
+        Class<?>[] interfaces = new Class[]{clazz};
+        Map<String, Object> values = new HashMap<>();
+        for (Map.Entry<String, AnnotationMember> member : members.entrySet()) {
+            values.put(member.getKey(), ((AnnotationMemberImpl) member.getValue()).value);
+        }
+        return (T) java.lang.reflect.Proxy.newProxyInstance(Thread.currentThread().getContextClassLoader(), interfaces,
+                new AnnotationInvocationHandler(clazz, values));
+    }
+
+    private static final class AnnotationInvocationHandler implements java.lang.reflect.InvocationHandler {
+        private final Class<? extends Annotation> clazz;
+        private final Map<String, Object> members;
+
+        AnnotationInvocationHandler(Class<? extends Annotation> clazz, Map<String, Object> members) {
+            this.clazz = clazz;
+            this.members = members;
+        }
+
+        @Override
+        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws Exception {
+            if ("annotationType".equals(method.getName())) {
+                return clazz;
+            } else if ("toString".equals(method.getName())) {
+                StringJoiner joiner = new StringJoiner(", ", "(", ")");
+                joiner.setEmptyValue("");
+                for (Map.Entry<String, Object> member : members.entrySet()) {
+                    joiner.add(member.getKey() + "=" + member.getValue());
+                }
+                return "@" + clazz.getName() + joiner.toString();
+            } else if ("equals".equals(method.getName())) {
+                Object other = args[0];
+                if (other instanceof Annotation) {
+                    Annotation that = (Annotation) other;
+                    if (clazz.equals(that.annotationType())) {
+                        for (java.lang.reflect.Method member : clazz.getDeclaredMethods()) {
+                            Object thisValue = members.get(member.getName());
+                            Object thatValue = method.invoke(that);
+                            if (!Objects.deepEquals(thisValue, thatValue)) {
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            } else if ("hashCode".equals(method.getName())) {
+                Object[] components = new Object[members.size() + 1];
+                components[0] = clazz;
+                int i = 1;
+                for (Object memberValue : members.values()) {
+                    components[i++] = memberValue;
+                }
+                return Objects.hash(components);
+            } else {
+                return members.get(method.getName());
+            }
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationTargetImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationTargetImpl.java
@@ -1,0 +1,64 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.AnnotationTarget;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+abstract class AnnotationTargetImpl<Reflection extends java.lang.reflect.AnnotatedElement> implements AnnotationTarget {
+    final Reflection reflection;
+    final AnnotationOverrides overrides;
+
+    AnnotationTargetImpl(Reflection reflection, AnnotationOverrides overrides) {
+        this.reflection = Objects.requireNonNull(reflection);
+        this.overrides = overrides;
+    }
+
+    @Override
+    public boolean hasAnnotation(Class<? extends Annotation> annotationType) {
+        java.lang.reflect.AnnotatedElement annotations = overrides != null ? overrides : reflection;
+        return annotations.isAnnotationPresent(annotationType);
+    }
+
+    @Override
+    public boolean hasAnnotation(Predicate<AnnotationInfo> predicate) {
+        java.lang.reflect.AnnotatedElement annotations = overrides != null ? overrides : reflection;
+        return Arrays.stream(annotations.getAnnotations())
+                .anyMatch(it -> predicate.test(new AnnotationInfoImpl(it)));
+    }
+
+    @Override
+    public <T extends Annotation> AnnotationInfo annotation(Class<T> annotationType) {
+        java.lang.reflect.AnnotatedElement annotations = overrides != null ? overrides : reflection;
+        T annotation = annotations.getAnnotation(annotationType);
+        return annotation == null ? null : new AnnotationInfoImpl(annotation);
+    }
+
+    @Override
+    public <T extends Annotation> Collection<AnnotationInfo> repeatableAnnotation(Class<T> annotationType) {
+        java.lang.reflect.AnnotatedElement annotations = overrides != null ? overrides : reflection;
+        return Arrays.stream(annotations.getAnnotationsByType(annotationType))
+                .map(AnnotationInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<AnnotationInfo> annotations(Predicate<AnnotationInfo> predicate) {
+        java.lang.reflect.AnnotatedElement annotations = overrides != null ? overrides : reflection;
+        return Arrays.stream(annotations.getAnnotations())
+                .map(AnnotationInfoImpl::new)
+                .filter(predicate)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<AnnotationInfo> annotations() {
+        return annotations(it -> true);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ArrayTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ArrayTypeImpl.java
@@ -1,0 +1,24 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.types.ArrayType;
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+
+class ArrayTypeImpl extends TypeImpl<java.lang.reflect.AnnotatedArrayType> implements ArrayType {
+    private final java.lang.reflect.AnnotatedType componentType;
+
+    ArrayTypeImpl(java.lang.reflect.AnnotatedArrayType reflectionType) {
+        this(reflectionType, null);
+    }
+
+    ArrayTypeImpl(java.lang.reflect.AnnotatedArrayType reflectionType, AnnotationOverrides overrides) {
+        super(reflectionType, overrides);
+
+        this.componentType = reflectionType.getAnnotatedGenericComponentType();
+    }
+
+    @Override
+    public Type componentType() {
+        return TypeImpl.fromReflectionType(componentType);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BeanInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BeanInfoImpl.java
@@ -1,0 +1,149 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.DisposerInfo;
+import jakarta.enterprise.inject.build.compatible.spi.InjectionPointInfo;
+import jakarta.enterprise.inject.build.compatible.spi.ScopeInfo;
+import jakarta.enterprise.inject.build.compatible.spi.StereotypeInfo;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.declarations.FieldInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+class BeanInfoImpl implements BeanInfo {
+    final jakarta.enterprise.inject.spi.Bean<?> cdiBean;
+    final jakarta.enterprise.inject.spi.Annotated cdiDeclaration;
+    final jakarta.enterprise.inject.spi.AnnotatedParameter<?> cdiDisposerDeclaration;
+
+    BeanInfoImpl(jakarta.enterprise.inject.spi.Bean<?> cdiBean, jakarta.enterprise.inject.spi.Annotated cdiDeclaration,
+            jakarta.enterprise.inject.spi.AnnotatedParameter<?> cdiDisposerDeclaration) {
+        this.cdiBean = cdiBean;
+        this.cdiDeclaration = cdiDeclaration;
+        this.cdiDisposerDeclaration = cdiDisposerDeclaration;
+    }
+
+    @Override
+    public ScopeInfo scope() {
+        jakarta.enterprise.inject.spi.AnnotatedType<?> scopeType = BeanManagerAccess.createAnnotatedType(cdiBean.getScope());
+        boolean isNormal = scopeType.isAnnotationPresent(jakarta.enterprise.context.NormalScope.class);
+        return new ScopeInfoImpl(new ClassInfoImpl(scopeType), isNormal);
+    }
+
+    @Override
+    public Collection<Type> types() {
+        return cdiBean.getTypes()
+                .stream()
+                .map(it -> TypeImpl.fromReflectionType(AnnotatedTypes.from(it)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<AnnotationInfo> qualifiers() {
+        return cdiBean.getQualifiers()
+                .stream()
+                .map(AnnotationInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ClassInfo declaringClass() {
+        jakarta.enterprise.inject.spi.AnnotatedType<?> beanClass = BeanManagerAccess.createAnnotatedType(cdiBean.getBeanClass());
+        return new ClassInfoImpl(beanClass);
+    }
+
+    @Override
+    public boolean isClassBean() {
+        return cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedType;
+    }
+
+    @Override
+    public boolean isProducerMethod() {
+        return cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedMethod;
+    }
+
+    @Override
+    public boolean isProducerField() {
+        return cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedField;
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return cdiDeclaration == null;
+    }
+
+    @Override
+    public MethodInfo producerMethod() {
+        if (cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedMethod) {
+            return new MethodInfoImpl((jakarta.enterprise.inject.spi.AnnotatedMethod<?>) cdiDeclaration);
+        }
+        return null;
+    }
+
+    @Override
+    public FieldInfo producerField() {
+        if (cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedField) {
+            return new FieldInfoImpl((jakarta.enterprise.inject.spi.AnnotatedField<?>) cdiDeclaration);
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return cdiBean.isAlternative();
+    }
+
+    @Override
+    public Integer priority() {
+        if (cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedType
+                && cdiDeclaration.isAnnotationPresent(Priority.class)) {
+            return cdiDeclaration.getAnnotation(Priority.class).value();
+        }
+        if (cdiBean instanceof jakarta.enterprise.inject.spi.Prioritized) {
+            return ((jakarta.enterprise.inject.spi.Prioritized) cdiBean).getPriority();
+        }
+
+        return null;
+    }
+
+    @Override
+    public String name() {
+        return cdiBean.getName();
+    }
+
+    @Override
+    public DisposerInfo disposer() {
+        if (cdiDisposerDeclaration != null) {
+            return new DisposerInfoImpl(cdiDisposerDeclaration);
+        }
+        return null;
+    }
+
+    @Override
+    public Collection<StereotypeInfo> stereotypes() {
+        return cdiBean.getStereotypes()
+                .stream()
+                .map(StereotypeInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<InjectionPointInfo> injectionPoints() {
+        return cdiBean.getInjectionPoints()
+                .stream()
+                .map(InjectionPointInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String toString() {
+        return "@" + cdiBean.getScope().getSimpleName() + " bean [types=" + cdiBean.getTypes()
+                + ", qualifiers=" + cdiBean.getQualifiers() + "]"
+                + (cdiDeclaration != null ? " declared at " + cdiDeclaration : "");
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BeanManagerAccess.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BeanManagerAccess.java
@@ -10,6 +10,9 @@ import java.lang.annotation.Annotation;
 final class BeanManagerAccess {
     private static jakarta.enterprise.inject.spi.BeanManager beanManager;
 
+    private BeanManagerAccess() {
+    }
+
     static void set(jakarta.enterprise.inject.spi.BeanManager beanManager) {
         BeanManagerAccess.beanManager = beanManager;
     }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BeanManagerAccess.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BeanManagerAccess.java
@@ -1,0 +1,40 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.decorator.Decorator;
+import jakarta.enterprise.context.Dependent;
+import jakarta.interceptor.Interceptor;
+
+import java.lang.annotation.Annotation;
+
+// TODO this is mostly a hack
+final class BeanManagerAccess {
+    private static jakarta.enterprise.inject.spi.BeanManager beanManager;
+
+    static void set(jakarta.enterprise.inject.spi.BeanManager beanManager) {
+        BeanManagerAccess.beanManager = beanManager;
+    }
+
+    static void remove() {
+        BeanManagerAccess.beanManager = null;
+    }
+
+    static <T> jakarta.enterprise.inject.spi.AnnotatedType<T> createAnnotatedType(Class<T> clazz) {
+        if (beanManager == null) {
+            throw new IllegalStateException("BeanManagerAccess.createAnnotatedType can only be called within an extension method");
+        }
+
+        return beanManager.createAnnotatedType(clazz);
+    }
+
+    static boolean isBeanDefiningAnnotation(Class<? extends Annotation> annotationType) {
+        if (beanManager == null) {
+            throw new IllegalStateException("BeanManagerAccess.isBeanDefiningAnnotation can only be called within an extension method");
+        }
+
+        return beanManager.isNormalScope(annotationType)
+                || beanManager.isStereotype(annotationType)
+                || Dependent.class.equals(annotationType)
+                || Interceptor.class.equals(annotationType)
+                || Decorator.class.equals(annotationType);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BuildServicesImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/BuildServicesImpl.java
@@ -1,0 +1,16 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.AnnotationBuilderFactory;
+import jakarta.enterprise.inject.build.compatible.spi.BuildServices;
+
+public class BuildServicesImpl implements BuildServices {
+    @Override
+    public AnnotationBuilderFactory annotationBuilderFactory() {
+        return new AnnotationBuilderFactoryImpl();
+    }
+
+    @Override
+    public int getPriority() {
+        return 0;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ClassConfigImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ClassConfigImpl.java
@@ -1,0 +1,80 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.ClassConfig;
+import jakarta.enterprise.inject.build.compatible.spi.FieldConfig;
+import jakarta.enterprise.inject.build.compatible.spi.MethodConfig;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+class ClassConfigImpl implements ClassConfig {
+    private final jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator<?> configurator;
+
+    ClassConfigImpl(jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator<?> configurator) {
+        this.configurator = configurator;
+    }
+
+    @Override
+    public ClassInfo info() {
+        return new ClassInfoImpl(configurator.getAnnotated());
+    }
+
+    @Override
+    public ClassConfig addAnnotation(Class<? extends Annotation> annotationType) {
+        configurator.add(AnnotationProxy.create(annotationType, Collections.emptyMap()));
+        return this;
+    }
+
+    @Override
+    public ClassConfig addAnnotation(AnnotationInfo annotation) {
+        configurator.add(((AnnotationInfoImpl) annotation).annotation);
+        return this;
+    }
+
+    @Override
+    public ClassConfig addAnnotation(Annotation annotation) {
+        configurator.add(annotation);
+        return this;
+    }
+
+    @Override
+    public ClassConfig removeAnnotation(Predicate<AnnotationInfo> predicate) {
+        configurator.remove(annotation -> predicate.test(new AnnotationInfoImpl(annotation)));
+        return this;
+    }
+
+    @Override
+    public ClassConfig removeAllAnnotations() {
+        configurator.removeAll();
+        return this;
+    }
+
+    @Override
+    public Collection<MethodConfig> constructors() {
+        return configurator.constructors()
+                .stream()
+                .map(MethodConstructorConfigImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<MethodConfig> methods() {
+        return configurator.methods()
+                .stream()
+                .map(MethodConfigImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<FieldConfig> fields() {
+        return configurator.fields()
+                .stream()
+                .map(FieldConfigImpl::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ClassInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ClassInfoImpl.java
@@ -1,0 +1,218 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.declarations.FieldInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+import jakarta.enterprise.lang.model.declarations.PackageInfo;
+import jakarta.enterprise.lang.model.declarations.RecordComponentInfo;
+import jakarta.enterprise.lang.model.types.Type;
+import jakarta.enterprise.lang.model.types.TypeVariable;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+class ClassInfoImpl extends DeclarationInfoImpl<Class<?>, jakarta.enterprise.inject.spi.AnnotatedType<?>> implements ClassInfo {
+    // only for equals/hashCode
+    private final String name;
+
+    ClassInfoImpl(jakarta.enterprise.inject.spi.AnnotatedType<?> cdiDeclaration) {
+        super(cdiDeclaration.getJavaClass(), cdiDeclaration);
+        this.name = cdiDeclaration.getJavaClass().getName();
+    }
+
+    @Override
+    public String name() {
+        return reflection.getName();
+    }
+
+    @Override
+    public String simpleName() {
+        return reflection.getSimpleName();
+    }
+
+    @Override
+    public PackageInfo packageInfo() {
+        return new PackageInfoImpl(reflection.getPackage());
+    }
+
+    @Override
+    public List<TypeVariable> typeParameters() {
+        return Arrays.stream(reflection.getTypeParameters())
+                .map(AnnotatedTypes::typeVariable)
+                .map(TypeVariableImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Type superClass() {
+        java.lang.reflect.AnnotatedType superClass = reflection.getAnnotatedSuperclass();
+        return superClass != null ? TypeImpl.fromReflectionType(superClass) : null;
+    }
+
+    @Override
+    public ClassInfo superClassDeclaration() {
+        Class<?> superClass = reflection.getSuperclass();
+        return superClass != null ? new ClassInfoImpl(BeanManagerAccess.createAnnotatedType(superClass)) : null;
+    }
+
+    @Override
+    public List<Type> superInterfaces() {
+        java.lang.reflect.AnnotatedType[] interfaces = reflection.getAnnotatedInterfaces();
+        return Arrays.stream(interfaces)
+                .map(TypeImpl::fromReflectionType)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<ClassInfo> superInterfacesDeclarations() {
+        return Arrays.stream(reflection.getInterfaces())
+                .map(it -> new ClassInfoImpl(BeanManagerAccess.createAnnotatedType(it)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isPlainClass() {
+        return !isInterface() && !isEnum() && !isAnnotation() && !isRecord();
+    }
+
+    @Override
+    public boolean isInterface() {
+        if (isAnnotation()) {
+            return false;
+        }
+        return reflection.isInterface();
+    }
+
+    @Override
+    public boolean isEnum() {
+        return reflection.isEnum();
+    }
+
+    @Override
+    public boolean isAnnotation() {
+        return reflection.isAnnotation();
+    }
+
+    @Override
+    public boolean isRecord() {
+        Class<?> superclass = reflection.getSuperclass();
+        return superclass != null && superclass.getName().equals("java.lang.Record");
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return java.lang.reflect.Modifier.isAbstract(reflection.getModifiers());
+    }
+
+    @Override
+    public boolean isFinal() {
+        return java.lang.reflect.Modifier.isFinal(reflection.getModifiers());
+    }
+
+    @Override
+    public int modifiers() {
+        return reflection.getModifiers();
+    }
+
+    @Override
+    public Collection<MethodInfo> constructors() {
+        // CDI doesn't define precisly what `AnnotatedType.getConstructors` should return,
+        // but the language model does -- so here, we return exactly what the lang model
+        // defines, but backed by the CDI model as much as possible
+
+        Map<java.lang.reflect.Constructor<?>, jakarta.enterprise.inject.spi.AnnotatedConstructor<?>> map = new HashMap<>();
+        for (jakarta.enterprise.inject.spi.AnnotatedConstructor<?> constructor : cdiDeclaration.getConstructors()) {
+            map.put(constructor.getJavaMember(), constructor);
+        }
+
+        return Arrays.stream(reflection.getDeclaredConstructors())
+                .filter(it -> !it.isSynthetic())
+                .map(it -> {
+                    if (map.containsKey(it)) {
+                        return new MethodInfoImpl(map.get(it));
+                    } else {
+                        return new MethodInfoImpl(it);
+                    }
+                }).collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<MethodInfo> methods() {
+        // CDI doesn't define precisly what `AnnotatedType.getMethods` should return,
+        // but the language model does -- so here, we return exactly what the lang model
+        // defines, but backed by the CDI model as much as possible
+
+        Map<java.lang.reflect.Method, jakarta.enterprise.inject.spi.AnnotatedMethod<?>> map = new HashMap<>();
+        for (jakarta.enterprise.inject.spi.AnnotatedMethod<?> method : cdiDeclaration.getMethods()) {
+            map.put(method.getJavaMember(), method);
+        }
+
+        return ReflectionMembers.allMethods(reflection)
+                .stream()
+                .filter(it -> !it.isSynthetic())
+                .map(it -> {
+                    if (map.containsKey(it)) {
+                        return new MethodInfoImpl(map.get(it));
+                    } else {
+                        return new MethodInfoImpl(it);
+                    }
+                }).collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<FieldInfo> fields() {
+        // CDI doesn't define precisly what `AnnotatedType.getFields` should return,
+        // but the language model does -- so here, we return exactly what the lang model
+        // defines, but backed by the CDI model as much as possible
+
+        Map<java.lang.reflect.Field, jakarta.enterprise.inject.spi.AnnotatedField<?>> map = new HashMap<>();
+        for (jakarta.enterprise.inject.spi.AnnotatedField<?> field : cdiDeclaration.getFields()) {
+            map.put(field.getJavaMember(), field);
+        }
+
+        return ReflectionMembers.allFields(reflection)
+                .stream()
+                .filter(it -> !it.isSynthetic())
+                .map(it -> {
+                    if (map.containsKey(it)) {
+                        return new FieldInfoImpl(map.get(it));
+                    } else {
+                        return new FieldInfoImpl(it);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<RecordComponentInfo> recordComponents() {
+        if (isRecord()) {
+            // TODO
+            throw new UnsupportedOperationException("Records not yet supported");
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClassInfoImpl classInfo = (ClassInfoImpl) o;
+        return Objects.equals(name, classInfo.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ClassTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ClassTypeImpl.java
@@ -1,0 +1,33 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.types.ClassType;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+class ClassTypeImpl extends TypeImpl<java.lang.reflect.AnnotatedType> implements ClassType {
+    final Class<?> clazz;
+
+    ClassTypeImpl(java.lang.reflect.AnnotatedType clazz) {
+        this(clazz, null);
+    }
+
+    ClassTypeImpl(java.lang.reflect.AnnotatedType clazz, AnnotationOverrides overrides) {
+        super(clazz, overrides);
+        this.clazz = (Class<?>) clazz.getType();
+    }
+
+    ClassTypeImpl(Class<?> clazz) {
+        this(clazz, null);
+    }
+
+    ClassTypeImpl(Class<?> clazz, AnnotationOverrides overrides) {
+        super(AnnotatedTypes.from(clazz), overrides);
+        this.clazz = clazz;
+    }
+
+    @Override
+    public ClassInfo declaration() {
+        return new ClassInfoImpl(BeanManagerAccess.createAnnotatedType(clazz));
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/DeclarationInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/DeclarationInfoImpl.java
@@ -1,0 +1,99 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.DeclarationInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+abstract class DeclarationInfoImpl<ReflectionDeclaration extends java.lang.reflect.AnnotatedElement,
+        CdiDeclaration extends jakarta.enterprise.inject.spi.Annotated> extends AnnotationTargetImpl<ReflectionDeclaration> implements DeclarationInfo {
+    final CdiDeclaration cdiDeclaration; // may be null
+
+    DeclarationInfoImpl(ReflectionDeclaration reflectionDeclaration, CdiDeclaration cdiDeclaration) {
+        super(reflectionDeclaration, null);
+        this.cdiDeclaration = cdiDeclaration;
+    }
+
+    static DeclarationInfo fromCdiDeclaration(jakarta.enterprise.inject.spi.Annotated cdiDeclaration) {
+        Objects.requireNonNull(cdiDeclaration);
+
+        if (cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedType) {
+            return new ClassInfoImpl((jakarta.enterprise.inject.spi.AnnotatedType<?>) cdiDeclaration);
+        } else if (cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedCallable) {
+            // method or constructor
+            return new MethodInfoImpl((jakarta.enterprise.inject.spi.AnnotatedCallable<?>) cdiDeclaration);
+        } else if (cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedParameter) {
+            return new ParameterInfoImpl((jakarta.enterprise.inject.spi.AnnotatedParameter<?>) cdiDeclaration);
+        } else if (cdiDeclaration instanceof jakarta.enterprise.inject.spi.AnnotatedField) {
+            return new FieldInfoImpl((jakarta.enterprise.inject.spi.AnnotatedField<?>) cdiDeclaration);
+        } else {
+            throw new IllegalArgumentException("Unknown declaration " + cdiDeclaration);
+        }
+    }
+
+    @Override
+    public boolean hasAnnotation(Class<? extends Annotation> annotationType) {
+        if (cdiDeclaration == null) {
+            return super.hasAnnotation(annotationType);
+        }
+
+        return cdiDeclaration.isAnnotationPresent(annotationType);
+    }
+
+    @Override
+    public boolean hasAnnotation(Predicate<AnnotationInfo> predicate) {
+        if (cdiDeclaration == null) {
+            return super.hasAnnotation(predicate);
+        }
+
+        return cdiDeclaration.getAnnotations()
+                .stream()
+                .anyMatch(it -> predicate.test(new AnnotationInfoImpl(it)));
+    }
+
+    @Override
+    public <T extends Annotation> AnnotationInfo annotation(Class<T> annotationType) {
+        if (cdiDeclaration == null) {
+            return super.annotation(annotationType);
+        }
+
+        T annotation = cdiDeclaration.getAnnotation(annotationType);
+        return annotation == null ? null : new AnnotationInfoImpl(annotation);
+    }
+
+    @Override
+    public <T extends Annotation> Collection<AnnotationInfo> repeatableAnnotation(Class<T> annotationType) {
+        if (cdiDeclaration == null) {
+            return super.repeatableAnnotation(annotationType);
+        }
+
+        return cdiDeclaration.getAnnotations(annotationType)
+                .stream()
+                .map(AnnotationInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<AnnotationInfo> annotations(Predicate<AnnotationInfo> predicate) {
+        if (cdiDeclaration == null) {
+            return super.annotations(predicate);
+        }
+
+        return cdiDeclaration.getAnnotations()
+                .stream()
+                .map(AnnotationInfoImpl::new)
+                .filter(predicate)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String toString() {
+        return cdiDeclaration != null
+                ? cdiDeclaration.toString()
+                : reflection.toString();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/DisposerInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/DisposerInfoImpl.java
@@ -1,0 +1,23 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.DisposerInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+import jakarta.enterprise.lang.model.declarations.ParameterInfo;
+
+class DisposerInfoImpl implements DisposerInfo {
+    private final jakarta.enterprise.inject.spi.AnnotatedParameter<?> cdiDeclaration;
+
+    DisposerInfoImpl(jakarta.enterprise.inject.spi.AnnotatedParameter<?> cdiDeclaration) {
+        this.cdiDeclaration = cdiDeclaration;
+    }
+
+    @Override
+    public MethodInfo disposerMethod() {
+        return new MethodInfoImpl(cdiDeclaration.getDeclaringCallable());
+    }
+
+    @Override
+    public ParameterInfo disposedParameter() {
+        return new ParameterInfoImpl(cdiDeclaration);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionInvoker.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionInvoker.java
@@ -1,0 +1,126 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.SkipIfPortableExtensionPresent;
+import jakarta.interceptor.Interceptor;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+class ExtensionInvoker {
+
+    private static final int DEFAULT_PRIORITY = Interceptor.Priority.APPLICATION + 500;
+
+    private final Map<String, Class<?>> extensionClasses = new HashMap<>();
+    private final Map<Class<?>, Object> extensionClassInstances = new HashMap<>();
+
+    ExtensionInvoker() {
+        for (BuildCompatibleExtension extension : ServiceLoader.load(BuildCompatibleExtension.class)) {
+            Class<? extends BuildCompatibleExtension> extensionClass = extension.getClass();
+
+            SkipIfPortableExtensionPresent skip = extensionClass.getAnnotation(SkipIfPortableExtensionPresent.class);
+            if (skip != null && isClassPresent(skip.value())) {
+                continue;
+            }
+
+            extensionClasses.put(extensionClass.getName(), extensionClass);
+            extensionClassInstances.put(extensionClass, extension);
+        }
+    }
+
+    private boolean isClassPresent(String className) {
+        try {
+            Class.forName(className, true, Thread.currentThread().getContextClassLoader());
+            // TODO consult BeanManager if extension is present?
+            return true;
+        } catch (ClassNotFoundException ignored) {
+            return false;
+        }
+    }
+
+    List<java.lang.reflect.Method> findExtensionMethods(Class<? extends Annotation> annotation) {
+        return extensionClasses.values()
+                .stream()
+                .flatMap(it -> Arrays.stream(it.getDeclaredMethods()))
+                .filter(it -> it.getAnnotation(annotation) != null)
+                .sorted((m1, m2) -> {
+                    if (m1.equals(m2)) {
+                        return 0;
+                    }
+
+                    int p1 = getExtensionMethodPriority(m1);
+                    int p2 = getExtensionMethodPriority(m2);
+
+                    // must _not_ return 0 if priorities are equal, because that isn't consistent
+                    // with the `equals` method
+                    return p1 < p2 ? -1 : 1;
+                })
+                .collect(Collectors.toList());
+    }
+
+    private int getExtensionMethodPriority(java.lang.reflect.Method method) {
+        Priority priority = method.getAnnotation(Priority.class);
+        if (priority != null) {
+            return priority.value();
+        }
+        return DEFAULT_PRIORITY;
+    }
+
+    void callExtensionMethod(java.lang.reflect.Method method, List<Object> arguments) throws ReflectiveOperationException {
+        Class<?>[] parameterTypes = new Class[arguments.size()];
+
+        for (int i = 0; i < parameterTypes.length; i++) {
+            Object argument = arguments.get(i);
+            Class<?> argumentClass = argument.getClass();
+
+            // beware of ordering! subtypes must precede supertypes
+            if (jakarta.enterprise.lang.model.declarations.ClassInfo.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.lang.model.declarations.ClassInfo.class;
+            } else if (jakarta.enterprise.lang.model.declarations.MethodInfo.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.lang.model.declarations.MethodInfo.class;
+            } else if (jakarta.enterprise.lang.model.declarations.FieldInfo.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.lang.model.declarations.FieldInfo.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.ScannedClasses.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.ScannedClasses.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.MetaAnnotations.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.MetaAnnotations.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.ClassConfig.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.ClassConfig.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.MethodConfig.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.MethodConfig.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.FieldConfig.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.FieldConfig.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.BeanInfo.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.BeanInfo.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.ObserverInfo.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.ObserverInfo.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.Messages.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.Messages.class;
+            } else if (jakarta.enterprise.inject.build.compatible.spi.Types.class.isAssignableFrom(argumentClass)) {
+                parameterTypes[i] = jakarta.enterprise.inject.build.compatible.spi.Types.class;
+            } else {
+                // should never happen, internal error (or missing error handling) if it does
+                throw new IllegalArgumentException("Unexpected extension method argument: " + argument);
+            }
+        }
+
+        Class<?> extensionClass = extensionClasses.get(method.getDeclaringClass().getName());
+        Object extensionClassInstance = extensionClassInstances.get(extensionClass);
+
+        method.setAccessible(true);
+        method.invoke(extensionClassInstance, arguments.toArray());
+    }
+
+    void clear() {
+        extensionClasses.clear();
+        extensionClassInstances.clear();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionMethodParameterType.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionMethodParameterType.java
@@ -1,0 +1,83 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.ClassConfig;
+import jakarta.enterprise.inject.build.compatible.spi.FieldConfig;
+import jakarta.enterprise.inject.build.compatible.spi.InterceptorInfo;
+import jakarta.enterprise.inject.build.compatible.spi.Messages;
+import jakarta.enterprise.inject.build.compatible.spi.MetaAnnotations;
+import jakarta.enterprise.inject.build.compatible.spi.MethodConfig;
+import jakarta.enterprise.inject.build.compatible.spi.ObserverInfo;
+import jakarta.enterprise.inject.build.compatible.spi.ScannedClasses;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+import jakarta.enterprise.inject.build.compatible.spi.Types;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.declarations.FieldInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+
+enum ExtensionMethodParameterType {
+    META_ANNOTATIONS(MetaAnnotations.class, false, ExtensionPhase.DISCOVERY),
+    SCANNED_CLASSES(ScannedClasses.class, false, ExtensionPhase.DISCOVERY),
+
+    CLASS_INFO(ClassInfo.class, true, ExtensionPhase.ENHANCEMENT),
+    METHOD_INFO(MethodInfo.class, true, ExtensionPhase.ENHANCEMENT),
+    FIELD_INFO(FieldInfo.class, true, ExtensionPhase.ENHANCEMENT),
+
+    CLASS_CONFIG(ClassConfig.class, true, ExtensionPhase.ENHANCEMENT),
+    METHOD_CONFIG(MethodConfig.class, true, ExtensionPhase.ENHANCEMENT),
+    FIELD_CONFIG(FieldConfig.class, true, ExtensionPhase.ENHANCEMENT),
+
+    BEAN_INFO(BeanInfo.class, true, ExtensionPhase.REGISTRATION),
+    INTERCEPTOR_INFO(InterceptorInfo.class, true, ExtensionPhase.REGISTRATION),
+    OBSERVER_INFO(ObserverInfo.class, true, ExtensionPhase.REGISTRATION),
+
+    SYNTHETIC_COMPONENTS(SyntheticComponents.class, false, ExtensionPhase.SYNTHESIS),
+
+    MESSAGES(Messages.class, false, ExtensionPhase.DISCOVERY, ExtensionPhase.ENHANCEMENT,
+            ExtensionPhase.REGISTRATION, ExtensionPhase.SYNTHESIS, ExtensionPhase.VALIDATION),
+    TYPES(Types.class, false, ExtensionPhase.ENHANCEMENT, ExtensionPhase.REGISTRATION,
+            ExtensionPhase.SYNTHESIS, ExtensionPhase.VALIDATION),
+
+    UNKNOWN(null, false),
+    ;
+
+    private final Class<?> type;
+    private final boolean isQuery;
+    private final Set<ExtensionPhase> validPhases;
+
+    ExtensionMethodParameterType(Class<?> type, boolean isQuery, ExtensionPhase... validPhases) {
+        this.type = type;
+        this.isQuery = isQuery;
+        if (validPhases == null || validPhases.length == 0) {
+            this.validPhases = EnumSet.noneOf(ExtensionPhase.class);
+        } else {
+            this.validPhases = EnumSet.copyOf(Arrays.asList(validPhases));
+        }
+    }
+
+    boolean isQuery() {
+        return isQuery;
+    }
+
+    void verifyAvailable(ExtensionPhase phase, java.lang.reflect.Method method) {
+        if (!validPhases.contains(phase)) {
+            throw new IllegalArgumentException(phase + " methods can't declare a parameter of type "
+                    + (type != null ? type.getSimpleName() : this.name()) + ", found at "
+                    + method.getDeclaringClass().getSimpleName() + "." + method.getName());
+        }
+    }
+
+    static ExtensionMethodParameterType of(Class<?> type) {
+        for (ExtensionMethodParameterType candidate : ExtensionMethodParameterType.values()) {
+            if (candidate.type.equals(type)) {
+                return candidate;
+            }
+        }
+
+        return UNKNOWN;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhase.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhase.java
@@ -1,0 +1,29 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.Discovery;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.Validation;
+
+import java.lang.annotation.Annotation;
+
+enum ExtensionPhase {
+    DISCOVERY(Discovery.class),
+    ENHANCEMENT(Enhancement.class),
+    REGISTRATION(Registration.class),
+    SYNTHESIS(Synthesis.class),
+    VALIDATION(Validation.class),
+    ;
+
+    final Class<? extends Annotation> annotation;
+
+    ExtensionPhase(Class<? extends Annotation> annotation) {
+        this.annotation = annotation;
+    }
+
+    @Override
+    public String toString() {
+        return "@" + annotation.getSimpleName();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseBase.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseBase.java
@@ -1,0 +1,65 @@
+package org.jboss.weld.lite.extension.translator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+abstract class ExtensionPhaseBase {
+    private final ExtensionPhase phase;
+
+    final jakarta.enterprise.inject.spi.BeanManager beanManager;
+    final ExtensionInvoker util;
+    final SharedErrors errors;
+
+    ExtensionPhaseBase(ExtensionPhase phase, jakarta.enterprise.inject.spi.BeanManager beanManager,
+            ExtensionInvoker util, SharedErrors errors) {
+        this.phase = phase;
+
+        this.beanManager = beanManager;
+        this.util = util;
+        this.errors = errors;
+    }
+
+    final void run() {
+        try {
+            List<java.lang.reflect.Method> extensionMethods = util.findExtensionMethods(phase.annotation);
+
+            for (java.lang.reflect.Method method : extensionMethods) {
+                runExtensionMethod(method);
+            }
+        } catch (Exception e) {
+            // TODO proper diagnostics system
+            throw new RuntimeException(e);
+        }
+    }
+
+    // complex phases may override, but this is enough for the simple phases
+    void runExtensionMethod(java.lang.reflect.Method method) throws ReflectiveOperationException {
+        int numParameters = method.getParameterCount();
+        List<ExtensionMethodParameterType> parameters = new ArrayList<>(numParameters);
+        for (int i = 0; i < numParameters; i++) {
+            Class<?> parameterType = method.getParameterTypes()[i];
+            ExtensionMethodParameterType parameter = ExtensionMethodParameterType.of(parameterType);
+            parameters.add(parameter);
+
+            parameter.verifyAvailable(phase, method);
+        }
+
+        List<Object> arguments = new ArrayList<>(numParameters);
+        for (ExtensionMethodParameterType parameter : parameters) {
+            Object argument = argumentForExtensionMethod(parameter, method);
+            arguments.add(argument);
+        }
+
+        util.callExtensionMethod(method, arguments);
+    }
+
+    // all phases should override and use this as a fallback
+    Object argumentForExtensionMethod(ExtensionMethodParameterType type, java.lang.reflect.Method method) {
+        if (type == ExtensionMethodParameterType.MESSAGES) {
+            return new MessagesImpl(method, errors);
+        }
+
+        throw new IllegalArgumentException("internal error, " + type + " parameter declared at "
+                + method.getDeclaringClass().getSimpleName() + "." + method.getName());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseDiscovery.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseDiscovery.java
@@ -1,0 +1,32 @@
+package org.jboss.weld.lite.extension.translator;
+
+import java.util.List;
+
+class ExtensionPhaseDiscovery extends ExtensionPhaseBase {
+    private final jakarta.enterprise.inject.spi.BeforeBeanDiscovery bbd;
+    private final List<MetaAnnotationsImpl.StereotypeConfigurator<?>> stereotypes;
+    private final List<MetaAnnotationsImpl.ContextData> contexts;
+
+    ExtensionPhaseDiscovery(jakarta.enterprise.inject.spi.BeanManager beanManager, ExtensionInvoker util,
+            SharedErrors errors, jakarta.enterprise.inject.spi.BeforeBeanDiscovery bbd,
+            List<MetaAnnotationsImpl.StereotypeConfigurator<?>> stereotypes,
+            List<MetaAnnotationsImpl.ContextData> contexts) {
+        super(ExtensionPhase.DISCOVERY, beanManager, util, errors);
+        this.bbd = bbd;
+        this.stereotypes = stereotypes;
+        this.contexts = contexts;
+    }
+
+    @Override
+    Object argumentForExtensionMethod(ExtensionMethodParameterType type, java.lang.reflect.Method method) {
+        switch (type) {
+            case META_ANNOTATIONS:
+                return new MetaAnnotationsImpl(bbd, stereotypes, contexts);
+            case SCANNED_CLASSES:
+                return new ScannedClassesImpl(bbd);
+
+            default:
+                return super.argumentForExtensionMethod(type, method);
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancement.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancement.java
@@ -1,0 +1,191 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Consumer;
+
+class ExtensionPhaseEnhancement extends ExtensionPhaseBase {
+    private final List<ExtensionPhaseEnhancementAction> actions;
+
+    ExtensionPhaseEnhancement(jakarta.enterprise.inject.spi.BeanManager beanManager, ExtensionInvoker util,
+            SharedErrors errors, List<ExtensionPhaseEnhancementAction> actions) {
+        super(ExtensionPhase.ENHANCEMENT, beanManager, util, errors);
+        this.actions = actions;
+    }
+
+    @Override
+    void runExtensionMethod(java.lang.reflect.Method method) {
+        int numParameters = method.getParameterCount();
+        int numQueryParameters = 0;
+        List<ExtensionMethodParameterType> parameters = new ArrayList<>(numParameters);
+        for (int i = 0; i < numParameters; i++) {
+            Class<?> parameterType = method.getParameterTypes()[i];
+            ExtensionMethodParameterType parameter = ExtensionMethodParameterType.of(parameterType);
+            parameters.add(parameter);
+
+            if (parameter.isQuery()) {
+                numQueryParameters++;
+            }
+
+            parameter.verifyAvailable(ExtensionPhase.ENHANCEMENT, method);
+        }
+
+        if (numQueryParameters == 0) {
+            throw new IllegalArgumentException("No parameter of type ClassInfo, MethodInfo, FieldInfo, "
+                    + "ClassConfig, MethodConfig, or FieldConfig for method " + method + " @ " + method.getDeclaringClass());
+        }
+
+        if (numQueryParameters > 1) {
+            throw new IllegalArgumentException("More than 1 parameter of type ClassInfo, MethodInfo, FieldInfo, "
+                    + "ClassConfig, MethodConfig, or FieldConfig for method " + method + " @ " + method.getDeclaringClass());
+        }
+
+        ExtensionMethodParameterType query = parameters.stream()
+                .filter(ExtensionMethodParameterType::isQuery)
+                .findAny()
+                .get(); // guaranteed to be there
+
+        Consumer<jakarta.enterprise.inject.spi.ProcessAnnotatedType<?>> patAcceptor = pat -> {
+            // for Class{Info,Config}, there's just 1 argument list (one call);
+            // for {Field,Method}{Info,Config}, there's multiple argument lists
+            // (one call for each field/method)
+            List<List<Object>> argumentsForAllInvocations = new ArrayList<>();
+            if (query == ExtensionMethodParameterType.CLASS_INFO) {
+                List<Object> arguments = new ArrayList<>(numParameters);
+                for (ExtensionMethodParameterType parameter : parameters) {
+                    Object argument;
+                    if (parameter == ExtensionMethodParameterType.CLASS_INFO) {
+                        argument = new ClassInfoImpl(pat.getAnnotatedType());
+                    } else {
+                        argument = argumentForExtensionMethod(parameter, method);
+                    }
+                    arguments.add(argument);
+                }
+
+                argumentsForAllInvocations.add(arguments);
+            } else if (query == ExtensionMethodParameterType.CLASS_CONFIG) {
+                List<Object> arguments = new ArrayList<>(numParameters);
+                for (ExtensionMethodParameterType parameter : parameters) {
+                    Object argument;
+                    if (parameter == ExtensionMethodParameterType.CLASS_CONFIG) {
+                        argument = new ClassConfigImpl(pat.configureAnnotatedType());
+                    } else {
+                        argument = argumentForExtensionMethod(parameter, method);
+                    }
+                    arguments.add(argument);
+                }
+
+                argumentsForAllInvocations.add(arguments);
+            } else if (query == ExtensionMethodParameterType.METHOD_INFO) {
+                for (jakarta.enterprise.inject.spi.AnnotatedMethod<?> targetMethod : pat.getAnnotatedType().getMethods()) {
+                    List<Object> arguments = new ArrayList<>(numParameters);
+                    for (ExtensionMethodParameterType parameter : parameters) {
+                        Object argument;
+                        if (parameter == ExtensionMethodParameterType.METHOD_INFO) {
+                            argument = new MethodInfoImpl(targetMethod);
+                        } else {
+                            argument = argumentForExtensionMethod(parameter, method);
+                        }
+                        arguments.add(argument);
+                    }
+                    argumentsForAllInvocations.add(arguments);
+                }
+                for (jakarta.enterprise.inject.spi.AnnotatedConstructor<?> targetConstructor : pat.getAnnotatedType().getConstructors()) {
+                    List<Object> arguments = new ArrayList<>(numParameters);
+                    for (ExtensionMethodParameterType parameter : parameters) {
+                        Object argument;
+                        if (parameter == ExtensionMethodParameterType.METHOD_INFO) {
+                            argument = new MethodInfoImpl(targetConstructor);
+                        } else {
+                            argument = argumentForExtensionMethod(parameter, method);
+                        }
+                        arguments.add(argument);
+                    }
+                    argumentsForAllInvocations.add(arguments);
+                }
+            } else if (query == ExtensionMethodParameterType.METHOD_CONFIG) {
+                for (jakarta.enterprise.inject.spi.configurator.AnnotatedMethodConfigurator<?> targetMethodConfigurator : pat.configureAnnotatedType().methods()) {
+                    List<Object> arguments = new ArrayList<>(numParameters);
+                    for (ExtensionMethodParameterType parameter : parameters) {
+                        Object argument;
+                        if (parameter == ExtensionMethodParameterType.METHOD_CONFIG) {
+                            argument = new MethodConfigImpl(targetMethodConfigurator);
+                        } else {
+                            argument = argumentForExtensionMethod(parameter, method);
+                        }
+                        arguments.add(argument);
+                    }
+                    argumentsForAllInvocations.add(arguments);
+                }
+                for (jakarta.enterprise.inject.spi.configurator.AnnotatedConstructorConfigurator<?> targetConstructorConfigurator : pat.configureAnnotatedType().constructors()) {
+                    List<Object> arguments = new ArrayList<>(numParameters);
+                    for (ExtensionMethodParameterType parameter : parameters) {
+                        Object argument;
+                        if (parameter == ExtensionMethodParameterType.METHOD_CONFIG) {
+                            argument = new MethodConstructorConfigImpl(targetConstructorConfigurator);
+                        } else {
+                            argument = argumentForExtensionMethod(parameter, method);
+                        }
+                        arguments.add(argument);
+                    }
+                    argumentsForAllInvocations.add(arguments);
+                }
+            } else if (query == ExtensionMethodParameterType.FIELD_INFO) {
+                for (jakarta.enterprise.inject.spi.AnnotatedField<?> targetField : pat.getAnnotatedType().getFields()) {
+                    List<Object> arguments = new ArrayList<>(numParameters);
+                    for (ExtensionMethodParameterType parameter : parameters) {
+                        Object argument;
+                        if (parameter == ExtensionMethodParameterType.FIELD_INFO) {
+                            argument = new FieldInfoImpl(targetField);
+                        } else {
+                            argument = argumentForExtensionMethod(parameter, method);
+                        }
+                        arguments.add(argument);
+                    }
+                    argumentsForAllInvocations.add(arguments);
+                }
+            } else if (query == ExtensionMethodParameterType.FIELD_CONFIG) {
+                for (jakarta.enterprise.inject.spi.configurator.AnnotatedFieldConfigurator<?> targetFieldConfigurator : pat.configureAnnotatedType().fields()) {
+                    List<Object> arguments = new ArrayList<>(numParameters);
+                    for (ExtensionMethodParameterType parameter : parameters) {
+                        Object argument;
+                        if (parameter == ExtensionMethodParameterType.FIELD_CONFIG) {
+                            argument = new FieldConfigImpl(targetFieldConfigurator);
+                        } else {
+                            argument = argumentForExtensionMethod(parameter, method);
+                        }
+                        arguments.add(argument);
+                    }
+                    argumentsForAllInvocations.add(arguments);
+                }
+            } else {
+                throw new IllegalStateException("Unknown query parameter " + query);
+            }
+
+            for (List<Object> arguments : argumentsForAllInvocations) {
+                try {
+                    util.callExtensionMethod(method, arguments);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+
+        Enhancement enhancement = method.getAnnotation(Enhancement.class);
+        actions.add(new ExtensionPhaseEnhancementAction(new HashSet<>(Arrays.asList(enhancement.types())), enhancement.withSubtypes(),
+                new HashSet<>(Arrays.asList(enhancement.withAnnotations())), patAcceptor));
+    }
+
+    @Override
+    Object argumentForExtensionMethod(ExtensionMethodParameterType type, java.lang.reflect.Method method) {
+        if (type == ExtensionMethodParameterType.TYPES) {
+            return new TypesImpl();
+        }
+
+        return super.argumentForExtensionMethod(type, method);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancement.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancement.java
@@ -34,14 +34,16 @@ class ExtensionPhaseEnhancement extends ExtensionPhaseBase {
             parameter.verifyAvailable(ExtensionPhase.ENHANCEMENT, method);
         }
 
-        if (numQueryParameters == 0) {
-            throw new IllegalArgumentException("No parameter of type ClassInfo, MethodInfo, FieldInfo, "
-                    + "ClassConfig, MethodConfig, or FieldConfig for method " + method + " @ " + method.getDeclaringClass());
-        }
+        if (numQueryParameters != 1) {
+            String errorMsg = " of type ClassInfo, MethodInfo, FieldInfo, ClassConfig, MethodConfig," +
+                    " or FieldConfig for method " + method + " @ " + method.getDeclaringClass();
+            if (numQueryParameters == 0) {
+                throw new IllegalArgumentException("No parameter" + errorMsg);
+            }
 
-        if (numQueryParameters > 1) {
-            throw new IllegalArgumentException("More than 1 parameter of type ClassInfo, MethodInfo, FieldInfo, "
-                    + "ClassConfig, MethodConfig, or FieldConfig for method " + method + " @ " + method.getDeclaringClass());
+            if (numQueryParameters > 1) {
+                throw new IllegalArgumentException("More than 1 parameter" + errorMsg);
+            }
         }
 
         ExtensionMethodParameterType query = parameters.stream()

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancementAction.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancementAction.java
@@ -13,7 +13,7 @@ class ExtensionPhaseEnhancementAction {
     private final Consumer<jakarta.enterprise.inject.spi.ProcessAnnotatedType<?>> acceptor;
 
     ExtensionPhaseEnhancementAction(Set<Class<?>> types, boolean withSubtypes, Set<Class<? extends Annotation>> withAnnotations,
-            Consumer<jakarta.enterprise.inject.spi.ProcessAnnotatedType<?>> acceptor) {
+                                    Consumer<jakarta.enterprise.inject.spi.ProcessAnnotatedType<?>> acceptor) {
         this.types = types;
         this.withSubtypes = withSubtypes;
         this.withAnnotations = withAnnotations;
@@ -45,16 +45,19 @@ class ExtensionPhaseEnhancementAction {
     }
 
     private boolean satisfiesAnnotationConstraints(jakarta.enterprise.inject.spi.AnnotatedType<?> annotatedType) {
+        // TODO see https://github.com/eclipse-ee4j/cdi/issues/564
+        // This is a default value of all Enhancement methods but we need to treat it as "accept all"
+        // in order to be able to modify all classes
+        if (withAnnotations.contains(Enhancement.BeanDefiningAnnotations.class)) {
+            return true;
+        }
+
         return AnnotationPresence.allAnnotations(annotatedType)
                 .anyMatch(it -> {
                     if (withAnnotations.contains(Annotation.class)) {
                         return true;
                     }
                     if (withAnnotations.contains(it.annotationType())) {
-                        return true;
-                    }
-                    if (withAnnotations.contains(Enhancement.BeanDefiningAnnotations.class)
-                            && BeanManagerAccess.isBeanDefiningAnnotation(it.annotationType())) {
                         return true;
                     }
                     return false;

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancementAction.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancementAction.java
@@ -1,0 +1,63 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+import java.util.function.Consumer;
+
+class ExtensionPhaseEnhancementAction {
+    private final Set<Class<?>> types;
+    private final boolean withSubtypes;
+    private final Set<Class<? extends Annotation>> withAnnotations;
+    private final Consumer<jakarta.enterprise.inject.spi.ProcessAnnotatedType<?>> acceptor;
+
+    ExtensionPhaseEnhancementAction(Set<Class<?>> types, boolean withSubtypes, Set<Class<? extends Annotation>> withAnnotations,
+            Consumer<jakarta.enterprise.inject.spi.ProcessAnnotatedType<?>> acceptor) {
+        this.types = types;
+        this.withSubtypes = withSubtypes;
+        this.withAnnotations = withAnnotations;
+        this.acceptor = acceptor;
+    }
+
+    void run(jakarta.enterprise.inject.spi.ProcessAnnotatedType<?> pat) {
+        if (satisfies(pat.getAnnotatedType())) {
+            acceptor.accept(pat);
+        }
+    }
+
+    private boolean satisfies(jakarta.enterprise.inject.spi.AnnotatedType<?> inspectedAnnotatedType) {
+        Class<?> inspectedClass = inspectedAnnotatedType.getJavaClass();
+        if (types.contains(inspectedClass)) {
+            return satisfiesAnnotationConstraints(inspectedAnnotatedType);
+        } else if (withSubtypes) {
+            boolean typeMatches = false;
+            for (Class<?> type : types) {
+                if (type.isAssignableFrom(inspectedClass)) {
+                    typeMatches = true;
+                    break;
+                }
+            }
+            return typeMatches && satisfiesAnnotationConstraints(inspectedAnnotatedType);
+        } else {
+            return false;
+        }
+    }
+
+    private boolean satisfiesAnnotationConstraints(jakarta.enterprise.inject.spi.AnnotatedType<?> annotatedType) {
+        return AnnotationPresence.allAnnotations(annotatedType)
+                .anyMatch(it -> {
+                    if (withAnnotations.contains(Annotation.class)) {
+                        return true;
+                    }
+                    if (withAnnotations.contains(it.annotationType())) {
+                        return true;
+                    }
+                    if (withAnnotations.contains(Enhancement.BeanDefiningAnnotations.class)
+                            && BeanManagerAccess.isBeanDefiningAnnotation(it.annotationType())) {
+                        return true;
+                    }
+                    return false;
+                });
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
@@ -34,14 +34,15 @@ class ExtensionPhaseRegistration extends ExtensionPhaseBase {
             parameter.verifyAvailable(ExtensionPhase.REGISTRATION, method);
         }
 
-        if (numQueryParameters == 0) {
-            throw new IllegalArgumentException("No parameter of type BeanInfo or ObserverInfo"
-                    + " for method " + method + " @ " + method.getDeclaringClass());
-        }
+        if (numQueryParameters != 1) {
+            String errorMsg = " of type BeanInfo or ObserverInfo for method " + method + " @ " + method.getDeclaringClass();
+            if (numQueryParameters == 0) {
+                throw new IllegalArgumentException("No parameter" + errorMsg);
+            }
 
-        if (numQueryParameters > 1) {
-            throw new IllegalArgumentException("More than 1 parameter of type BeanInfo or ObserverInfo"
-                    + " for method " + method + " @ " + method.getDeclaringClass());
+            if (numQueryParameters > 1) {
+                throw new IllegalArgumentException("More than 1 parameter" + errorMsg);
+            }
         }
 
         ExtensionMethodParameterType query = parameters.stream()

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
@@ -1,0 +1,147 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Consumer;
+
+class ExtensionPhaseRegistration extends ExtensionPhaseBase {
+    private final List<ExtensionPhaseRegistrationAction> actions;
+
+    ExtensionPhaseRegistration(jakarta.enterprise.inject.spi.BeanManager beanManager, ExtensionInvoker util,
+            SharedErrors errors, List<ExtensionPhaseRegistrationAction> actions) {
+        super(ExtensionPhase.REGISTRATION, beanManager, util, errors);
+        this.actions = actions;
+    }
+
+    @Override
+    void runExtensionMethod(java.lang.reflect.Method method) {
+        int numParameters = method.getParameterCount();
+        int numQueryParameters = 0;
+        List<ExtensionMethodParameterType> parameters = new ArrayList<>(numParameters);
+        for (int i = 0; i < numParameters; i++) {
+            Class<?> parameterType = method.getParameterTypes()[i];
+            ExtensionMethodParameterType parameter = ExtensionMethodParameterType.of(parameterType);
+            parameters.add(parameter);
+
+            if (parameter.isQuery()) {
+                numQueryParameters++;
+            }
+
+            parameter.verifyAvailable(ExtensionPhase.REGISTRATION, method);
+        }
+
+        if (numQueryParameters == 0) {
+            throw new IllegalArgumentException("No parameter of type BeanInfo or ObserverInfo"
+                    + " for method " + method + " @ " + method.getDeclaringClass());
+        }
+
+        if (numQueryParameters > 1) {
+            throw new IllegalArgumentException("More than 1 parameter of type BeanInfo or ObserverInfo"
+                    + " for method " + method + " @ " + method.getDeclaringClass());
+        }
+
+        ExtensionMethodParameterType query = parameters.stream()
+                .filter(ExtensionMethodParameterType::isQuery)
+                .findAny()
+                .get(); // guaranteed to be there
+
+        if (query == ExtensionMethodParameterType.BEAN_INFO) {
+            Consumer<jakarta.enterprise.inject.spi.ProcessBean<?>> pbAcceptor = pb -> {
+                List<Object> arguments = new ArrayList<>(numParameters);
+                for (ExtensionMethodParameterType parameter : parameters) {
+                    Object argument;
+                    if (parameter.isQuery()) {
+                        jakarta.enterprise.inject.spi.AnnotatedParameter<?> disposer = null;
+                        if (pb instanceof jakarta.enterprise.inject.spi.ProcessProducerField) {
+                            disposer = ((jakarta.enterprise.inject.spi.ProcessProducerField<?, ?>) pb).getAnnotatedDisposedParameter();
+                        } else if (pb instanceof jakarta.enterprise.inject.spi.ProcessProducerMethod) {
+                            disposer = ((jakarta.enterprise.inject.spi.ProcessProducerMethod<?, ?>) pb).getAnnotatedDisposedParameter();
+                        }
+
+                        argument = new BeanInfoImpl(pb.getBean(), pb.getAnnotated(), disposer);
+                    } else {
+                        argument = argumentForExtensionMethod(parameter, method);
+                    }
+                    arguments.add(argument);
+                }
+
+                try {
+                    util.callExtensionMethod(method, arguments);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            Registration registration = method.getAnnotation(Registration.class);
+            actions.add(new ExtensionPhaseRegistrationAction(new HashSet<>(Arrays.asList(registration.types())),
+                    pbAcceptor, null));
+        } else if (query == ExtensionMethodParameterType.INTERCEPTOR_INFO) {
+            Consumer<jakarta.enterprise.inject.spi.ProcessBean<?>> pbAcceptor = pb -> {
+                if (!(pb.getBean() instanceof jakarta.enterprise.inject.spi.Interceptor)) {
+                    return;
+                }
+
+                jakarta.enterprise.inject.spi.Interceptor<?> cdiInterceptor = (jakarta.enterprise.inject.spi.Interceptor<?>) pb.getBean();
+
+                List<Object> arguments = new ArrayList<>(numParameters);
+                for (ExtensionMethodParameterType parameter : parameters) {
+                    Object argument;
+                    if (parameter.isQuery()) {
+                        argument = new InterceptorInfoImpl(cdiInterceptor, pb.getAnnotated());
+                    } else {
+                        argument = argumentForExtensionMethod(parameter, method);
+                    }
+                    arguments.add(argument);
+                }
+
+                try {
+                    util.callExtensionMethod(method, arguments);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            Registration registration = method.getAnnotation(Registration.class);
+            actions.add(new ExtensionPhaseRegistrationAction(new HashSet<>(Arrays.asList(registration.types())),
+                    pbAcceptor, null));
+        } else if (query == ExtensionMethodParameterType.OBSERVER_INFO) {
+            Consumer<jakarta.enterprise.inject.spi.ProcessObserverMethod<?, ?>> pomAcceptor = pom -> {
+                List<Object> arguments = new ArrayList<>(numParameters);
+                for (ExtensionMethodParameterType parameter : parameters) {
+                    Object argument;
+                    if (parameter.isQuery()) {
+                        argument = new ObserverInfoImpl(pom.getObserverMethod(), pom.getAnnotatedMethod());
+                    } else {
+                        argument = argumentForExtensionMethod(parameter, method);
+                    }
+                    arguments.add(argument);
+                }
+
+                try {
+                    util.callExtensionMethod(method, arguments);
+                } catch (ReflectiveOperationException e) {
+                    throw new RuntimeException(e);
+                }
+            };
+
+            Registration registration = method.getAnnotation(Registration.class);
+            actions.add(new ExtensionPhaseRegistrationAction(new HashSet<>(Arrays.asList(registration.types())),
+                    null, pomAcceptor));
+        } else {
+            throw new IllegalStateException("Unknown query parameter " + query);
+        }
+    }
+
+    @Override
+    Object argumentForExtensionMethod(ExtensionMethodParameterType type, java.lang.reflect.Method method) {
+        if (type == ExtensionMethodParameterType.TYPES) {
+            return new TypesImpl();
+        }
+
+        return super.argumentForExtensionMethod(type, method);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistrationAction.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistrationAction.java
@@ -1,0 +1,74 @@
+package org.jboss.weld.lite.extension.translator;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.function.Consumer;
+
+class ExtensionPhaseRegistrationAction {
+    private final Set<Class<?>> types;
+    private final Consumer<jakarta.enterprise.inject.spi.ProcessBean<?>> beanAcceptor;
+    private final Consumer<jakarta.enterprise.inject.spi.ProcessObserverMethod<?, ?>> observerAcceptor;
+
+    ExtensionPhaseRegistrationAction(Set<Class<?>> types,
+            Consumer<jakarta.enterprise.inject.spi.ProcessBean<?>> beanAcceptor,
+            Consumer<jakarta.enterprise.inject.spi.ProcessObserverMethod<?, ?>> observerAcceptor) {
+        this.types = types;
+        this.beanAcceptor = beanAcceptor;
+        this.observerAcceptor = observerAcceptor;
+    }
+
+    void run(jakarta.enterprise.inject.spi.ProcessBean<?> pb) {
+        if (beanAcceptor == null) {
+            return;
+        }
+
+        Set<java.lang.reflect.Type> beanTypes = pb.getBean().getTypes();
+        if (satisfies(beanTypes)) {
+            beanAcceptor.accept(pb);
+        }
+    }
+
+    void run(jakarta.enterprise.inject.spi.ProcessObserverMethod<?, ?> pom) {
+        if (observerAcceptor == null) {
+            return;
+        }
+
+        java.lang.reflect.Type observedType = pom.getObserverMethod().getObservedType();
+        if (satisfies(Collections.singleton(observedType))) {
+            observerAcceptor.accept(pom);
+        }
+    }
+
+    private boolean satisfies(Set<java.lang.reflect.Type> inspectedTypes) {
+        for (java.lang.reflect.Type type : this.types) {
+            Class<?> rawType = getRawType(type);
+            if (rawType == null) {
+                continue;
+            }
+
+            if (inspectedTypes.contains(rawType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Class<?> getRawType(java.lang.reflect.Type type) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        } else if (type instanceof java.lang.reflect.ParameterizedType) {
+            return (Class<?>) ((java.lang.reflect.ParameterizedType) type).getRawType();
+        } else if (type instanceof java.lang.reflect.TypeVariable) {
+            return getRawType(((java.lang.reflect.TypeVariable<?>) type).getBounds()[0]);
+        } else if (type instanceof java.lang.reflect.WildcardType) {
+            return getRawType(((java.lang.reflect.WildcardType) type).getUpperBounds()[0]);
+        } else if (type instanceof java.lang.reflect.GenericArrayType) {
+            Class<?> rawType = getRawType(((java.lang.reflect.GenericArrayType) type).getGenericComponentType());
+            if (rawType != null) {
+                return java.lang.reflect.Array.newInstance(rawType, 0).getClass();
+            }
+        }
+        return null;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistrationAction.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistrationAction.java
@@ -1,6 +1,5 @@
 package org.jboss.weld.lite.extension.translator;
 
-import java.util.Collections;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -34,7 +33,7 @@ class ExtensionPhaseRegistrationAction {
         }
 
         java.lang.reflect.Type observedType = pom.getObserverMethod().getObservedType();
-        if (satisfies(Collections.singleton(observedType))) {
+        if (satisfiesObserverMethod(observedType)) {
             observerAcceptor.accept(pom);
         }
     }
@@ -47,6 +46,24 @@ class ExtensionPhaseRegistrationAction {
             }
 
             if (inspectedTypes.contains(rawType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean satisfiesObserverMethod(java.lang.reflect.Type observedType) {
+        Class<?> rawObservedType = getRawType(observedType);
+        if (rawObservedType == null) {
+            return false;
+        }
+        for (java.lang.reflect.Type type : this.types) {
+            Class<?> rawType = getRawType(type);
+            if (rawType == null) {
+                continue;
+            }
+            if (rawType.isAssignableFrom(rawObservedType)) {
                 return true;
             }
         }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseSynthesis.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseSynthesis.java
@@ -1,0 +1,29 @@
+package org.jboss.weld.lite.extension.translator;
+
+import java.util.List;
+
+class ExtensionPhaseSynthesis extends ExtensionPhaseBase {
+    private final List<SyntheticBeanBuilderImpl<?>> syntheticBeans;
+    private final List<SyntheticObserverBuilderImpl<?>> syntheticObservers;
+
+    ExtensionPhaseSynthesis(jakarta.enterprise.inject.spi.BeanManager beanManager, ExtensionInvoker util,
+            SharedErrors errors, List<SyntheticBeanBuilderImpl<?>> syntheticBeans,
+            List<SyntheticObserverBuilderImpl<?>> syntheticObservers) {
+        super(ExtensionPhase.SYNTHESIS, beanManager, util, errors);
+        this.syntheticBeans = syntheticBeans;
+        this.syntheticObservers = syntheticObservers;
+    }
+
+    @Override
+    Object argumentForExtensionMethod(ExtensionMethodParameterType type, java.lang.reflect.Method method) {
+        switch (type) {
+            case SYNTHETIC_COMPONENTS:
+                return new SyntheticComponentsImpl(syntheticBeans, syntheticObservers, method.getDeclaringClass());
+            case TYPES:
+                return new TypesImpl();
+
+            default:
+                return super.argumentForExtensionMethod(type, method);
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseValidation.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseValidation.java
@@ -1,0 +1,17 @@
+package org.jboss.weld.lite.extension.translator;
+
+class ExtensionPhaseValidation extends ExtensionPhaseBase {
+    ExtensionPhaseValidation(jakarta.enterprise.inject.spi.BeanManager beanManager, ExtensionInvoker util,
+            SharedErrors errors) {
+        super(ExtensionPhase.VALIDATION, beanManager, util, errors);
+    }
+
+    @Override
+    Object argumentForExtensionMethod(ExtensionMethodParameterType type, java.lang.reflect.Method method) {
+        if (type == ExtensionMethodParameterType.TYPES) {
+            return new TypesImpl();
+        }
+
+        return super.argumentForExtensionMethod(type, method);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/FieldConfigImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/FieldConfigImpl.java
@@ -1,0 +1,52 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.FieldConfig;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.FieldInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.function.Predicate;
+
+class FieldConfigImpl implements FieldConfig {
+    private final jakarta.enterprise.inject.spi.configurator.AnnotatedFieldConfigurator<?> configurator;
+
+    FieldConfigImpl(jakarta.enterprise.inject.spi.configurator.AnnotatedFieldConfigurator<?> configurator) {
+        this.configurator = configurator;
+    }
+
+    @Override
+    public FieldInfo info() {
+        return new FieldInfoImpl(configurator.getAnnotated());
+    }
+
+    @Override
+    public FieldConfig addAnnotation(Class<? extends Annotation> annotationType) {
+        configurator.add(AnnotationProxy.create(annotationType, Collections.emptyMap()));
+        return this;
+    }
+
+    @Override
+    public FieldConfig addAnnotation(AnnotationInfo annotation) {
+        configurator.add(((AnnotationInfoImpl) annotation).annotation);
+        return this;
+    }
+
+    @Override
+    public FieldConfig addAnnotation(Annotation annotation) {
+        configurator.add(annotation);
+        return this;
+    }
+
+    @Override
+    public FieldConfig removeAnnotation(Predicate<AnnotationInfo> predicate) {
+        configurator.remove(annotation -> predicate.test(new AnnotationInfoImpl(annotation)));
+        return this;
+    }
+
+    @Override
+    public FieldConfig removeAllAnnotations() {
+        configurator.removeAll();
+        return this;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/FieldInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/FieldInfoImpl.java
@@ -1,0 +1,73 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.declarations.FieldInfo;
+import jakarta.enterprise.lang.model.types.Type;
+
+import java.util.Objects;
+
+class FieldInfoImpl extends DeclarationInfoImpl<java.lang.reflect.Field, jakarta.enterprise.inject.spi.AnnotatedField<?>> implements FieldInfo {
+    // only for equals/hashCode
+    private final String className;
+    private final String name;
+
+    FieldInfoImpl(jakarta.enterprise.inject.spi.AnnotatedField<?> cdiDeclaration) {
+        super(cdiDeclaration.getJavaMember(), cdiDeclaration);
+        this.className = reflection.getDeclaringClass().getName();
+        this.name = reflection.getName();
+    }
+
+    FieldInfoImpl(java.lang.reflect.Field reflectionDeclaration) {
+        super(reflectionDeclaration, null);
+        this.className = reflectionDeclaration.getDeclaringClass().getName();
+        this.name = reflectionDeclaration.getName();
+    }
+
+    @Override
+    public String name() {
+        return reflection.getName();
+    }
+
+    @Override
+    public Type type() {
+        return TypeImpl.fromReflectionType(reflection.getAnnotatedType());
+    }
+
+    @Override
+    public boolean isStatic() {
+        return java.lang.reflect.Modifier.isStatic(reflection.getModifiers());
+    }
+
+    @Override
+    public boolean isFinal() {
+        return java.lang.reflect.Modifier.isFinal(reflection.getModifiers());
+    }
+
+    @Override
+    public int modifiers() {
+        return reflection.getModifiers();
+    }
+
+    @Override
+    public ClassInfo declaringClass() {
+        return new ClassInfoImpl(BeanManagerAccess.createAnnotatedType(reflection.getDeclaringClass()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FieldInfoImpl fieldInfo = (FieldInfoImpl) o;
+        return Objects.equals(className, fieldInfo.className)
+                && Objects.equals(name, fieldInfo.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(className, name);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/InjectionPointInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/InjectionPointInfoImpl.java
@@ -1,0 +1,36 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.InjectionPointInfo;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.DeclarationInfo;
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+class InjectionPointInfoImpl implements InjectionPointInfo {
+    private final jakarta.enterprise.inject.spi.InjectionPoint cdiInjectionPoint;
+
+    InjectionPointInfoImpl(jakarta.enterprise.inject.spi.InjectionPoint cdiInjectionPoint) {
+        this.cdiInjectionPoint = cdiInjectionPoint;
+    }
+
+    @Override
+    public Type type() {
+        return TypeImpl.fromReflectionType(AnnotatedTypes.from(cdiInjectionPoint.getType()));
+    }
+
+    @Override
+    public Collection<AnnotationInfo> qualifiers() {
+        return cdiInjectionPoint.getQualifiers()
+                .stream()
+                .map(AnnotationInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public DeclarationInfo declaration() {
+        return DeclarationInfoImpl.fromCdiDeclaration(cdiInjectionPoint.getAnnotated());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/InterceptorInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/InterceptorInfoImpl.java
@@ -1,0 +1,30 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.InterceptorInfo;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+class InterceptorInfoImpl extends BeanInfoImpl implements InterceptorInfo {
+    final jakarta.enterprise.inject.spi.Interceptor<?> cdiInterceptor;
+
+    InterceptorInfoImpl(jakarta.enterprise.inject.spi.Interceptor<?> cdiInterceptor,
+            jakarta.enterprise.inject.spi.Annotated cdiDeclaration) {
+        super(cdiInterceptor, cdiDeclaration, null);
+        this.cdiInterceptor = cdiInterceptor;
+    }
+
+    @Override
+    public Collection<AnnotationInfo> interceptorBindings() {
+        return cdiInterceptor.getInterceptorBindings()
+                .stream()
+                .map(AnnotationInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean intercepts(jakarta.enterprise.inject.spi.InterceptionType interceptionType) {
+        return cdiInterceptor.intercepts(interceptionType);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/LiteExtensionTranslator.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/LiteExtensionTranslator.java
@@ -1,0 +1,232 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.NormalScope;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanDisposer;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticObserver;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This CDI extension allows execution of build compatible extensions (BCE) via portable extensions (PE)
+ * by mapping phases of BCE onto PE.
+ *
+ * <p>
+ *  This extension is by default disabled and integrators need to manually register it with Weld container when
+ *  bootstrapping it. For SE and servlet, this is done directly in Weld. However, for EE integrators need to determine
+ *  the root deployment and register the extension themselves.
+ * </p>
+ */
+public class LiteExtensionTranslator implements jakarta.enterprise.inject.spi.Extension {
+    private final ExtensionInvoker util = new ExtensionInvoker();
+    private final SharedErrors errors = new SharedErrors();
+
+    private final List<Class<? extends jakarta.enterprise.context.spi.AlterableContext>> contextsToRegister = new ArrayList<>();
+
+    private final List<ExtensionPhaseEnhancementAction> enhancementActions = new ArrayList<>();
+    private final List<ExtensionPhaseRegistrationAction> registrationActions = new ArrayList<>();
+
+    public void discovery(@Priority(Integer.MAX_VALUE) @Observes jakarta.enterprise.inject.spi.BeforeBeanDiscovery bbd,
+            jakarta.enterprise.inject.spi.BeanManager bm) {
+
+        try {
+            BeanManagerAccess.set(bm);
+
+            List<MetaAnnotationsImpl.StereotypeConfigurator<?>> stereotypes = new ArrayList<>();
+            List<MetaAnnotationsImpl.ContextData> contexts = new ArrayList<>();
+
+            new ExtensionPhaseDiscovery(bm, util, errors, bbd, stereotypes, contexts).run();
+
+            // qualifiers and interceptor bindings are handled directly in MetaAnnotationsImpl (via BBD)
+            for (MetaAnnotationsImpl.StereotypeConfigurator<?> stereotype : stereotypes) {
+                bbd.addStereotype(stereotype.annotation, stereotype.annotations.toArray(new Annotation[0]));
+            }
+
+            for (MetaAnnotationsImpl.ContextData context : contexts) {
+                Class<? extends Annotation> scopeAnnotation = context.scopeAnnotation;
+                if (scopeAnnotation == null) {
+                    try {
+                        scopeAnnotation = context.contextClass.newInstance().getScope();
+                    } catch (ReflectiveOperationException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+
+                boolean isNormal;
+                boolean isPassivating;
+                if (context.isNormal != null) {
+                    isNormal = context.isNormal;
+                    isPassivating = false; // TODO
+                } else {
+                    NormalScope normalScope = scopeAnnotation.getAnnotation(NormalScope.class);
+                    if (normalScope != null) {
+                        isNormal = true;
+                        isPassivating = normalScope.passivating();
+                    } else {
+                        isNormal = false;
+                        isPassivating = false;
+                    }
+                }
+
+                bbd.addScope(scopeAnnotation, isNormal, isPassivating);
+
+                Class<? extends jakarta.enterprise.context.spi.AlterableContext> contextClass = context.contextClass;
+                contextsToRegister.add(contextClass);
+            }
+
+            new ExtensionPhaseEnhancement(bm, util, errors, enhancementActions).run();
+        } finally {
+            BeanManagerAccess.remove();
+        }
+    }
+
+    public void enhancement(@Priority(Integer.MAX_VALUE) @Observes jakarta.enterprise.inject.spi.ProcessAnnotatedType<?> pat,
+            jakarta.enterprise.inject.spi.BeanManager bm) {
+
+        try {
+            BeanManagerAccess.set(bm);
+
+            for (ExtensionPhaseEnhancementAction enhancementAction : enhancementActions) {
+                enhancementAction.run(pat);
+            }
+        } finally {
+            BeanManagerAccess.remove();
+        }
+    }
+
+    public void registration(@Priority(Integer.MAX_VALUE) @Observes jakarta.enterprise.inject.spi.AfterTypeDiscovery atd,
+            jakarta.enterprise.inject.spi.BeanManager bm) {
+
+        try {
+            BeanManagerAccess.set(bm);
+
+            new ExtensionPhaseRegistration(bm, util, errors, registrationActions).run();
+        } finally {
+            BeanManagerAccess.remove();
+        }
+    }
+
+    public void collectBeans(@Priority(Integer.MAX_VALUE) @Observes jakarta.enterprise.inject.spi.ProcessBean<?> pb,
+            jakarta.enterprise.inject.spi.BeanManager bm) {
+
+        try {
+            BeanManagerAccess.set(bm);
+
+            // for synthetic beans, this will run @Registration before @Synthesis is fully over, maybe change that?
+            for (ExtensionPhaseRegistrationAction registrationAction : registrationActions) {
+                registrationAction.run(pb);
+            }
+        } finally {
+            BeanManagerAccess.remove();
+        }
+    }
+
+    public void collectObservers(@Priority(Integer.MAX_VALUE) @Observes jakarta.enterprise.inject.spi.ProcessObserverMethod<?, ?> pom,
+            jakarta.enterprise.inject.spi.BeanManager bm) {
+
+        try {
+            BeanManagerAccess.set(bm);
+
+            // for synthetic observers, this will run @Registration before @Synthesis is fully over, maybe change that?
+            for (ExtensionPhaseRegistrationAction registrationAction : registrationActions) {
+                registrationAction.run(pom);
+            }
+        } finally {
+            BeanManagerAccess.remove();
+        }
+    }
+
+    public void synthesis(@Priority(Integer.MAX_VALUE) @Observes jakarta.enterprise.inject.spi.AfterBeanDiscovery abd,
+            jakarta.enterprise.inject.spi.BeanManager bm) throws IllegalAccessException, InstantiationException {
+
+        try {
+            BeanManagerAccess.set(bm);
+
+            for (Class<? extends jakarta.enterprise.context.spi.AlterableContext> contextClass : contextsToRegister) {
+                abd.addContext(contextClass.newInstance());
+            }
+
+            List<SyntheticBeanBuilderImpl<?>> syntheticBeans = new ArrayList<>();
+            List<SyntheticObserverBuilderImpl<?>> syntheticObservers = new ArrayList<>();
+
+            new ExtensionPhaseSynthesis(bm, util, errors, syntheticBeans, syntheticObservers).run();
+
+            for (SyntheticBeanBuilderImpl<?> syntheticBean : syntheticBeans) {
+                jakarta.enterprise.inject.spi.configurator.BeanConfigurator<Object> configurator = abd.addBean();
+                configurator.beanClass(syntheticBean.implementationClass);
+                configurator.types(syntheticBean.types);
+                configurator.qualifiers(syntheticBean.qualifiers);
+                if (syntheticBean.scope != null) {
+                    configurator.scope(syntheticBean.scope);
+                }
+                configurator.alternative(syntheticBean.isAlternative);
+                configurator.priority(syntheticBean.priority);
+                configurator.name(syntheticBean.name);
+                configurator.stereotypes(syntheticBean.stereotypes);
+                configurator.produceWith(lookup -> {
+                    try {
+                        SyntheticBeanCreator creator = syntheticBean.creatorClass.newInstance();
+                        return creator.create(lookup, new ParametersImpl(syntheticBean.params));
+                    } catch (ReflectiveOperationException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                if (syntheticBean.disposerClass != null) {
+                    configurator.disposeWith((object, lookup) -> {
+                        try {
+                            SyntheticBeanDisposer disposer = syntheticBean.disposerClass.newInstance();
+                            disposer.dispose(object, lookup, new ParametersImpl(syntheticBean.params));
+                        } catch (ReflectiveOperationException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                }
+            }
+
+            for (SyntheticObserverBuilderImpl<?> syntheticObserver : syntheticObservers) {
+                jakarta.enterprise.inject.spi.configurator.ObserverMethodConfigurator<Object> configurator = abd.addObserverMethod();
+                configurator.beanClass(syntheticObserver.declaringClass);
+                configurator.observedType(syntheticObserver.eventType);
+                configurator.qualifiers(syntheticObserver.qualifiers);
+                configurator.priority(syntheticObserver.priority);
+                configurator.async(syntheticObserver.isAsync);
+                configurator.reception(syntheticObserver.reception);
+                configurator.transactionPhase(syntheticObserver.transactionPhase);
+                configurator.notifyWith(eventContext -> {
+                    SyntheticObserver observer = syntheticObserver.observerClass.newInstance();
+                    observer.observe(eventContext, new ParametersImpl(syntheticObserver.params));
+                });
+            }
+        } finally {
+            BeanManagerAccess.remove();
+        }
+    }
+
+    public void validation(@Priority(Integer.MAX_VALUE) @Observes jakarta.enterprise.inject.spi.AfterDeploymentValidation adv,
+            jakarta.enterprise.inject.spi.BeanManager bm) {
+
+        try {
+            BeanManagerAccess.set(bm);
+
+            new ExtensionPhaseValidation(bm, util, errors).run();
+
+            for (Throwable error : errors.list) {
+                adv.addDeploymentProblem(error);
+            }
+        } finally {
+            // cleanup
+            util.clear();
+            errors.list.clear();
+
+            contextsToRegister.clear();
+            enhancementActions.clear();
+            registrationActions.clear();
+
+            BeanManagerAccess.remove();
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MessagesImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MessagesImpl.java
@@ -1,0 +1,87 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.Messages;
+import jakarta.enterprise.inject.build.compatible.spi.ObserverInfo;
+import jakarta.enterprise.lang.model.AnnotationTarget;
+
+import java.util.logging.Logger;
+
+class MessagesImpl implements Messages {
+    private final SharedErrors errors;
+    private final Logger logger;
+
+    MessagesImpl(java.lang.reflect.Method method, SharedErrors errors) {
+        this.errors = errors;
+        this.logger = Logger.getLogger(method.getDeclaringClass().getName());
+    }
+
+    @Override
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    @Override
+    public void info(String message, AnnotationTarget relatedTo) {
+        logger.info(message + " at " + relatedTo);
+    }
+
+    @Override
+    public void info(String message, BeanInfo relatedTo) {
+        logger.info(message + " at " + relatedTo);
+    }
+
+    @Override
+    public void info(String message, ObserverInfo relatedTo) {
+        logger.info(message + " at " + relatedTo);
+    }
+
+    @Override
+    public void warn(String message) {
+        logger.warning(message);
+    }
+
+    @Override
+    public void warn(String message, AnnotationTarget relatedTo) {
+        logger.warning(message + " at " + relatedTo);
+    }
+
+    @Override
+    public void warn(String message, BeanInfo relatedTo) {
+        logger.warning(message + " at " + relatedTo);
+    }
+
+    @Override
+    public void warn(String message, ObserverInfo relatedTo) {
+        logger.warning(message + " at " + relatedTo);
+    }
+
+    @Override
+    public void error(String message) {
+        logger.severe(message);
+        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message));
+    }
+
+    @Override
+    public void error(String message, AnnotationTarget relatedTo) {
+        logger.severe(message + " at " + relatedTo);
+        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + " at " + relatedTo));
+    }
+
+    @Override
+    public void error(String message, BeanInfo relatedTo) {
+        logger.severe(message + " at " + relatedTo);
+        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + " at " + relatedTo));
+    }
+
+    @Override
+    public void error(String message, ObserverInfo relatedTo) {
+        logger.severe(message + " at " + relatedTo);
+        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + " at " + relatedTo));
+    }
+
+    @Override
+    public void error(Exception exception) {
+        errors.list.add(exception);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MessagesImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MessagesImpl.java
@@ -8,6 +8,9 @@ import jakarta.enterprise.lang.model.AnnotationTarget;
 import java.util.logging.Logger;
 
 class MessagesImpl implements Messages {
+
+    private final String AT = " at ";
+
     private final SharedErrors errors;
     private final Logger logger;
 
@@ -23,17 +26,17 @@ class MessagesImpl implements Messages {
 
     @Override
     public void info(String message, AnnotationTarget relatedTo) {
-        logger.info(message + " at " + relatedTo);
+        logger.info(message + AT + relatedTo);
     }
 
     @Override
     public void info(String message, BeanInfo relatedTo) {
-        logger.info(message + " at " + relatedTo);
+        logger.info(message + AT + relatedTo);
     }
 
     @Override
     public void info(String message, ObserverInfo relatedTo) {
-        logger.info(message + " at " + relatedTo);
+        logger.info(message + AT + relatedTo);
     }
 
     @Override
@@ -43,17 +46,17 @@ class MessagesImpl implements Messages {
 
     @Override
     public void warn(String message, AnnotationTarget relatedTo) {
-        logger.warning(message + " at " + relatedTo);
+        logger.warning(message + AT + relatedTo);
     }
 
     @Override
     public void warn(String message, BeanInfo relatedTo) {
-        logger.warning(message + " at " + relatedTo);
+        logger.warning(message + AT + relatedTo);
     }
 
     @Override
     public void warn(String message, ObserverInfo relatedTo) {
-        logger.warning(message + " at " + relatedTo);
+        logger.warning(message + AT + relatedTo);
     }
 
     @Override
@@ -64,20 +67,20 @@ class MessagesImpl implements Messages {
 
     @Override
     public void error(String message, AnnotationTarget relatedTo) {
-        logger.severe(message + " at " + relatedTo);
-        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + " at " + relatedTo));
+        logger.severe(message + AT + relatedTo);
+        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + AT + relatedTo));
     }
 
     @Override
     public void error(String message, BeanInfo relatedTo) {
-        logger.severe(message + " at " + relatedTo);
-        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + " at " + relatedTo));
+        logger.severe(message + AT + relatedTo);
+        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + AT + relatedTo));
     }
 
     @Override
     public void error(String message, ObserverInfo relatedTo) {
-        logger.severe(message + " at " + relatedTo);
-        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + " at " + relatedTo));
+        logger.severe(message + AT + relatedTo);
+        errors.list.add(new jakarta.enterprise.inject.spi.DeploymentException(message + AT + relatedTo));
     }
 
     @Override

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MetaAnnotationsImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MetaAnnotationsImpl.java
@@ -1,0 +1,115 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.ClassConfig;
+import jakarta.enterprise.inject.build.compatible.spi.MetaAnnotations;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+class MetaAnnotationsImpl implements MetaAnnotations {
+    private final jakarta.enterprise.inject.spi.BeforeBeanDiscovery bbd;
+
+    private final List<StereotypeConfigurator<?>> stereotypes;
+    private final List<ContextData> contexts;
+
+    MetaAnnotationsImpl(jakarta.enterprise.inject.spi.BeforeBeanDiscovery bbd, List<StereotypeConfigurator<?>> stereotypes, List<ContextData> contexts) {
+        this.bbd = bbd;
+
+        this.stereotypes = stereotypes;
+        this.contexts = contexts;
+    }
+
+    @Override
+    public ClassConfig addQualifier(Class<? extends Annotation> annotation) {
+        jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator<? extends Annotation> cfg = bbd.configureQualifier(annotation);
+        return new ClassConfigImpl(cfg);
+    }
+
+    @Override
+    public ClassConfig addInterceptorBinding(Class<? extends Annotation> annotation) {
+        jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator<? extends Annotation> cfg = bbd.configureInterceptorBinding(annotation);
+        return new ClassConfigImpl(cfg);
+    }
+
+    @Override
+    public ClassConfig addStereotype(Class<? extends Annotation> annotation) {
+        StereotypeConfigurator<? extends Annotation> cfg = new StereotypeConfigurator<>(annotation);
+        stereotypes.add(cfg);
+        return new ClassConfigImpl(cfg);
+    }
+
+    @Override
+    public void addContext(Class<? extends Annotation> scopeAnnotation,
+            Class<? extends jakarta.enterprise.context.spi.AlterableContext> contextClass) {
+        contexts.add(new ContextData(scopeAnnotation, null, contextClass));
+    }
+
+    @Override
+    public void addContext(Class<? extends Annotation> scopeAnnotation, boolean isNormal,
+            Class<? extends jakarta.enterprise.context.spi.AlterableContext> contextClass) {
+        contexts.add(new ContextData(scopeAnnotation, isNormal, contextClass));
+    }
+
+    static final class ContextData {
+        final Class<? extends Annotation> scopeAnnotation;
+        final Boolean isNormal; // null if not set, in which case it's derived from the scope annotation
+
+        final Class<? extends jakarta.enterprise.context.spi.AlterableContext> contextClass;
+
+        ContextData(Class<? extends Annotation> scopeAnnotation, Boolean isNormal,
+                Class<? extends jakarta.enterprise.context.spi.AlterableContext> contextClass) {
+            this.scopeAnnotation = scopeAnnotation;
+            this.isNormal = isNormal;
+
+            this.contextClass = contextClass;
+        }
+    }
+
+    static final class StereotypeConfigurator<T extends Annotation> implements jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator<T> {
+        final Class<T> annotation;
+        final Set<Annotation> annotations = new HashSet<>();
+
+        StereotypeConfigurator(Class<T> annotation) {
+            this.annotation = annotation;
+        }
+
+        @Override
+        public jakarta.enterprise.inject.spi.AnnotatedType<T> getAnnotated() {
+            return BeanManagerAccess.createAnnotatedType(annotation);
+        }
+
+        @Override
+        public jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator<T> add(Annotation annotation) {
+            annotations.add(annotation);
+            return this;
+        }
+
+        @Override
+        public jakarta.enterprise.inject.spi.configurator.AnnotatedTypeConfigurator<T> remove(Predicate<Annotation> predicate) {
+            annotations.removeIf(predicate);
+            return this;
+        }
+
+        @Override
+        public Set<jakarta.enterprise.inject.spi.configurator.AnnotatedMethodConfigurator<? super T>> methods() {
+            // TODO
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<jakarta.enterprise.inject.spi.configurator.AnnotatedFieldConfigurator<? super T>> fields() {
+            // TODO
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<jakarta.enterprise.inject.spi.configurator.AnnotatedConstructorConfigurator<T>> constructors() {
+            // TODO
+            return Collections.emptySet();
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MethodConfigImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MethodConfigImpl.java
@@ -1,0 +1,63 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.MethodConfig;
+import jakarta.enterprise.inject.build.compatible.spi.ParameterConfig;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+class MethodConfigImpl implements MethodConfig {
+    private final jakarta.enterprise.inject.spi.configurator.AnnotatedMethodConfigurator<?> configurator;
+
+    MethodConfigImpl(jakarta.enterprise.inject.spi.configurator.AnnotatedMethodConfigurator<?> configurator) {
+        this.configurator = configurator;
+    }
+
+    @Override
+    public MethodInfo info() {
+        return new MethodInfoImpl(configurator.getAnnotated());
+    }
+
+    @Override
+    public MethodConfig addAnnotation(Class<? extends Annotation> annotationType) {
+        configurator.add(AnnotationProxy.create(annotationType, Collections.emptyMap()));
+        return this;
+    }
+
+    @Override
+    public MethodConfig addAnnotation(AnnotationInfo annotation) {
+        configurator.add(((AnnotationInfoImpl) annotation).annotation);
+        return this;
+    }
+
+    @Override
+    public MethodConfig addAnnotation(Annotation annotation) {
+        configurator.add(annotation);
+        return this;
+    }
+
+    @Override
+    public MethodConfig removeAnnotation(Predicate<AnnotationInfo> predicate) {
+        configurator.remove(annotation -> predicate.test(new AnnotationInfoImpl(annotation)));
+        return this;
+    }
+
+    @Override
+    public MethodConfig removeAllAnnotations() {
+        configurator.removeAll();
+        return this;
+    }
+
+    @Override
+    public List<ParameterConfig> parameters() {
+        return configurator.params()
+                .stream()
+                .map(ParameterConfigImpl::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MethodConstructorConfigImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MethodConstructorConfigImpl.java
@@ -1,0 +1,63 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.MethodConfig;
+import jakarta.enterprise.inject.build.compatible.spi.ParameterConfig;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+class MethodConstructorConfigImpl implements MethodConfig {
+    private final jakarta.enterprise.inject.spi.configurator.AnnotatedConstructorConfigurator<?> configurator;
+
+    MethodConstructorConfigImpl(jakarta.enterprise.inject.spi.configurator.AnnotatedConstructorConfigurator<?> configurator) {
+        this.configurator = configurator;
+    }
+
+    @Override
+    public MethodInfo info() {
+        return new MethodInfoImpl(configurator.getAnnotated());
+    }
+
+    @Override
+    public MethodConfig addAnnotation(Class<? extends Annotation> annotationType) {
+        configurator.add(AnnotationProxy.create(annotationType, Collections.emptyMap()));
+        return this;
+    }
+
+    @Override
+    public MethodConfig addAnnotation(AnnotationInfo annotation) {
+        configurator.add(((AnnotationInfoImpl) annotation).annotation);
+        return this;
+    }
+
+    @Override
+    public MethodConfig addAnnotation(Annotation annotation) {
+        configurator.add(annotation);
+        return this;
+    }
+
+    @Override
+    public MethodConfig removeAnnotation(Predicate<AnnotationInfo> predicate) {
+        configurator.remove(annotation -> predicate.test(new AnnotationInfoImpl(annotation)));
+        return this;
+    }
+
+    @Override
+    public MethodConfig removeAllAnnotations() {
+        configurator.removeAll();
+        return this;
+    }
+
+    @Override
+    public List<ParameterConfig> parameters() {
+        return configurator.params()
+                .stream()
+                .map(ParameterConfigImpl::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MethodInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/MethodInfoImpl.java
@@ -1,0 +1,175 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+import jakarta.enterprise.lang.model.declarations.ParameterInfo;
+import jakarta.enterprise.lang.model.types.Type;
+import jakarta.enterprise.lang.model.types.TypeVariable;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+class MethodInfoImpl extends DeclarationInfoImpl<java.lang.reflect.Executable, jakarta.enterprise.inject.spi.AnnotatedCallable<?>> implements MethodInfo {
+    // only for equals/hashCode
+    private final String className;
+    private final String name;
+    private final java.lang.reflect.Type[] parameterTypes;
+
+    MethodInfoImpl(jakarta.enterprise.inject.spi.AnnotatedCallable<?> cdiDeclaration) {
+        super((java.lang.reflect.Executable) cdiDeclaration.getJavaMember(), cdiDeclaration);
+        this.className = reflection.getDeclaringClass().getName();
+        this.name = reflection.getName();
+        this.parameterTypes = reflection.getGenericParameterTypes();
+    }
+
+    MethodInfoImpl(java.lang.reflect.Executable reflectionDeclaration) {
+        super(reflectionDeclaration, null);
+        this.className = reflectionDeclaration.getDeclaringClass().getName();
+        this.name = reflectionDeclaration.getName();
+        this.parameterTypes = reflectionDeclaration.getGenericParameterTypes();
+    }
+
+    @Override
+    public String name() {
+        if (isConstructor()) {
+            return reflection.getDeclaringClass().getName();
+        }
+        return reflection.getName();
+    }
+
+    @Override
+    public List<ParameterInfo> parameters() {
+        // CDI doesn't define precisly what `AnnotatedCallable.getParameters` should return,
+        // but the language model does -- so here, we return exactly what the lang model
+        // defines, but backed by the CDI model as much as possible
+
+        Map<Parameter, jakarta.enterprise.inject.spi.AnnotatedParameter<?>> map = new HashMap<>();
+        for (jakarta.enterprise.inject.spi.AnnotatedParameter<?> parameter : cdiDeclaration.getParameters()) {
+            map.put(parameter.getJavaParameter(), parameter);
+        }
+
+        List<ParameterInfo> result = new ArrayList<>();
+        Parameter[] parameters = reflection.getParameters();
+        parameters = enumConstructorHack(parameters);
+
+        int position = 0;
+        for (Parameter parameter : parameters) {
+            if (parameter.isSynthetic()) {
+                continue;
+            }
+
+            if (map.containsKey(parameter)) {
+                result.add(new ParameterInfoImpl(map.get(parameter)));
+            } else {
+                result.add(new ParameterInfoImpl(parameter, this, position));
+            }
+
+            position++;
+        }
+
+        return result;
+    }
+
+    private Parameter[] enumConstructorHack(Parameter[] parameters) {
+        // enum constructors often have 2 synthetic parameters whose `isSynthetic()` returns `false`
+        if (isConstructor()
+                && reflection.getDeclaringClass().isEnum()
+                && reflection.getGenericParameterTypes().length != parameters.length
+                && parameters.length >= 2
+                && parameters[0].getType().equals(String.class)
+                && parameters[1].getType().equals(int.class)) {
+            Parameter[] declaredParameters = new Parameter[parameters.length - 2];
+            System.arraycopy(parameters, 2, declaredParameters, 0, declaredParameters.length);
+            return declaredParameters;
+        }
+        return parameters;
+    }
+
+    @Override
+    public Type returnType() {
+        return TypeImpl.fromReflectionType(reflection.getAnnotatedReturnType());
+    }
+
+    @Override
+    public Type receiverType() {
+        java.lang.reflect.AnnotatedType receiverType = reflection.getAnnotatedReceiverType();
+        if (receiverType == null) {
+            return null;
+        }
+
+        return TypeImpl.fromReflectionType(receiverType);
+    }
+
+    @Override
+    public List<Type> throwsTypes() {
+        return Arrays.stream(reflection.getAnnotatedExceptionTypes())
+                .map(TypeImpl::fromReflectionType)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<TypeVariable> typeParameters() {
+        return Arrays.stream(reflection.getTypeParameters())
+                .map(AnnotatedTypes::typeVariable)
+                .map(TypeVariableImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isConstructor() {
+        return reflection instanceof java.lang.reflect.Constructor;
+    }
+
+    @Override
+    public boolean isStatic() {
+        return java.lang.reflect.Modifier.isStatic(reflection.getModifiers());
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return java.lang.reflect.Modifier.isAbstract(reflection.getModifiers());
+    }
+
+    @Override
+    public boolean isFinal() {
+        return java.lang.reflect.Modifier.isFinal(reflection.getModifiers());
+    }
+
+    @Override
+    public int modifiers() {
+        return reflection.getModifiers();
+    }
+
+    @Override
+    public ClassInfo declaringClass() {
+        return new ClassInfoImpl(BeanManagerAccess.createAnnotatedType(reflection.getDeclaringClass()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MethodInfoImpl)) {
+            return false;
+        }
+        MethodInfoImpl that = (MethodInfoImpl) o;
+        return Objects.equals(className, that.className)
+                && Objects.equals(name, that.name)
+                && Arrays.equals(parameterTypes, that.parameterTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(className, name);
+        result = 31 * result + Arrays.hashCode(parameterTypes);
+        return result;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ObserverInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ObserverInfoImpl.java
@@ -1,0 +1,112 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.Reception;
+import jakarta.enterprise.event.TransactionPhase;
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.ObserverInfo;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+import jakarta.enterprise.lang.model.declarations.ParameterInfo;
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+class ObserverInfoImpl implements ObserverInfo {
+    final jakarta.enterprise.inject.spi.ObserverMethod<?> cdiObserver;
+    final jakarta.enterprise.inject.spi.AnnotatedMethod<?> cdiDeclaration;
+
+    ObserverInfoImpl(jakarta.enterprise.inject.spi.ObserverMethod<?> cdiObserver,
+            jakarta.enterprise.inject.spi.AnnotatedMethod<?> cdiDeclaration) {
+        this.cdiObserver = cdiObserver;
+        this.cdiDeclaration = cdiDeclaration;
+    }
+
+    @Override
+    public Type eventType() {
+        java.lang.reflect.Type observedType = cdiObserver.getObservedType();
+        return TypeImpl.fromReflectionType(AnnotatedTypes.from(observedType));
+    }
+
+    @Override
+    public Collection<AnnotationInfo> qualifiers() {
+        return cdiObserver.getObservedQualifiers()
+                .stream()
+                .map(AnnotationInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public ClassInfo declaringClass() {
+        jakarta.enterprise.inject.spi.AnnotatedType<?> beanClass = BeanManagerAccess.createAnnotatedType(cdiObserver.getBeanClass());
+        return new ClassInfoImpl(beanClass);
+    }
+
+    @Override
+    public MethodInfo observerMethod() {
+        if (cdiDeclaration == null) {
+            return null;
+        }
+
+        return new MethodInfoImpl(cdiDeclaration);
+    }
+
+    @Override
+    public ParameterInfo eventParameter() {
+        if (cdiDeclaration == null) {
+            return null;
+        }
+
+        for (jakarta.enterprise.inject.spi.AnnotatedParameter<?> parameter : cdiDeclaration.getParameters()) {
+            if (parameter.isAnnotationPresent(Observes.class)) {
+                return new ParameterInfoImpl(parameter);
+            }
+        }
+        throw new IllegalStateException("Observer method without an @Observes parameter: " + cdiDeclaration);
+    }
+
+    @Override
+    public BeanInfo bean() {
+        if (cdiDeclaration == null) {
+            return null;
+        }
+
+        // TODO ???
+        throw new UnsupportedOperationException("Probably get rid of ObserverInfo.bean()");
+    }
+
+    @Override
+    public boolean isSynthetic() {
+        return cdiDeclaration == null;
+    }
+
+    @Override
+    public int priority() {
+        return cdiObserver.getPriority();
+    }
+
+    @Override
+    public boolean isAsync() {
+        return cdiObserver.isAsync();
+    }
+
+    @Override
+    public Reception reception() {
+        return cdiObserver.getReception();
+    }
+
+    @Override
+    public TransactionPhase transactionPhase() {
+        return cdiObserver.getTransactionPhase();
+    }
+
+    @Override
+    public String toString() {
+        return "observer [type=" + cdiObserver.getObservedType()
+                + ", qualifiers=" + cdiObserver.getObservedQualifiers() + "]"
+                + (cdiDeclaration != null ? " declared at " + cdiDeclaration : "");
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/PackageInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/PackageInfoImpl.java
@@ -1,0 +1,37 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.declarations.PackageInfo;
+
+import java.util.Objects;
+
+class PackageInfoImpl extends DeclarationInfoImpl<Package, /*always null*/ jakarta.enterprise.inject.spi.Annotated> implements PackageInfo {
+    // only for equals/hashCode
+    private final String name;
+
+    PackageInfoImpl(Package pkg) {
+        super(pkg, null);
+        this.name = reflection.getName();
+    }
+
+    @Override
+    public String name() {
+        return reflection.getName();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PackageInfoImpl that = (PackageInfoImpl) o;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParameterConfigImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParameterConfigImpl.java
@@ -1,0 +1,52 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.ParameterConfig;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.ParameterInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.function.Predicate;
+
+class ParameterConfigImpl implements ParameterConfig {
+    private final jakarta.enterprise.inject.spi.configurator.AnnotatedParameterConfigurator<?> configurator;
+
+    ParameterConfigImpl(jakarta.enterprise.inject.spi.configurator.AnnotatedParameterConfigurator<?> configurator) {
+        this.configurator = configurator;
+    }
+
+    @Override
+    public ParameterInfo info() {
+        return new ParameterInfoImpl(configurator.getAnnotated());
+    }
+
+    @Override
+    public ParameterConfig addAnnotation(Class<? extends Annotation> annotationType) {
+        configurator.add(AnnotationProxy.create(annotationType, Collections.emptyMap()));
+        return this;
+    }
+
+    @Override
+    public ParameterConfig addAnnotation(AnnotationInfo annotation) {
+        configurator.add(((AnnotationInfoImpl) annotation).annotation);
+        return this;
+    }
+
+    @Override
+    public ParameterConfig addAnnotation(Annotation annotation) {
+        configurator.add(annotation);
+        return this;
+    }
+
+    @Override
+    public ParameterConfig removeAnnotation(Predicate<AnnotationInfo> predicate) {
+        configurator.remove(annotation -> predicate.test(new AnnotationInfoImpl(annotation)));
+        return this;
+    }
+
+    @Override
+    public ParameterConfig removeAllAnnotations() {
+        configurator.removeAll();
+        return this;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParameterInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParameterInfoImpl.java
@@ -1,0 +1,157 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+import jakarta.enterprise.lang.model.declarations.ParameterInfo;
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+class ParameterInfoImpl extends DeclarationInfoImpl<Parameter, jakarta.enterprise.inject.spi.AnnotatedParameter<?>> implements ParameterInfo {
+    // only for equals/hashCode and going back to the method
+    private final MethodInfoImpl method;
+    private final int position;
+
+    ParameterInfoImpl(jakarta.enterprise.inject.spi.AnnotatedParameter<?> cdiDeclaration) {
+        super(cdiDeclaration.getJavaParameter(), cdiDeclaration);
+        this.method = new MethodInfoImpl(cdiDeclaration.getDeclaringCallable());
+        this.position = cdiDeclaration.getPosition();
+    }
+
+    ParameterInfoImpl(Parameter reflectionDeclaration, MethodInfoImpl backReference, int position) {
+        super(reflectionDeclaration, null);
+        this.method = backReference;
+        this.position = position;
+    }
+
+    @Override
+    public String name() {
+        return reflection.getName();
+    }
+
+    @Override
+    public Type type() {
+        // in the vast majority of cases, this condition holds true
+        if (canSuperHandleAnnotations()) {
+            return TypeImpl.fromReflectionType(reflection.getAnnotatedType());
+        }
+
+        // this only applies in a very specific situation: a method that has synthetic
+        // parameters and also annotations on (non-synthetic) parameters (for example,
+        // an enum constructor, as in the Lang Model TCK)
+        //
+        // in such case, reflective access to annotations is inconsistent and we have to
+        // compensate for that
+        AnnotationOverrides overrides = new AnnotationOverrides(reflection.getDeclaringExecutable()
+                .getAnnotatedParameterTypes()[position].getAnnotations());
+        return TypeImpl.fromReflectionType(reflection.getAnnotatedType(), overrides);
+    }
+
+    @Override
+    public MethodInfo declaringMethod() {
+        return method;
+    }
+
+    private boolean canSuperHandleAnnotations() {
+        if (cdiDeclaration != null) {
+            return true;
+        }
+
+        java.lang.reflect.Executable method = this.method.reflection;
+        if (method.getParameterTypes().length == method.getParameterAnnotations().length) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean hasAnnotation(Class<? extends Annotation> annotationType) {
+        if (canSuperHandleAnnotations()) {
+            return super.hasAnnotation(annotationType);
+        }
+
+        Annotation[] annotations = method.reflection.getParameterAnnotations()[position];
+        return Arrays.stream(annotations)
+                .anyMatch(it -> annotationType.isAssignableFrom(it.annotationType()));
+    }
+
+    @Override
+    public boolean hasAnnotation(Predicate<AnnotationInfo> predicate) {
+        if (canSuperHandleAnnotations()) {
+            return super.hasAnnotation(predicate);
+        }
+
+        Annotation[] annotations = method.reflection.getParameterAnnotations()[position];
+        return Arrays.stream(annotations)
+                .anyMatch(it -> predicate.test(new AnnotationInfoImpl(it)));
+    }
+
+    @Override
+    public <T extends Annotation> AnnotationInfo annotation(Class<T> annotationType) {
+        if (canSuperHandleAnnotations()) {
+            return super.annotation(annotationType);
+        }
+
+        Annotation[] annotations = method.reflection.getParameterAnnotations()[position];
+        T annotation = new AnnotationOverrides(annotations).getAnnotation(annotationType);
+        return annotation != null ? new AnnotationInfoImpl(annotation) : null;
+    }
+
+    @Override
+    public <T extends Annotation> Collection<AnnotationInfo> repeatableAnnotation(Class<T> annotationType) {
+        if (canSuperHandleAnnotations()) {
+            return super.repeatableAnnotation(annotationType);
+        }
+
+        Annotation[] annotations = method.reflection.getParameterAnnotations()[position];
+        return Arrays.stream(new AnnotationOverrides(annotations).getAnnotationsByType(annotationType))
+                .map(AnnotationInfoImpl::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<AnnotationInfo> annotations(Predicate<AnnotationInfo> predicate) {
+        if (canSuperHandleAnnotations()) {
+            return super.annotations(predicate);
+        }
+
+        Annotation[] annotations = method.reflection.getParameterAnnotations()[position];
+        return Arrays.stream(annotations)
+                .map(AnnotationInfoImpl::new)
+                .filter(predicate)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String toString() {
+        String name = name();
+        return "parameter " + (name != null ? name : position) + " of method "
+                + cdiDeclaration.getDeclaringCallable().getJavaMember().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ParameterInfoImpl that = (ParameterInfoImpl) o;
+        return position == that.position
+                && Objects.equals(method, that.method);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(method, position);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParameterizedTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParameterizedTypeImpl.java
@@ -1,0 +1,33 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.types.ClassType;
+import jakarta.enterprise.lang.model.types.ParameterizedType;
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class ParameterizedTypeImpl extends TypeImpl<java.lang.reflect.AnnotatedParameterizedType> implements ParameterizedType {
+    ParameterizedTypeImpl(java.lang.reflect.AnnotatedParameterizedType reflectionType) {
+        this(reflectionType, null);
+    }
+
+    ParameterizedTypeImpl(java.lang.reflect.AnnotatedParameterizedType reflectionType, AnnotationOverrides overrides) {
+        super(reflectionType, overrides);
+    }
+
+    @Override
+    public ClassType genericClass() {
+        java.lang.reflect.ParameterizedType type = (java.lang.reflect.ParameterizedType) reflection.getType();
+        return new ClassTypeImpl((Class<?>) type.getRawType(), null);
+    }
+
+    @Override
+    public List<Type> typeArguments() {
+        return Arrays.stream(reflection.getAnnotatedActualTypeArguments())
+                .map(TypeImpl::fromReflectionType)
+                .collect(Collectors.toList());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParametersImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ParametersImpl.java
@@ -1,0 +1,26 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.Parameters;
+
+import java.util.Map;
+
+class ParametersImpl implements Parameters {
+    private final Map<String, Object> data;
+
+    ParametersImpl(Map<String, Object> data) {
+        this.data = data;
+    }
+
+    @Override
+    public <T> T get(String key, Class<T> type) {
+        return type.cast(data.get(key));
+    }
+
+    @Override
+    public <T> T get(String key, Class<T> type, T defaultValue) {
+        if (!data.containsKey(key)) {
+            return defaultValue;
+        }
+        return type.cast(data.get(key));
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/PrimitiveTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/PrimitiveTypeImpl.java
@@ -1,0 +1,57 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.types.PrimitiveType;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.lang.reflect.AnnotatedType;
+
+class PrimitiveTypeImpl extends TypeImpl<AnnotatedType> implements PrimitiveType {
+    final Class<?> clazz;
+
+    PrimitiveTypeImpl(AnnotatedType primitiveType) {
+        this(primitiveType, null);
+    }
+
+    PrimitiveTypeImpl(AnnotatedType primitiveType, AnnotationOverrides overrides) {
+        super(primitiveType, overrides);
+        this.clazz = (Class<?>) primitiveType.getType();
+    }
+
+    PrimitiveTypeImpl(Class<?> primitiveType) {
+        this(primitiveType, null);
+    }
+
+    PrimitiveTypeImpl(Class<?> primitiveType, AnnotationOverrides overrides) {
+        super(AnnotatedTypes.from(primitiveType), overrides);
+        this.clazz = primitiveType;
+    }
+
+    @Override
+    public String name() {
+        return reflection.getType().getTypeName();
+    }
+
+    @Override
+    public PrimitiveKind primitiveKind() {
+        if (clazz == boolean.class) {
+            return PrimitiveKind.BOOLEAN;
+        } else if (clazz == byte.class) {
+            return PrimitiveKind.BYTE;
+        } else if (clazz == short.class) {
+            return PrimitiveKind.SHORT;
+        } else if (clazz == int.class) {
+            return PrimitiveKind.INT;
+        } else if (clazz == long.class) {
+            return PrimitiveKind.LONG;
+        } else if (clazz == float.class) {
+            return PrimitiveKind.FLOAT;
+        } else if (clazz == double.class) {
+            return PrimitiveKind.DOUBLE;
+        } else if (clazz == char.class) {
+            return PrimitiveKind.CHAR;
+        } else {
+            throw new IllegalStateException("Unknown primitive type " + clazz);
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ReflectionMembers.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ReflectionMembers.java
@@ -9,6 +9,10 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 class ReflectionMembers {
+
+    private ReflectionMembers() {
+    }
+
     static Set<Method> allMethods(Class<?> clazz) {
         Set<Method> result = new HashSet<>();
         forEachSuperclass(clazz, it -> result.addAll(Arrays.asList(it.getDeclaredMethods())));

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ReflectionMembers.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ReflectionMembers.java
@@ -1,0 +1,43 @@
+package org.jboss.weld.lite.extension.translator;
+
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
+import java.util.function.Consumer;
+
+class ReflectionMembers {
+    static Set<Method> allMethods(Class<?> clazz) {
+        Set<Method> result = new HashSet<>();
+        forEachSuperclass(clazz, it -> result.addAll(Arrays.asList(it.getDeclaredMethods())));
+        return result;
+    }
+
+    static Set<java.lang.reflect.Field> allFields(Class<?> clazz) {
+        Set<java.lang.reflect.Field> result = new HashSet<>();
+        forEachSuperclass(clazz, it -> result.addAll(Arrays.asList(it.getDeclaredFields())));
+        return result;
+    }
+
+    private static void forEachSuperclass(Class<?> clazz, Consumer<Class<?>> action) {
+        Queue<Class<?>> workQueue = new ArrayDeque<>();
+        workQueue.add(clazz);
+        while (!workQueue.isEmpty()) {
+            Class<?> item = workQueue.remove();
+
+            if (item.equals(Object.class)) {
+                continue;
+            }
+
+            Class<?> superclass = item.getSuperclass();
+            if (superclass != null) {
+                workQueue.add(superclass);
+            }
+            workQueue.addAll(Arrays.asList(item.getInterfaces()));
+
+            action.accept(item);
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ScannedClassesImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ScannedClassesImpl.java
@@ -1,0 +1,20 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.ScannedClasses;
+
+class ScannedClassesImpl implements ScannedClasses {
+    private final jakarta.enterprise.inject.spi.BeforeBeanDiscovery bbd;
+
+    ScannedClassesImpl(jakarta.enterprise.inject.spi.BeforeBeanDiscovery bbd) {
+        this.bbd = bbd;
+    }
+
+    @Override
+    public void add(String className) {
+        try {
+            bbd.addAnnotatedType(Class.forName(className), className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ScopeInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ScopeInfoImpl.java
@@ -1,0 +1,24 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.ScopeInfo;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+class ScopeInfoImpl implements ScopeInfo {
+    private final ClassInfo annotation;
+    private final boolean isNormal;
+
+    ScopeInfoImpl(ClassInfo annotation, boolean isNormal) {
+        this.annotation = annotation;
+        this.isNormal = isNormal;
+    }
+
+    @Override
+    public ClassInfo annotation() {
+        return annotation;
+    }
+
+    @Override
+    public boolean isNormal() {
+        return isNormal;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SharedErrors.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SharedErrors.java
@@ -1,0 +1,8 @@
+package org.jboss.weld.lite.extension.translator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class SharedErrors {
+    final List<Throwable> list = new ArrayList<>();
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/StereotypeInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/StereotypeInfoImpl.java
@@ -1,0 +1,72 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.NormalScope;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.build.compatible.spi.ScopeInfo;
+import jakarta.enterprise.inject.build.compatible.spi.StereotypeInfo;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.inject.Named;
+import jakarta.inject.Scope;
+import jakarta.interceptor.InterceptorBinding;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+class StereotypeInfoImpl implements StereotypeInfo {
+    // declaration of the sterotype annotation
+    private final jakarta.enterprise.inject.spi.AnnotatedType<? extends Annotation> cdiDeclaration;
+
+    StereotypeInfoImpl(Class<? extends Annotation> stereotypeAnnotation) {
+        cdiDeclaration = BeanManagerAccess.createAnnotatedType(stereotypeAnnotation);
+    }
+
+    @Override
+    public ScopeInfo defaultScope() {
+        Optional<jakarta.enterprise.inject.spi.AnnotatedType<?>> scopeAnnotation = cdiDeclaration.getAnnotations()
+                .stream()
+                .filter(it -> it.annotationType().isAnnotationPresent(Scope.class)
+                        || it.annotationType().isAnnotationPresent(NormalScope.class))
+                .findAny()
+                .map(it -> BeanManagerAccess.createAnnotatedType(it.annotationType()));
+
+        if (scopeAnnotation.isPresent()) {
+            jakarta.enterprise.inject.spi.AnnotatedType<?> scopeType = scopeAnnotation.get();
+            boolean isNormal = scopeType.isAnnotationPresent(NormalScope.class);
+            return new ScopeInfoImpl(new ClassInfoImpl(scopeType), isNormal);
+        }
+
+        return null;
+    }
+
+    @Override
+    public Collection<AnnotationInfo> interceptorBindings() {
+        List<AnnotationInfo> result = new ArrayList<>();
+        for (Annotation annotation : cdiDeclaration.getAnnotations()) {
+            if (annotation.annotationType().isAnnotationPresent(InterceptorBinding.class)) {
+                result.add(new AnnotationInfoImpl(annotation));
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean isAlternative() {
+        return cdiDeclaration.isAnnotationPresent(Alternative.class);
+    }
+
+    @Override
+    public Integer priority() {
+        return cdiDeclaration.isAnnotationPresent(Priority.class)
+                ? cdiDeclaration.getAnnotation(Priority.class).value()
+                : null;
+    }
+
+    @Override
+    public boolean isNamed() {
+        return cdiDeclaration.isAnnotationPresent(Named.class);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticBeanBuilderImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticBeanBuilderImpl.java
@@ -1,0 +1,114 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanBuilder;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanCreator;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanDisposer;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.types.Type;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+class SyntheticBeanBuilderImpl<T> extends SyntheticComponentBuilderBase<SyntheticBeanBuilderImpl<T>> implements SyntheticBeanBuilder<T> {
+    Class<?> implementationClass;
+    Set<java.lang.reflect.Type> types = new HashSet<>();
+    Set<Annotation> qualifiers = new HashSet<>();
+    Class<? extends Annotation> scope;
+    boolean isAlternative;
+    int priority;
+    String name;
+    Set<Class<? extends Annotation>> stereotypes = new HashSet<>();
+    Class<? extends SyntheticBeanCreator<T>> creatorClass;
+    Class<? extends SyntheticBeanDisposer<T>> disposerClass;
+
+    SyntheticBeanBuilderImpl(Class<?> implementationClass) {
+        this.implementationClass = implementationClass;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> type(Class<?> type) {
+        this.types.add(type);
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> type(ClassInfo type) {
+        this.types.add(((ClassInfoImpl) type).cdiDeclaration.getJavaClass());
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> type(Type type) {
+        this.types.add(((TypeImpl<?>) type).reflection.getType());
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> qualifier(Class<? extends Annotation> qualifierAnnotation) {
+        this.qualifiers.add(AnnotationProxy.create(qualifierAnnotation, Collections.emptyMap()));
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> qualifier(AnnotationInfo qualifierAnnotation) {
+        this.qualifiers.add(((AnnotationInfoImpl) qualifierAnnotation).annotation);
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> qualifier(Annotation qualifierAnnotation) {
+        this.qualifiers.add(qualifierAnnotation);
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> scope(Class<? extends Annotation> scopeAnnotation) {
+        this.scope = scopeAnnotation;
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> alternative(boolean isAlternative) {
+        this.isAlternative = isAlternative;
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> priority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> stereotype(Class<? extends Annotation> stereotypeAnnotation) {
+        this.stereotypes.add(stereotypeAnnotation);
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> stereotype(ClassInfo stereotypeAnnotation) {
+        this.stereotypes.add((Class<? extends Annotation>) ((ClassInfoImpl) stereotypeAnnotation).cdiDeclaration.getJavaClass());
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> createWith(Class<? extends SyntheticBeanCreator<T>> creatorClass) {
+        this.creatorClass = creatorClass;
+        return this;
+    }
+
+    @Override
+    public SyntheticBeanBuilder<T> disposeWith(Class<? extends SyntheticBeanDisposer<T>> disposerClass) {
+        this.disposerClass = disposerClass;
+        return this;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticComponentBuilderBase.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticComponentBuilderBase.java
@@ -1,0 +1,125 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.HashMap;
+import java.util.Map;
+
+class SyntheticComponentBuilderBase<THIS extends SyntheticComponentBuilderBase<THIS>> {
+    final Map<String, Object> params = new HashMap<>();
+
+    @SuppressWarnings("unchecked")
+    private THIS self() {
+        return (THIS) this;
+    }
+
+    public THIS withParam(String key, boolean value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, boolean[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, int value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, int[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, long value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, long[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, double value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, double[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, String value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, String[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, Enum<?> value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, Enum<?>[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, Class<?> value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, ClassInfo value) {
+        this.params.put(key, ((ClassInfoImpl) value).cdiDeclaration.getJavaClass());
+        return self();
+    }
+
+    public THIS withParam(String key, Class<?>[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, ClassInfo[] value) {
+        Class<?>[] array = new Class<?>[value.length];
+        for (int i = 0; i < value.length; i++) {
+            array[i] = ((ClassInfoImpl) value[i]).cdiDeclaration.getJavaClass();
+        }
+        this.params.put(key, array);
+        return self();
+    }
+
+    public THIS withParam(String key, AnnotationInfo value) {
+        this.params.put(key, ((AnnotationInfoImpl) value).annotation);
+        return self();
+    }
+
+    public THIS withParam(String key, Annotation value) {
+        this.params.put(key, value);
+        return self();
+    }
+
+    public THIS withParam(String key, AnnotationInfo[] value) {
+        Annotation[] array = new Annotation[value.length];
+        for (int i = 0; i < value.length; i++) {
+            array[i] = ((AnnotationInfoImpl) value[i]).annotation;
+        }
+        this.params.put(key, array);
+        return self();
+    }
+
+    public THIS withParam(String key, Annotation[] value) {
+        this.params.put(key, value);
+        return self();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticComponentsImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticComponentsImpl.java
@@ -1,0 +1,43 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticBeanBuilder;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticObserverBuilder;
+import jakarta.enterprise.lang.model.types.Type;
+
+import java.util.List;
+
+class SyntheticComponentsImpl implements SyntheticComponents {
+    final List<SyntheticBeanBuilderImpl<?>> syntheticBeans;
+    final List<SyntheticObserverBuilderImpl<?>> syntheticObservers;
+    final Class<?> extensionClass;
+
+    SyntheticComponentsImpl(List<SyntheticBeanBuilderImpl<?>> syntheticBeans,
+            List<SyntheticObserverBuilderImpl<?>> syntheticObservers, Class<?> extensionClass) {
+        this.syntheticBeans = syntheticBeans;
+        this.syntheticObservers = syntheticObservers;
+        this.extensionClass = extensionClass;
+    }
+
+    @Override
+    public <T> SyntheticBeanBuilder<T> addBean(Class<T> implementationClass) {
+        SyntheticBeanBuilderImpl<T> builder = new SyntheticBeanBuilderImpl<>(implementationClass);
+        syntheticBeans.add(builder);
+        return builder;
+    }
+
+    @Override
+    public <T> SyntheticObserverBuilder<T> addObserver(Class<T> eventType) {
+        SyntheticObserverBuilderImpl<T> builder = new SyntheticObserverBuilderImpl<>(extensionClass, eventType);
+        syntheticObservers.add(builder);
+        return builder;
+    }
+
+    @Override
+    public <T> SyntheticObserverBuilder<T> addObserver(Type eventType) {
+        SyntheticObserverBuilderImpl<T> builder = new SyntheticObserverBuilderImpl<>(extensionClass,
+                ((TypeImpl<?>) eventType).reflection.getType());
+        syntheticObservers.add(builder);
+        return builder;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticObserverBuilderImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/SyntheticObserverBuilderImpl.java
@@ -1,0 +1,83 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.event.Reception;
+import jakarta.enterprise.event.TransactionPhase;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticObserver;
+import jakarta.enterprise.inject.build.compatible.spi.SyntheticObserverBuilder;
+import jakarta.enterprise.lang.model.AnnotationInfo;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+class SyntheticObserverBuilderImpl<T> extends SyntheticComponentBuilderBase<SyntheticObserverBuilderImpl<T>> implements SyntheticObserverBuilder<T> {
+    Class<?> declaringClass;
+    java.lang.reflect.Type eventType;
+    Set<Annotation> qualifiers = new HashSet<>();
+    int priority = jakarta.enterprise.inject.spi.ObserverMethod.DEFAULT_PRIORITY;
+    boolean isAsync;
+    Reception reception = Reception.ALWAYS;
+    TransactionPhase transactionPhase = TransactionPhase.IN_PROGRESS;
+    Class<? extends SyntheticObserver<T>> observerClass;
+
+    SyntheticObserverBuilderImpl(Class<?> extensionClass, java.lang.reflect.Type eventType) {
+        this.declaringClass = extensionClass;
+        this.eventType = eventType;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> declaringClass(Class<?> declaringClass) {
+        this.declaringClass = declaringClass;
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> declaringClass(ClassInfo declaringClass) {
+        this.declaringClass = ((ClassInfoImpl) declaringClass).cdiDeclaration.getJavaClass();
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> qualifier(Class<? extends Annotation> qualifierAnnotation) {
+        this.qualifiers.add(AnnotationProxy.create(qualifierAnnotation, Collections.emptyMap()));
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> qualifier(AnnotationInfo qualifierAnnotation) {
+        this.qualifiers.add(((AnnotationInfoImpl) qualifierAnnotation).annotation);
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> qualifier(Annotation qualifierAnnotation) {
+        this.qualifiers.add(qualifierAnnotation);
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> priority(int priority) {
+        this.priority = priority;
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> async(boolean isAsync) {
+        this.isAsync = isAsync;
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> transactionPhase(TransactionPhase transactionPhase) {
+        this.transactionPhase = transactionPhase;
+        return this;
+    }
+
+    @Override
+    public SyntheticObserverBuilder<T> observeWith(Class<? extends SyntheticObserver<T>> observerClass) {
+        this.observerClass = observerClass;
+        return this;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypeImpl.java
@@ -1,0 +1,73 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.types.Type;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+abstract class TypeImpl<ReflectionType extends java.lang.reflect.AnnotatedType> extends AnnotationTargetImpl<ReflectionType> implements Type {
+    TypeImpl(ReflectionType reflectionType, AnnotationOverrides overrides) {
+        super(reflectionType, overrides);
+    }
+
+    static Type fromReflectionType(java.lang.reflect.AnnotatedType reflectionType) {
+        return fromReflectionType(reflectionType, null);
+    }
+
+    static Type fromReflectionType(java.lang.reflect.AnnotatedType reflectionType, AnnotationOverrides overrides) {
+        if (reflectionType instanceof java.lang.reflect.AnnotatedParameterizedType) {
+            return new ParameterizedTypeImpl((java.lang.reflect.AnnotatedParameterizedType) reflectionType, overrides);
+        } else if (reflectionType instanceof java.lang.reflect.AnnotatedTypeVariable) {
+            return new TypeVariableImpl((java.lang.reflect.AnnotatedTypeVariable) reflectionType, overrides);
+        } else if (reflectionType instanceof java.lang.reflect.AnnotatedArrayType) {
+            return new ArrayTypeImpl((java.lang.reflect.AnnotatedArrayType) reflectionType, overrides);
+        } else if (reflectionType instanceof java.lang.reflect.AnnotatedWildcardType) {
+            return new WildcardTypeImpl((java.lang.reflect.AnnotatedWildcardType) reflectionType, overrides);
+        } else {
+            // plain java.lang.reflect.AnnotatedType
+            if (reflectionType.getType() instanceof Class) {
+                Class<?> clazz = (Class<?>) reflectionType.getType();
+                if (clazz.isPrimitive()) {
+                    if (clazz == void.class) {
+                        return new VoidTypeImpl();
+                    } else {
+                        return new PrimitiveTypeImpl(reflectionType, overrides);
+                    }
+                }
+                if (clazz.isArray()) {
+                    return new ArrayTypeImpl((java.lang.reflect.AnnotatedArrayType) AnnotatedTypes.from(clazz), overrides);
+                }
+                return new ClassTypeImpl(reflectionType, overrides);
+            } else {
+                throw new IllegalArgumentException("Unknown type " + reflectionType);
+            }
+        }
+    }
+
+    @Override
+    public String toString() {
+        return reflection.getType().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TypeImpl)) {
+            return false;
+        }
+        TypeImpl<?> type = (TypeImpl<?>) o;
+        return Objects.equals(reflection.getType(), type.reflection.getType())
+                && Objects.deepEquals(reflection.getAnnotations(), type.reflection.getAnnotations());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(reflection.getType());
+        result = 31 * result + Arrays.hashCode(reflection.getAnnotations());
+        return result;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypeVariableImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypeVariableImpl.java
@@ -1,0 +1,31 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.types.Type;
+import jakarta.enterprise.lang.model.types.TypeVariable;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+class TypeVariableImpl extends TypeImpl<java.lang.reflect.AnnotatedTypeVariable> implements TypeVariable {
+    TypeVariableImpl(java.lang.reflect.AnnotatedTypeVariable reflectionType) {
+        this(reflectionType, null);
+    }
+
+    TypeVariableImpl(java.lang.reflect.AnnotatedTypeVariable reflectionType, AnnotationOverrides overrides) {
+        super(reflectionType, overrides);
+    }
+
+    @Override
+    public String name() {
+        return reflection.getType().getTypeName();
+    }
+
+    @Override
+    public List<Type> bounds() {
+        return Arrays.stream(reflection.getAnnotatedBounds())
+                .map(TypeImpl::fromReflectionType)
+                .collect(Collectors.toList());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypesImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypesImpl.java
@@ -12,6 +12,9 @@ import jakarta.enterprise.lang.model.types.WildcardType;
 import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
 
 class TypesImpl implements Types {
+
+    private final String UNKNOWN_PRIM_TYPE = "Unknown primitive type ";
+
     @Override
     public Type of(Class<?> clazz) {
         if (clazz.isArray()) {
@@ -44,7 +47,7 @@ class TypesImpl implements Types {
             } else if (clazz == char.class) {
                 return ofPrimitive(PrimitiveType.PrimitiveKind.CHAR);
             } else {
-                throw new IllegalArgumentException("Unknown primitive type " + clazz);
+                throw new IllegalArgumentException(UNKNOWN_PRIM_TYPE + clazz);
             }
         }
 
@@ -76,7 +79,7 @@ class TypesImpl implements Types {
             case CHAR:
                 return new PrimitiveTypeImpl(Character.TYPE);
             default:
-                throw new IllegalArgumentException("Unknown primitive type " + kind);
+                throw new IllegalArgumentException(UNKNOWN_PRIM_TYPE + kind);
         }
     }
 

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypesImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/TypesImpl.java
@@ -1,0 +1,141 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.inject.build.compatible.spi.Types;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+import jakarta.enterprise.lang.model.types.ArrayType;
+import jakarta.enterprise.lang.model.types.ClassType;
+import jakarta.enterprise.lang.model.types.ParameterizedType;
+import jakarta.enterprise.lang.model.types.PrimitiveType;
+import jakarta.enterprise.lang.model.types.Type;
+import jakarta.enterprise.lang.model.types.VoidType;
+import jakarta.enterprise.lang.model.types.WildcardType;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+class TypesImpl implements Types {
+    @Override
+    public Type of(Class<?> clazz) {
+        if (clazz.isArray()) {
+            int dimensions = 1;
+            Class<?> componentType = clazz.getComponentType();
+            while (componentType.isArray()) {
+                dimensions++;
+                componentType = componentType.getComponentType();
+            }
+            return ofArray(of(componentType), dimensions);
+        }
+
+        if (clazz.isPrimitive()) {
+            if (clazz == void.class) {
+                return ofVoid();
+            } else if (clazz == boolean.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.BOOLEAN);
+            } else if (clazz == byte.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.BYTE);
+            } else if (clazz == short.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.SHORT);
+            } else if (clazz == int.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.INT);
+            } else if (clazz == long.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.LONG);
+            } else if (clazz == float.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.FLOAT);
+            } else if (clazz == double.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.DOUBLE);
+            } else if (clazz == char.class) {
+                return ofPrimitive(PrimitiveType.PrimitiveKind.CHAR);
+            } else {
+                throw new IllegalArgumentException("Unknown primitive type " + clazz);
+            }
+        }
+
+        return new ClassTypeImpl(clazz);
+    }
+
+    @Override
+    public VoidType ofVoid() {
+        return new VoidTypeImpl();
+    }
+
+    @Override
+    public PrimitiveType ofPrimitive(PrimitiveType.PrimitiveKind kind) {
+        switch (kind) {
+            case BOOLEAN:
+                return new PrimitiveTypeImpl(Boolean.TYPE);
+            case BYTE:
+                return new PrimitiveTypeImpl(Byte.TYPE);
+            case SHORT:
+                return new PrimitiveTypeImpl(Short.TYPE);
+            case INT:
+                return new PrimitiveTypeImpl(Integer.TYPE);
+            case LONG:
+                return new PrimitiveTypeImpl(Long.TYPE);
+            case FLOAT:
+                return new PrimitiveTypeImpl(Float.TYPE);
+            case DOUBLE:
+                return new PrimitiveTypeImpl(Double.TYPE);
+            case CHAR:
+                return new PrimitiveTypeImpl(Character.TYPE);
+            default:
+                throw new IllegalArgumentException("Unknown primitive type " + kind);
+        }
+    }
+
+    @Override
+    public ClassType ofClass(String name) {
+        try {
+            Class<?> clazz = Class.forName(name, true, Thread.currentThread().getContextClassLoader());
+            return new ClassTypeImpl(clazz);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
+
+    @Override
+    public ClassType ofClass(ClassInfo clazz) {
+        return (ClassType) of(((ClassInfoImpl) clazz).cdiDeclaration.getJavaClass());
+    }
+
+    @Override
+    public ArrayType ofArray(Type elementType, int dimensions) {
+        return new ArrayTypeImpl(AnnotatedTypes.array(((TypeImpl<?>) elementType).reflection.getType(), dimensions));
+    }
+
+    @Override
+    public ParameterizedType parameterized(Class<?> genericType, Class<?>... typeArguments) {
+        return new ParameterizedTypeImpl(AnnotatedTypes.parameterized(genericType, typeArguments));
+    }
+
+    @Override
+    public ParameterizedType parameterized(Class<?> genericType, Type... typeArguments) {
+        java.lang.reflect.Type[] underlyingTypeArguments = new java.lang.reflect.Type[typeArguments.length];
+        for (int i = 0; i < typeArguments.length; i++) {
+            underlyingTypeArguments[i] = ((TypeImpl<?>) typeArguments[i]).reflection.getType();
+        }
+        return new ParameterizedTypeImpl(AnnotatedTypes.parameterized(genericType, underlyingTypeArguments));
+    }
+
+    @Override
+    public ParameterizedType parameterized(ClassType genericType, Type... typeArguments) {
+        Class<?> clazz = (Class<?>) ((TypeImpl<?>) genericType).reflection.getType();
+        java.lang.reflect.Type[] underlyingTypeArguments = new java.lang.reflect.Type[typeArguments.length];
+        for (int i = 0; i < typeArguments.length; i++) {
+            underlyingTypeArguments[i] = ((TypeImpl<?>) typeArguments[i]).reflection.getType();
+        }
+        return new ParameterizedTypeImpl(AnnotatedTypes.parameterized(clazz, underlyingTypeArguments));
+    }
+
+    @Override
+    public WildcardType wildcardWithUpperBound(Type upperBound) {
+        return new WildcardTypeImpl(AnnotatedTypes.wildcardWithUpperBound(((TypeImpl<?>) upperBound).reflection.getType()));
+    }
+
+    @Override
+    public WildcardType wildcardWithLowerBound(Type lowerBound) {
+        return new WildcardTypeImpl(AnnotatedTypes.wildcardWithLowerBound(((TypeImpl<?>) lowerBound).reflection.getType()));
+    }
+
+    @Override
+    public WildcardType wildcardUnbounded() {
+        return new WildcardTypeImpl(AnnotatedTypes.unboundedWildcardType());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/VoidTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/VoidTypeImpl.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.types.VoidType;
+import org.jboss.weld.lite.extension.translator.util.reflection.AnnotatedTypes;
+
+class VoidTypeImpl extends TypeImpl<java.lang.reflect.AnnotatedType> implements VoidType {
+    final Class<?> clazz;
+
+    VoidTypeImpl() {
+        super(AnnotatedTypes.from(void.class), null);
+        this.clazz = void.class;
+    }
+
+    @Override
+    public String name() {
+        return reflection.getType().getTypeName();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/WildcardTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/WildcardTypeImpl.java
@@ -1,0 +1,39 @@
+package org.jboss.weld.lite.extension.translator;
+
+import jakarta.enterprise.lang.model.types.Type;
+import jakarta.enterprise.lang.model.types.WildcardType;
+import org.jboss.weld.lite.extension.translator.util.AnnotationOverrides;
+
+class WildcardTypeImpl extends TypeImpl<java.lang.reflect.AnnotatedWildcardType> implements WildcardType {
+    private final boolean hasUpperBound;
+
+    // note that while java.lang.reflect.AnnotatedWildcardType API returns arrays,
+    // the Java language only permits at most one upper or lower bound
+
+    WildcardTypeImpl(java.lang.reflect.AnnotatedWildcardType reflectionType) {
+        this(reflectionType, null);
+    }
+
+    WildcardTypeImpl(java.lang.reflect.AnnotatedWildcardType reflectionType, AnnotationOverrides overrides) {
+        super(reflectionType, overrides);
+        this.hasUpperBound = reflectionType.getAnnotatedLowerBounds().length == 0;
+    }
+
+    @Override
+    public Type upperBound() {
+        if (!hasUpperBound) {
+            return null;
+        }
+
+        return TypeImpl.fromReflectionType(reflection.getAnnotatedUpperBounds()[0]);
+    }
+
+    @Override
+    public Type lowerBound() {
+        if (hasUpperBound) {
+            return null;
+        }
+
+        return TypeImpl.fromReflectionType(reflection.getAnnotatedLowerBounds()[0]);
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/AnnotationOverrides.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/AnnotationOverrides.java
@@ -1,0 +1,33 @@
+package org.jboss.weld.lite.extension.translator.util;
+
+import java.lang.annotation.Annotation;
+
+public final class AnnotationOverrides implements java.lang.reflect.AnnotatedElement {
+    private static final Annotation[] EMPTY_ARRAY = new Annotation[0];
+
+    private final Annotation[] annotations;
+
+    public AnnotationOverrides(Annotation[] annotations) {
+        this.annotations = annotations;
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+        for (Annotation annotation : annotations) {
+            if (annotationClass.isAssignableFrom(annotation.annotationType())) {
+                return annotationClass.cast(annotation);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Annotation[] getAnnotations() {
+        return annotations != null ? annotations : EMPTY_ARRAY;
+    }
+
+    @Override
+    public Annotation[] getDeclaredAnnotations() {
+        return annotations != null ? annotations : EMPTY_ARRAY;
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AbstractEmptyAnnotatedType.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AbstractEmptyAnnotatedType.java
@@ -1,0 +1,20 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.lang.annotation.Annotation;
+
+abstract class AbstractEmptyAnnotatedType implements java.lang.reflect.AnnotatedType {
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+        return null;
+    }
+
+    @Override
+    public Annotation[] getAnnotations() {
+        return new Annotation[0];
+    }
+
+    @Override
+    public Annotation[] getDeclaredAnnotations() {
+        return new Annotation[0];
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedArrayTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedArrayTypeImpl.java
@@ -1,0 +1,32 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+final class AnnotatedArrayTypeImpl extends AbstractEmptyAnnotatedType implements java.lang.reflect.AnnotatedArrayType {
+    private final java.lang.reflect.GenericArrayType arrayType;
+
+    AnnotatedArrayTypeImpl(java.lang.reflect.GenericArrayType arrayType) {
+        this.arrayType = arrayType;
+    }
+
+    @Override
+    public java.lang.reflect.AnnotatedType getAnnotatedGenericComponentType() {
+        return AnnotatedTypes.from(arrayType.getGenericComponentType());
+    }
+
+    // added in Java 9
+    /*
+    @Override
+    */
+    public java.lang.reflect.AnnotatedType getAnnotatedOwnerType() {
+        return null;
+    }
+
+    @Override
+    public java.lang.reflect.Type getType() {
+        return arrayType;
+    }
+
+    @Override
+    public String toString() {
+        return arrayType.toString();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedParameterizedTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedParameterizedTypeImpl.java
@@ -1,0 +1,37 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.util.Arrays;
+
+final class AnnotatedParameterizedTypeImpl extends AbstractEmptyAnnotatedType implements java.lang.reflect.AnnotatedParameterizedType {
+    private final java.lang.reflect.ParameterizedType parameterizedType;
+
+    AnnotatedParameterizedTypeImpl(java.lang.reflect.ParameterizedType parameterizedType) {
+        this.parameterizedType = parameterizedType;
+    }
+
+    @Override
+    public java.lang.reflect.AnnotatedType[] getAnnotatedActualTypeArguments() {
+        return Arrays.stream(parameterizedType.getActualTypeArguments())
+                .map(AnnotatedTypes::from)
+                .toArray(java.lang.reflect.AnnotatedType[]::new);
+    }
+
+    // added in Java 9
+    /*
+    @Override
+    */
+    public java.lang.reflect.AnnotatedType getAnnotatedOwnerType() {
+        java.lang.reflect.Type ownerType = parameterizedType.getOwnerType();
+        return ownerType == null ? null : AnnotatedTypes.from(ownerType);
+    }
+
+    @Override
+    public java.lang.reflect.Type getType() {
+        return parameterizedType;
+    }
+
+    @Override
+    public String toString() {
+        return parameterizedType.toString();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedTypeImpl.java
@@ -1,0 +1,49 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.lang.annotation.Annotation;
+
+final class AnnotatedTypeImpl implements java.lang.reflect.AnnotatedType {
+    private final Class<?> clazz;
+
+    AnnotatedTypeImpl(Class<?> clazz) {
+        this.clazz = clazz;
+    }
+
+    // added in Java 9
+    /*
+    @Override
+    */
+    public java.lang.reflect.AnnotatedType getAnnotatedOwnerType() {
+        if (clazz.isPrimitive() || clazz == Void.TYPE) {
+            return null;
+        }
+
+        Class<?> declaringClass = clazz.getDeclaringClass();
+        return declaringClass == null ? null : AnnotatedTypes.from(declaringClass);
+    }
+
+    @Override
+    public java.lang.reflect.Type getType() {
+        return clazz;
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+        return clazz.getAnnotation(annotationClass);
+    }
+
+    @Override
+    public Annotation[] getAnnotations() {
+        return clazz.getAnnotations();
+    }
+
+    @Override
+    public Annotation[] getDeclaredAnnotations() {
+        return clazz.getDeclaredAnnotations();
+    }
+
+    @Override
+    public String toString() {
+        return clazz.getName();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedTypeVariableImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedTypeVariableImpl.java
@@ -1,0 +1,49 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.lang.annotation.Annotation;
+
+final class AnnotatedTypeVariableImpl implements java.lang.reflect.AnnotatedTypeVariable {
+    private final java.lang.reflect.TypeVariable<?> typeVariable;
+
+    AnnotatedTypeVariableImpl(java.lang.reflect.TypeVariable<?> typeVariable) {
+        this.typeVariable = typeVariable;
+    }
+
+    @Override
+    public java.lang.reflect.AnnotatedType[] getAnnotatedBounds() {
+        return typeVariable.getAnnotatedBounds();
+    }
+
+    // added in Java 9
+    /*
+    @Override
+    */
+    public java.lang.reflect.AnnotatedType getAnnotatedOwnerType() {
+        return null;
+    }
+
+    @Override
+    public java.lang.reflect.Type getType() {
+        return typeVariable;
+    }
+
+    @Override
+    public <T extends Annotation> T getAnnotation(Class<T> annotationClass) {
+        return typeVariable.getAnnotation(annotationClass);
+    }
+
+    @Override
+    public Annotation[] getAnnotations() {
+        return typeVariable.getAnnotations();
+    }
+
+    @Override
+    public Annotation[] getDeclaredAnnotations() {
+        return typeVariable.getDeclaredAnnotations();
+    }
+
+    @Override
+    public String toString() {
+        return typeVariable.toString();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedTypes.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedTypes.java
@@ -1,0 +1,61 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+public final class AnnotatedTypes {
+
+    private AnnotatedTypes() {
+    }
+
+    public static java.lang.reflect.AnnotatedType from(java.lang.reflect.Type type) {
+        if (type instanceof Class) {
+            Class<?> clazz = (Class<?>) type;
+            if (clazz.isArray()) {
+                int dimensions = 0;
+                while (clazz.isArray()) {
+                    dimensions++;
+                    clazz = clazz.getComponentType();
+                }
+                return array(clazz, dimensions);
+            }
+            return new AnnotatedTypeImpl(clazz);
+        } else if (type instanceof java.lang.reflect.ParameterizedType) {
+            return new AnnotatedParameterizedTypeImpl((java.lang.reflect.ParameterizedType) type);
+        } else if (type instanceof java.lang.reflect.TypeVariable) {
+            return new AnnotatedTypeVariableImpl((java.lang.reflect.TypeVariable<?>) type);
+        } else if (type instanceof java.lang.reflect.WildcardType) {
+            return new AnnotatedWildcardTypeImpl((java.lang.reflect.WildcardType) type);
+        } else if (type instanceof java.lang.reflect.GenericArrayType) {
+            return new AnnotatedArrayTypeImpl((java.lang.reflect.GenericArrayType) type);
+        } else {
+            throw new IllegalArgumentException("Unknown type " + type);
+        }
+    }
+
+    public static java.lang.reflect.AnnotatedArrayType array(java.lang.reflect.Type componentType, int dimensions) {
+        java.lang.reflect.GenericArrayType type = new GenericArrayTypeImpl(componentType);
+        for (int i = 0; i < dimensions - 1; i++) {
+            type = new GenericArrayTypeImpl(type);
+        }
+        return new AnnotatedArrayTypeImpl(type);
+    }
+
+    public static java.lang.reflect.AnnotatedParameterizedType parameterized(Class<?> genericClass,
+            java.lang.reflect.Type... typeArguments) {
+        return new AnnotatedParameterizedTypeImpl(new ParameterizedTypeImpl(genericClass, typeArguments));
+    }
+
+    public static java.lang.reflect.AnnotatedTypeVariable typeVariable(java.lang.reflect.TypeVariable<?> typeVariable) {
+        return new AnnotatedTypeVariableImpl(typeVariable);
+    }
+
+    public static java.lang.reflect.AnnotatedWildcardType wildcardWithUpperBound(java.lang.reflect.Type upperBound) {
+        return new AnnotatedWildcardTypeImpl(WildcardTypeImpl.withUpperBound(upperBound));
+    }
+
+    public static java.lang.reflect.AnnotatedWildcardType wildcardWithLowerBound(java.lang.reflect.Type lowerBound) {
+        return new AnnotatedWildcardTypeImpl(WildcardTypeImpl.withLowerBound(lowerBound));
+    }
+
+    public static java.lang.reflect.AnnotatedWildcardType unboundedWildcardType() {
+        return new AnnotatedWildcardTypeImpl(WildcardTypeImpl.unbounded());
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedWildcardTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/AnnotatedWildcardTypeImpl.java
@@ -1,0 +1,43 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.util.Arrays;
+
+final class AnnotatedWildcardTypeImpl extends AbstractEmptyAnnotatedType implements java.lang.reflect.AnnotatedWildcardType {
+    private final java.lang.reflect.WildcardType wildcardType;
+
+    AnnotatedWildcardTypeImpl(java.lang.reflect.WildcardType wildcardType) {
+        this.wildcardType = wildcardType;
+    }
+
+    @Override
+    public java.lang.reflect.AnnotatedType[] getAnnotatedLowerBounds() {
+        return Arrays.stream(wildcardType.getLowerBounds())
+                .map(AnnotatedTypes::from)
+                .toArray(java.lang.reflect.AnnotatedType[]::new);
+    }
+
+    @Override
+    public java.lang.reflect.AnnotatedType[] getAnnotatedUpperBounds() {
+        return Arrays.stream(wildcardType.getUpperBounds())
+                .map(AnnotatedTypes::from)
+                .toArray(java.lang.reflect.AnnotatedType[]::new);
+    }
+
+    // added in Java 9
+    /*
+    @Override
+    */
+    public java.lang.reflect.AnnotatedType getAnnotatedOwnerType() {
+        return null;
+    }
+
+    @Override
+    public java.lang.reflect.Type getType() {
+        return wildcardType;
+    }
+
+    @Override
+    public String toString() {
+        return wildcardType.toString();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/GenericArrayTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/GenericArrayTypeImpl.java
@@ -33,10 +33,11 @@ final class GenericArrayTypeImpl implements java.lang.reflect.GenericArrayType {
 
     @Override
     public String toString() {
+        String arrayBrackets = "[]";
         if (componentType instanceof Class) {
-            return ((Class<?>) componentType).getName() + "[]";
+            return ((Class<?>) componentType).getName() + arrayBrackets;
         }
 
-        return componentType + "[]";
+        return componentType + arrayBrackets;
     }
 }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/GenericArrayTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/GenericArrayTypeImpl.java
@@ -1,0 +1,42 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.util.Objects;
+
+final class GenericArrayTypeImpl implements java.lang.reflect.GenericArrayType {
+    private final java.lang.reflect.Type componentType;
+
+    GenericArrayTypeImpl(java.lang.reflect.Type componentType) {
+        this.componentType = componentType;
+    }
+
+    @Override
+    public java.lang.reflect.Type getGenericComponentType() {
+        return componentType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof java.lang.reflect.GenericArrayType) {
+            java.lang.reflect.GenericArrayType that = (java.lang.reflect.GenericArrayType) o;
+            return Objects.equals(componentType, that.getGenericComponentType());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(componentType);
+    }
+
+    @Override
+    public String toString() {
+        if (componentType instanceof Class) {
+            return ((Class<?>) componentType).getName() + "[]";
+        }
+
+        return componentType + "[]";
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/ParameterizedTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/ParameterizedTypeImpl.java
@@ -1,0 +1,62 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.StringJoiner;
+
+final class ParameterizedTypeImpl implements java.lang.reflect.ParameterizedType {
+    private final Class<?> genericClass;
+    private final java.lang.reflect.Type[] typeArguments;
+    private final java.lang.reflect.Type ownerType;
+
+    ParameterizedTypeImpl(Class<?> genericClass, java.lang.reflect.Type... typeArguments) {
+        this(genericClass, typeArguments, null);
+    }
+
+    ParameterizedTypeImpl(Class<?> genericClass, java.lang.reflect.Type[] typeArguments, java.lang.reflect.Type ownerType) {
+        this.genericClass = genericClass;
+        this.typeArguments = typeArguments;
+        this.ownerType = ownerType;
+    }
+
+    public java.lang.reflect.Type getRawType() {
+        return genericClass;
+    }
+
+    public java.lang.reflect.Type[] getActualTypeArguments() {
+        return typeArguments;
+    }
+
+    public java.lang.reflect.Type getOwnerType() {
+        return ownerType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof java.lang.reflect.ParameterizedType) {
+            java.lang.reflect.ParameterizedType that = (java.lang.reflect.ParameterizedType) o;
+            return Objects.equals(ownerType, that.getOwnerType())
+                    && Objects.equals(genericClass, that.getRawType())
+                    && Arrays.equals(typeArguments, that.getActualTypeArguments());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(typeArguments) ^ Objects.hashCode(ownerType) ^ Objects.hashCode(genericClass);
+    }
+
+    @Override
+    public String toString() {
+        StringJoiner result = new StringJoiner(",", genericClass.getName() + "<", ">");
+        result.setEmptyValue(genericClass.getName());
+        for (java.lang.reflect.Type typeArgument : typeArguments) {
+            result.add(typeArgument.toString());
+        }
+        return result.toString();
+    }
+}

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/WildcardTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/WildcardTypeImpl.java
@@ -64,11 +64,14 @@ final class WildcardTypeImpl implements java.lang.reflect.WildcardType {
             return "?";
         } else if (noUpperBound) {
             return "? super " + lowerBounds[0];
-        } else if (noLowerBound) {
-            return "? extends " + upperBounds[0];
         } else {
-            // should never happen
-            return "? extends " + upperBounds[0] + " super " + lowerBounds[0];
+            String returnString = "? extends " + upperBounds[0];
+            if (noLowerBound) {
+                return returnString;
+            } else {
+                // should never happen
+                return returnString + " super " + lowerBounds[0];
+            }
         }
     }
 }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/WildcardTypeImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/util/reflection/WildcardTypeImpl.java
@@ -1,0 +1,74 @@
+package org.jboss.weld.lite.extension.translator.util.reflection;
+
+import java.util.Arrays;
+
+final class WildcardTypeImpl implements java.lang.reflect.WildcardType {
+    private static final java.lang.reflect.Type[] NO_UPPER_BOUND = new java.lang.reflect.Type[]{Object.class};
+    private static final java.lang.reflect.Type[] NO_LOWER_BOUND = new java.lang.reflect.Type[0];
+    private static final java.lang.reflect.WildcardType UNBOUNDED = new WildcardTypeImpl(NO_UPPER_BOUND, NO_LOWER_BOUND);
+
+    static java.lang.reflect.WildcardType unbounded() {
+        return UNBOUNDED;
+    }
+
+    static java.lang.reflect.WildcardType withUpperBound(java.lang.reflect.Type type) {
+        return new WildcardTypeImpl(new java.lang.reflect.Type[]{type}, NO_LOWER_BOUND);
+    }
+
+    static java.lang.reflect.WildcardType withLowerBound(java.lang.reflect.Type type) {
+        return new WildcardTypeImpl(NO_UPPER_BOUND, new java.lang.reflect.Type[]{type});
+    }
+
+    private final java.lang.reflect.Type[] upperBounds;
+    private final java.lang.reflect.Type[] lowerBounds;
+
+    private WildcardTypeImpl(java.lang.reflect.Type[] upperBounds, java.lang.reflect.Type[] lowerBounds) {
+        this.upperBounds = upperBounds;
+        this.lowerBounds = lowerBounds;
+    }
+
+    @Override
+    public java.lang.reflect.Type[] getUpperBounds() {
+        return upperBounds;
+    }
+
+    @Override
+    public java.lang.reflect.Type[] getLowerBounds() {
+        return lowerBounds;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        } else if (o instanceof java.lang.reflect.WildcardType) {
+            java.lang.reflect.WildcardType that = (java.lang.reflect.WildcardType) o;
+            return Arrays.equals(upperBounds, that.getUpperBounds())
+                    && Arrays.equals(lowerBounds, that.getLowerBounds());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Arrays.hashCode(lowerBounds) ^ Arrays.hashCode(upperBounds);
+    }
+
+    @Override
+    public String toString() {
+        boolean noUpperBound = Arrays.equals(upperBounds, NO_UPPER_BOUND);
+        boolean noLowerBound = Arrays.equals(lowerBounds, NO_LOWER_BOUND);
+
+        if (noUpperBound && noLowerBound) {
+            return "?";
+        } else if (noUpperBound) {
+            return "? super " + lowerBounds[0];
+        } else if (noLowerBound) {
+            return "? extends " + upperBounds[0];
+        } else {
+            // should never happen
+            return "? extends " + upperBounds[0] + " super " + lowerBounds[0];
+        }
+    }
+}

--- a/weld-lite-extension-translator/src/main/resources/META-INF/services/jakarta.enterprise.inject.build.compatible.spi.BuildServices
+++ b/weld-lite-extension-translator/src/main/resources/META-INF/services/jakarta.enterprise.inject.build.compatible.spi.BuildServices
@@ -1,0 +1,1 @@
+org.jboss.weld.lite.extension.translator.BuildServicesImpl


### PR DESCRIPTION
A draft of the PR needed to include support for build compatible extensions.
First commit is just adding the impl as-is from Ladislav's StillDI implementation.
Next ones are minor adjustments are integration into SE and Servlet in order to allow testing of TCKs via embedded container.

I will keep adding more modifications as there are multiple TODOs in the impl.
From the top of my head, we'll also need to:
* Change logging to jboss logging (which is what rest of Weld code uses)
* Remove any deprecated methods used in impl (ATM I know of `Class.newInstance()`)
* Use security actions for any operation with CL and possibly others place?
* ?? probably more things that I will update as I go...