### PR TITLE
WELD-2717 Only fire Startup event right after Initialized(AppScoped) …

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldRuntime.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldRuntime.java
@@ -58,10 +58,10 @@ public class WeldRuntime {
 
     public void shutdown() {
         try {
-            // fire Shutdown event for all modules first
+            // fire Shutdown event for all non-web modules first
             Environment env = Container.getEnvironment();
             if (env != null && env.automaticallyHandleStartupShutdownEvents()) {
-                fireEventForAllModules(Shutdown.class, new Shutdown(), Any.Literal.INSTANCE);
+                fireEventForNonWebModules(Shutdown.class, new Shutdown(), Any.Literal.INSTANCE);
             }
             // The container must destroy all contexts.
             // For non-web modules, fire @BeforeDestroyed event

--- a/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/WeldStartup.java
@@ -576,10 +576,11 @@ public class WeldStartup {
             for (BeanDeploymentModule module : modules) {
                 if (!module.isWebModule()) {
                     module.fireEvent(Object.class, ContextEvent.APPLICATION_INITIALIZED, Initialized.Literal.APPLICATION);
-                }
-                // Fire Startup event for all modules if required
-                if (environment.automaticallyHandleStartupShutdownEvents()) {
-                    module.fireEvent(Startup.class, new Startup(), Any.Literal.INSTANCE);
+                    // Fire Startup event for all non-web modules if required
+                    // web modules have to be handled alongside @Initialized(AppScoped) fired there to make sure the ordering fits
+                    if (environment.automaticallyHandleStartupShutdownEvents()) {
+                        module.fireEvent(Startup.class, new Startup(), Any.Literal.INSTANCE);
+                    }
                 }
             }
         }


### PR DESCRIPTION
…event.

I have seen a failure on WFLY where, for a web module, the `@Initialized(AppScoped) event can happen *after* `Startup` which is against specification. Therefore, we should move the logic to always follow up on `@Initialized` firing.


CC @tevans78 since you reviewed the original PR.
I am fairly surprised the current release worked for you on Open Liberty, I'd expect a similar issue.
Could you verify this doesn't break anything for you, please?