### PR TITLE
Propagate causes in Lite Extension Translator

### DIFF
--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationInfoImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/AnnotationInfoImpl.java
@@ -45,7 +45,7 @@ class AnnotationInfoImpl implements AnnotationInfo {
         } catch (NoSuchMethodException e) {
             return null;
         } catch (ReflectiveOperationException e) {
-            throw LiteExtensionTranslatorLogger.LOG.unableToAccessAnnotationMembers(annotation, e.toString());
+            throw LiteExtensionTranslatorLogger.LOG.unableToAccessAnnotationMembers(annotation, e.toString(), e);
         }
     }
 
@@ -62,7 +62,7 @@ class AnnotationInfoImpl implements AnnotationInfo {
             }
             return result;
         } catch (ReflectiveOperationException e) {
-            throw LiteExtensionTranslatorLogger.LOG.unableToAccessAnnotationMembers(annotation, e.toString());
+            throw LiteExtensionTranslatorLogger.LOG.unableToAccessAnnotationMembers(annotation, e.toString(), e);
         }
     }
 

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionInvoker.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionInvoker.java
@@ -7,6 +7,7 @@ import jakarta.interceptor.Interceptor;
 import org.jboss.weld.lite.extension.translator.logging.LiteExtensionTranslatorLogger;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -33,8 +34,10 @@ class ExtensionInvoker {
                 BuildCompatibleExtension extensionInstance = SecurityActions.getConstructor(extensionClass).newInstance();
                 extensionClasses.put(extensionClass.getName(), extensionClass);
                 extensionClassInstances.put(extensionClass, extensionInstance);
+            } catch (InvocationTargetException e) {
+                throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(extensionClass, e.getCause().toString(), e);
             } catch (ReflectiveOperationException e) {
-                throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(extensionClass, e.toString());
+                throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(extensionClass, e.toString(), e);
             }
 
         }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseBase.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseBase.java
@@ -4,6 +4,7 @@ import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.enterprise.inject.spi.DeploymentException;
 import org.jboss.weld.lite.extension.translator.logging.LiteExtensionTranslatorLogger;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -31,9 +32,11 @@ abstract class ExtensionPhaseBase {
                 runExtensionMethod(method);
             } catch (DefinitionException | DeploymentException e) {
                 throw e;
+            } catch (InvocationTargetException e) {
+                throw LiteExtensionTranslatorLogger.LOG.problemExecutingExtensionMethod(method, phase, e.getCause().toString(), e);
             } catch (Exception e) {
                 // we treat every other error as deployment error
-                throw LiteExtensionTranslatorLogger.LOG.problemExecutingExtensionMethod(method, phase, e.toString());
+                throw LiteExtensionTranslatorLogger.LOG.problemExecutingExtensionMethod(method, phase, e.toString(), e);
 
             }
         }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancement.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseEnhancement.java
@@ -3,6 +3,7 @@ package org.jboss.weld.lite.extension.translator;
 import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
 import org.jboss.weld.lite.extension.translator.logging.LiteExtensionTranslatorLogger;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -164,8 +165,10 @@ class ExtensionPhaseEnhancement extends ExtensionPhaseBase {
             for (List<Object> arguments : argumentsForAllInvocations) {
                 try {
                     util.callExtensionMethod(method, arguments);
+                } catch (InvocationTargetException e) {
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.getCause().toString(), e);
                 } catch (ReflectiveOperationException e) {
-                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString());
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString(), e);
                 }
             }
         };

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
@@ -3,6 +3,7 @@ package org.jboss.weld.lite.extension.translator;
 import jakarta.enterprise.inject.build.compatible.spi.Registration;
 import org.jboss.weld.lite.extension.translator.logging.LiteExtensionTranslatorLogger;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -66,8 +67,10 @@ class ExtensionPhaseRegistration extends ExtensionPhaseBase {
 
                 try {
                     util.callExtensionMethod(method, arguments);
+                } catch (InvocationTargetException e) {
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.getCause().toString(), e);
                 } catch (ReflectiveOperationException e) {
-                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString());
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString(), e);
                 }
             };
 
