### PR TITLE
Update CI to run on JDK 11 and 17.

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -87,8 +87,8 @@ jobs:
               java-version: 11,
           }
           - {
-            name: "16",
-            java-version: 16,
+            name: "17",
+            java-version: 17,
           }
     steps:
       - uses: actions/checkout@v2
@@ -152,8 +152,8 @@ jobs:
               java-version: 11,
           }
           - {
-            name: "16",
-            java-version: 16,
+            name: "17",
+            java-version: 17,
           }
     steps:
       - uses: actions/checkout@v2
@@ -215,8 +215,8 @@ jobs:
               java-version: 11,
           }
           - {
-            name: "16",
-            java-version: 16,
+            name: "17",
+            java-version: 17,
           }
     steps:
       - uses: actions/checkout@v2
@@ -314,8 +314,8 @@ jobs:
               java-version: 11,
           }
           - {
-            name: "16",
-            java-version: 16,
+            name: "17",
+            java-version: 17,
           }
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Since EE 10 cares about LTS Java versions, we should adapt the CI to do the same - we need to test with JDK 11 and 17.