### PR TITLE
WELD-2720 Introduce a null check before attempting to fire startup/sh…

### DIFF
--- a/modules/web/src/main/java/org/jboss/weld/module/web/servlet/HttpContextLifecycle.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/servlet/HttpContextLifecycle.java
@@ -150,7 +150,7 @@ public class HttpContextLifecycle implements Service {
         servletContextService.contextInitialized(ctx);
         fireEventForApplicationScope(ctx, Initialized.Literal.APPLICATION);
         Environment env = Container.getEnvironment();
-        if (env != null && env.automaticallyHandleStartupShutdownEvents()) {
+        if (module != null && env != null && env.automaticallyHandleStartupShutdownEvents()) {
             module.fireEvent(Startup.class, new Startup(), Any.Literal.INSTANCE);
         }
     }
@@ -158,7 +158,7 @@ public class HttpContextLifecycle implements Service {
     public void contextDestroyed(ServletContext ctx) {
         // firstly, fire Shutdown event
         Environment env = Container.getEnvironment();
-        if (env != null && env.automaticallyHandleStartupShutdownEvents()) {
+        if (module != null && env != null && env.automaticallyHandleStartupShutdownEvents()) {
             module.fireEvent(Shutdown.class, new Shutdown(), Any.Literal.INSTANCE);
         }
         // TODO WELD-2282 Firing these two right after each other does not really make sense


### PR DESCRIPTION
…utdown in servlet lifecycle

Related issue - https://issues.redhat.com/browse/WELD-2720
In most normal cases this won't happen but apparently there are some SE/servlet combinations that might lead to NPE.
Note that we already guard for `null` in another similar method - `fireEventForApplicationScope`. 