@@ -95,8 +98,10 @@ class ExtensionPhaseRegistration extends ExtensionPhaseBase {
 
                 try {
                     util.callExtensionMethod(method, arguments);
+                } catch (InvocationTargetException e) {
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.getCause().toString(), e);
                 } catch (ReflectiveOperationException e) {
-                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString());
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString(), e);
                 }
             };
 
@@ -119,8 +124,10 @@ class ExtensionPhaseRegistration extends ExtensionPhaseBase {
 
                 try {
                     util.callExtensionMethod(method, arguments);
+                } catch (InvocationTargetException e) {
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.getCause().toString(), e);
                 } catch (ReflectiveOperationException e) {
-                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString());
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInvokeExtensionMethod(method, arguments, e.toString(), e);
                 }
             };
 

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/LiteExtensionTranslator.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/LiteExtensionTranslator.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.inject.build.compatible.spi.SyntheticObserver;
 import org.jboss.weld.lite.extension.translator.logging.LiteExtensionTranslatorLogger;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -69,8 +70,10 @@ public class LiteExtensionTranslator implements jakarta.enterprise.inject.spi.Ex
             if (scopeAnnotation == null) {
                 try {
                     scopeAnnotation = SecurityActions.getConstructor(context.contextClass).newInstance().getScope();
+                } catch (InvocationTargetException e) {
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(context.contextClass, e.getCause().toString(), e);
                 } catch (ReflectiveOperationException e) {
-                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(context.contextClass, e.toString());
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(context.contextClass, e.toString(), e);
                 }
             }
 
@@ -129,8 +132,10 @@ public class LiteExtensionTranslator implements jakarta.enterprise.inject.spi.Ex
         for (Class<? extends jakarta.enterprise.context.spi.AlterableContext> contextClass : contextsToRegister) {
             try {
                 abd.addContext(SecurityActions.getConstructor(contextClass).newInstance());
+            } catch (InvocationTargetException e) {
+                throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(contextClass, e.getCause().toString(), e);
             } catch (ReflectiveOperationException e) {
-                throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(contextClass, e.toString());
+                throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(contextClass, e.toString(), e);
             }
         }
 
@@ -155,8 +160,10 @@ public class LiteExtensionTranslator implements jakarta.enterprise.inject.spi.Ex
                 try {
                     SyntheticBeanCreator creator = SecurityActions.getConstructor(syntheticBean.creatorClass).newInstance();
                     return creator.create(lookup, new ParametersImpl(syntheticBean.params));
+                } catch (InvocationTargetException e) {
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticBean.creatorClass, e.getCause().toString(), e);
                 } catch (ReflectiveOperationException e) {
-                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticBean.creatorClass, e.toString());
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticBean.creatorClass, e.toString(), e);
                 }
             });
             if (syntheticBean.disposerClass != null) {
@@ -164,8 +171,10 @@ public class LiteExtensionTranslator implements jakarta.enterprise.inject.spi.Ex
                     try {
                         SyntheticBeanDisposer disposer = SecurityActions.getConstructor(syntheticBean.disposerClass).newInstance();
                         disposer.dispose(object, lookup, new ParametersImpl(syntheticBean.params));
+                    } catch (InvocationTargetException e) {
+                        throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticBean.disposerClass, e.getCause().toString(), e);
                     } catch (ReflectiveOperationException e) {
-                        throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticBean.disposerClass, e.toString());
+                        throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticBean.disposerClass, e.toString(), e);
                     }
                 });
             }
@@ -184,8 +193,10 @@ public class LiteExtensionTranslator implements jakarta.enterprise.inject.spi.Ex
                 try {
                     SyntheticObserver observer = SecurityActions.getConstructor(syntheticObserver.observerClass).newInstance();
                     observer.observe(eventContext, new ParametersImpl(syntheticObserver.params));
+                } catch (InvocationTargetException e) {
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticObserver.observerClass, e.getCause().toString(), e);
                 } catch (ReflectiveOperationException e) {
-                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticObserver.observerClass, e.toString());
+                    throw LiteExtensionTranslatorLogger.LOG.unableToInstantiateObject(syntheticObserver.observerClass, e.toString(), e);
                 }
             });
         }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ScannedClassesImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ScannedClassesImpl.java
