### PR TITLE
Update Arq embedded container to version supporting Lite extensions.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <arquillian.version>1.7.0.Alpha10</arquillian.version>
         <arquillian.drone.version>2.5.2</arquillian.drone.version>
         <arquillian.graphene.version>2.3.2</arquillian.graphene.version>
-        <arquillian.weld.version>3.0.1.Final</arquillian.weld.version>
+        <arquillian.weld.version>3.0.2.Final</arquillian.weld.version>
         <arquillian.se.container.version>1.0.2.Final</arquillian.se.container.version>
         <arquillian.tomcat.version>1.2.0.Alpha1</arquillian.tomcat.version>
         <arquillian.jetty.version>1.0.0.CR3</arquillian.jetty.version>


### PR DESCRIPTION
This version of Arq. container already supports CDI Lite extension execution through portable extension.