### PR TITLE
WELD-2721 Change AfterBeanDiscoveryImpl to correctly check the state …

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/AfterBeanDiscoveryImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/AfterBeanDiscoveryImpl.java
@@ -102,7 +102,9 @@ public class AfterBeanDiscoveryImpl extends AbstractBeanDiscoveryEvent implement
 
     @Override
     public <T> WeldBeanConfigurator<T> addBean() {
-        return addBean(getReceiver().getClass());
+        // null is only going to occur if the invocation is outside of OM in which case it will fail in the
+        // subsequent method inside checkWithinObserverNotification()
+        return addBean(getReceiver() != null ? getReceiver().getClass() : null);
     }
 
     /**


### PR DESCRIPTION
…of invocation before making assumptions about it


I have verified this with WFLY (which I am now trying to bring back to PR testing).