@@ -17,7 +17,7 @@ class ScannedClassesImpl implements ScannedClasses {
         try {
             bbd.addAnnotatedType(Class.forName(className, true, cl), className);
         } catch (ClassNotFoundException e) {
-            throw LiteExtensionTranslatorLogger.LOG.cannotLoadClassByName(className, e.toString());
+            throw LiteExtensionTranslatorLogger.LOG.cannotLoadClassByName(className, e.toString(), e);
         }
     }
 }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/logging/LiteExtensionTranslatorLogger.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/logging/LiteExtensionTranslatorLogger.java
@@ -19,6 +19,7 @@ package org.jboss.weld.lite.extension.translator.logging;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
@@ -38,7 +39,7 @@ public interface LiteExtensionTranslatorLogger extends BasicLogger {
     LiteExtensionTranslatorLogger LOG = Logger.getMessageLogger(LiteExtensionTranslatorLogger.class, Category.LITE_EXTENSION_TRANSLATOR.getName());
 
     @Message(id = 0, value = "Unable to instantiate object from class {0} via no-args constructor. The exception was: {1}", format = Message.Format.MESSAGE_FORMAT)
-    IllegalStateException unableToInstantiateObject(Class<?> classToInstantiate, String exception);
+    IllegalStateException unableToInstantiateObject(Class<?> classToInstantiate, String exception, @Cause Throwable cause);
 
     @Message(id = 1, value = "Unexpected extension method argument: {0}", format = Message.Format.MESSAGE_FORMAT)
     IllegalArgumentException unexpectedMethodArgument(Object argument);
@@ -63,10 +64,10 @@ public interface LiteExtensionTranslatorLogger extends BasicLogger {
     IllegalStateException unknownQueryParameter(Object query);
 
     @Message(id = 8, value = "Unable to invoke extension method {0} with arguments {1}. The exception was: {2}", format = Message.Format.MESSAGE_FORMAT)
-    IllegalStateException unableToInvokeExtensionMethod(Object method, Object arguments, String exception);
+    IllegalStateException unableToInvokeExtensionMethod(Object method, Object arguments, String exception, @Cause Exception cause);
 
     @Message(id = 9, value = "Unable to load class with name {0}. The exception was: {1}", format = Message.Format.MESSAGE_FORMAT)
-    IllegalStateException cannotLoadClassByName(Object className, String exception);
+    IllegalStateException cannotLoadClassByName(Object className, String exception, @Cause Throwable cause);
 
     @Message(id = 10, value = "Unrecognized parameter of type {0} declared in class {1}#{2}", format = Message.Format.MESSAGE_FORMAT)
     IllegalArgumentException invalidExtensionMethodParameterType(Object type, Object declaringClass, Object methodName);
@@ -81,7 +82,7 @@ public interface LiteExtensionTranslatorLogger extends BasicLogger {
     IllegalArgumentException kindNotEqual(Object kind, Object value);
 
     @Message(id = 14, value = "Unable to access annotation member(s) for annotation {0}. The exception was: {1}", format = Message.Format.MESSAGE_FORMAT)
-    DefinitionException unableToAccessAnnotationMembers(Object annotation, String exception);
+    DefinitionException unableToAccessAnnotationMembers(Object annotation, String exception, @Cause Throwable cause);
 
     @Message(id = 15, value = "Provided type {0} is illegal because it doesn't match an of known annotation member types.", format = Message.Format.MESSAGE_FORMAT)
     IllegalArgumentException illegalAnnotationMemberType(Object type);
@@ -92,6 +93,6 @@ public interface LiteExtensionTranslatorLogger extends BasicLogger {
     void annotationFactoryInstanceNotInitialized();
 
     @Message(id = 17, value = "There was a problem executing Build Compatible Extension method {0} during phase {1}. The exception was: {2}", format = Message.Format.MESSAGE_FORMAT)
-    DeploymentException problemExecutingExtensionMethod(Object method, Object phase, String exception);
+    DeploymentException problemExecutingExtensionMethod(Object method, Object phase, String exception, @Cause Throwable cause);
 
 }


### PR DESCRIPTION
Ensure that when we're wrapping an exception using the translation
logger, we retain the proper cause.

Also, if the cause is an InvocationTargetException, it won't have a
useful toString, so use the toString of its cause in the exception
message instead.

Fixes [WELD-2710](https://issues.redhat.com/browse/WELD-2710)