### PR TITLE
Updated weld-api dependency to 5.0.SP2

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <weld.api.bom.version>5.0.Final</weld.api.bom.version>
+        <weld.api.bom.version>5.0.SP2</weld.api.bom.version>
         <gpg.plugin.version>3.0.1</gpg.plugin.version>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>

--- a/environments/se/build/pom.xml
+++ b/environments/se/build/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-api</artifactId>
-            <version>${weld.api.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/environments/servlet/build/pom.xml
+++ b/environments/servlet/build/pom.xml
@@ -43,7 +43,6 @@
         <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-api</artifactId>
-            <version>${weld.api.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/modules/web/src/main/java/org/jboss/weld/module/web/HttpSessionBean.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/HttpSessionBean.java
@@ -25,8 +25,6 @@ import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpSession;
-import jakarta.servlet.http.HttpSessionContext;
-
 import org.jboss.weld.bean.builtin.AbstractStaticallyDecorableBuiltInBean;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.module.web.logging.ServletLogger;
@@ -40,7 +38,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  * @author Jozef Hartinger
  * @author Martin Kouba
  */
-@SuppressWarnings("deprecation")
 public class HttpSessionBean extends AbstractStaticallyDecorableBuiltInBean<HttpSession> {
 
     public HttpSessionBean(BeanManagerImpl manager) {
@@ -99,18 +96,8 @@ public class HttpSessionBean extends AbstractStaticallyDecorableBuiltInBean<Http
         }
 
         @Override
-        public HttpSessionContext getSessionContext() {
-            return session().getSessionContext();
-        }
-
-        @Override
         public Object getAttribute(String name) {
             return session().getAttribute(name);
-        }
-
-        @Override
-        public Object getValue(String name) {
-            return session().getValue(name);
         }
 
         @Override
@@ -119,28 +106,13 @@ public class HttpSessionBean extends AbstractStaticallyDecorableBuiltInBean<Http
         }
 
         @Override
-        public String[] getValueNames() {
-            return session().getValueNames();
-        }
-
-        @Override
         public void setAttribute(String name, Object value) {
             session().setAttribute(name, value);
         }
 
         @Override
-        public void putValue(String name, Object value) {
-            session().putValue(name, value);
-        }
-
-        @Override
         public void removeAttribute(String name) {
             session().removeAttribute(name);
-        }
-
-        @Override
-        public void removeValue(String name) {
-            session().removeValue(name);
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
         <shrinkwrap.resolver.version>3.1.4</shrinkwrap.resolver.version>
         <testng.version>7.4.0</testng.version>
-        <weld.api.version>5.0.Final</weld.api.version>
+        <weld.api.version>5.0.SP2</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>3.0.1.Final</wildfly.arquillian.version>
     </properties>

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/alternatives/ee/AlternativeHttpServletRequestProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/alternatives/ee/AlternativeHttpServletRequestProducer.java
@@ -33,6 +33,7 @@ import jakarta.interceptor.Interceptor;
 import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletConnection;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
@@ -178,11 +179,6 @@ public class AlternativeHttpServletRequestProducer {
 
             @Override
             public boolean isRequestedSessionIdFromURL() {
-                return false;
-            }
-
-            @Override
-            public boolean isRequestedSessionIdFromUrl() {
                 return false;
             }
 
@@ -337,11 +333,6 @@ public class AlternativeHttpServletRequestProducer {
             }
 
             @Override
-            public String getRealPath(String path) {
-                return null;
-            }
-
-            @Override
             public int getRemotePort() {
                 return 0;
             }
@@ -393,6 +384,21 @@ public class AlternativeHttpServletRequestProducer {
 
             @Override
             public DispatcherType getDispatcherType() {
+                return null;
+            }
+
+            @Override
+            public String getRequestId() {
+                return null;
+            }
+
+            @Override
+            public String getProtocolRequestId() {
+                return null;
+            }
+
+            @Override
+            public ServletConnection getServletConnection() {
                 return null;
             }
         };


### PR DESCRIPTION
weld-se-shaded contains old Jakarta EE APIs which fail TCK signature tests so I updated the dependency to the latest Weld API.
