### PR TITLE
Added support to read beans.xml and Jandex-Index from JRT-images

### DIFF
--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DefaultBeanArchiveScanner.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/DefaultBeanArchiveScanner.java
@@ -21,6 +21,7 @@ import static org.jboss.weld.environment.util.URLUtils.PROCOTOL_FILE;
 import static org.jboss.weld.environment.util.URLUtils.PROCOTOL_HTTP;
 import static org.jboss.weld.environment.util.URLUtils.PROCOTOL_HTTPS;
 import static org.jboss.weld.environment.util.URLUtils.PROCOTOL_JAR;
+import static org.jboss.weld.environment.util.URLUtils.PROCOTOL_JRT;
 import static org.jboss.weld.environment.util.URLUtils.PROTOCOL_FILE_PART;
 import static org.jboss.weld.environment.util.URLUtils.PROTOCOL_WAR_PART;
 
@@ -113,6 +114,9 @@ public class DefaultBeanArchiveScanner extends AbstractBeanArchiveScanner {
                 ref = ref.substring(0, ref.lastIndexOf(JAR_URL_SEPARATOR));
             }
             ref = getBeanArchiveReferenceForJar(ref, url);
+        } else if (PROCOTOL_JRT.equals(url.getProtocol())) {
+            // Getting the reference of an url like "jrt:/weld.module.example/META-INF/beans.xml" (returns "jrt:/weld.module.example")
+            ref = url.toExternalForm().replaceAll("^(jrt:/[\\w.]+)/.*$", "$1");
         } else {
             logger.infov("Unable to adapt URL: {0}, using its external form instead", url);
             ref = url.toExternalForm();

--- a/environments/common/src/main/java/org/jboss/weld/environment/util/URLUtils.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/util/URLUtils.java
@@ -26,10 +26,12 @@ public class URLUtils {
 
     public static final String PROCOTOL_FILE = "file";
     public static final String PROCOTOL_JAR = "jar";
+    public static final String PROCOTOL_JRT = "jrt";
     public static final String PROCOTOL_WAR = "war";
     public static final String PROCOTOL_HTTP = "http";
     public static final String PROCOTOL_HTTPS = "https";
     public static final String PROTOCOL_FILE_PART = PROCOTOL_FILE + ":";
+    public static final String PROTOCOL_JRT_PART = PROCOTOL_JRT + ":/";
     public static final String PROTOCOL_WAR_PART = PROCOTOL_WAR + ":";
     // according to JarURLConnection api doc, the separator is "!/"
     public static final String JAR_URL_SEPARATOR = "!/";


### PR DESCRIPTION
JRT-images are modular run-time images from JEP 220.