### PR TITLE
WELD-2704 Apply the change about Class.getPackage() to ProxyFactory.createProxyClass().

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -486,7 +486,7 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
 
         ProtectionDomain domain = AccessController.doPrivileged(new GetProtectionDomainAction(proxiedBeanType));
 
-        if (proxiedBeanType.getPackage() == null || proxiedBeanType.equals(Object.class)) {
+        if (proxiedBeanType.getPackage() == null || proxiedBeanType.getPackage().getName().isEmpty() || proxiedBeanType.equals(Object.class)) {
             domain = ProxyFactory.class.getProtectionDomain();
         } else if (System.getSecurityManager() != null) {
             ProtectionDomainCache cache = Container.instance(contextId).services().get(ProtectionDomainCache.class);


### PR DESCRIPTION
* Related to https://github.com/weld/core/pull/2264  

With JDK 11, Class.getPackage no longer returns null for classes in default packages.   
The following conditional branch also uses Class.getPackage() to determine the ProtectionDomain, so it is necessary to apply the above fix.  
https://github.com/weld/core/blob/f504fdf1cfc45a98d01c35e9ec294ec6ffa42ec9/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java#L489-L490