### PR TITLE
WELD-2725 Add profile for lang model TCK execution on WFLY

### DIFF
--- a/lang-model-tck/pom.xml
+++ b/lang-model-tck/pom.xml
@@ -57,16 +57,118 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-weld-embedded</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-core-impl</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Weld Weld Arq. Container - embedded testing -->
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>!incontainer</name>
+                </property>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.jboss.arquillian.container</groupId>
+                    <artifactId>arquillian-weld-embedded</artifactId>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
+                            </systemProperties>
+                            <test>${test}</test>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!-- WildFly Managed -->
+        <profile>
+            <id>incontainer</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>incontainer</name>
+                    <value>true</value>
+                </property>
+            </activation>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-container-managed</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly.arquillian</groupId>
+                    <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+                    <scope>test</scope>
+                </dependency>
+                <!-- Due to exclusion on wildfly-arquillian-common, we need to add enricher manually for WFLY tests -->
+                <dependency>
+                    <groupId>org.jboss.arquillian.testenricher</groupId>
+                    <artifactId>arquillian-testenricher-cdi-jakarta</artifactId>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-enforcer-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>enforce-jboss-home-is-set</id>
+                                <goals>
+                                    <goal>enforce</goal>
+                                </goals>
+                                <configuration>
+                                    <rules>
+                                        <requireEnvironmentVariable>
+                                            <variableName>JBOSS_HOME</variableName>
+                                            <message>Environment variable "JBOSS_HOME" must be set in order to execute in-container tests. Please configure it so that it points to your WildFly installation.</message>
+                                        </requireEnvironmentVariable>
+                                    </rules>
+                                    <fail>true</fail>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <!-- jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name-->
+                            </systemPropertyVariables>
+                            <systemProperties>
+                                <arquillian.xml>wildfly-arquillian.xml</arquillian.xml>
+                                <jacoco.agent>${jacoco.agent}</jacoco.agent>
+                                <node.address>127.0.0.1</node.address>
+                                <additional.vm.args>${surefire.plugin.jdk17.args}</additional.vm.args>
+                                <additional.jboss.args>${additional.jboss.args}</additional.jboss.args>
+                            </systemProperties>
+                            <test>${test}</test>
+                            <parallel>none</parallel>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/lang-model-tck/src/test/java/org/jboss/weld/lang/model/tck/LangModelExtension.java
+++ b/lang-model-tck/src/test/java/org/jboss/weld/lang/model/tck/LangModelExtension.java
@@ -18,7 +18,9 @@
 package org.jboss.weld.lang.model.tck;
 
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Discovery;
 import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.ScannedClasses;
 import jakarta.enterprise.lang.model.declarations.ClassInfo;
 import org.jboss.cdi.lang.model.tck.LangModelVerifier;
 
@@ -30,5 +32,14 @@ public class LangModelExtension implements BuildCompatibleExtension {
     public void run(ClassInfo clazz) {
         ENHANCEMENT_INVOKED++;
         LangModelVerifier.verify(clazz);
+    }
+
+    /**
+     * {@link LangModelVerifier} doesn't have any bean defining annotation and wouldn't be discovered while usingg
+     * annotated discovery mode
+     */
+    @Discovery
+    public void addClass(ScannedClasses sc) {
+        sc.add(LangModelVerifier.class.getName());
     }
 }

--- a/lang-model-tck/src/test/java/org/jboss/weld/lang/model/tck/LangModelTckTest.java
+++ b/lang-model-tck/src/test/java/org/jboss/weld/lang/model/tck/LangModelTckTest.java
@@ -27,15 +27,14 @@ import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.impl.BeansXml;
-import org.jboss.weld.tests.util.Assert;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
  * <p>
- * Executes CDI TCK for language model used in CDI Lite, current setup requires discovery mode ALL plus adding
- * {@link LangModelVerifier} into the deployment to discover it as a bean. Alternatively, this could be added
- * synthetically inside {@link LangModelExtension}.
+ * Executes CDI TCK for language model used in CDI Lite.
+ * Current setup uses discovery mode ANNOTATED and registers {@link LangModelVerifier} as additional bean via extension.
  * </p>
  *
  * <p>
@@ -48,11 +47,12 @@ public class LangModelTckTest {
     @Deployment
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, LangModelTckTest.class.getSimpleName() + ".war")
-                // beans.xml with discovery mode "all"
-                .addAsWebInfResource(new BeansXml(BeanDiscoveryMode.ALL), "beans.xml")
+                // beans.xml with discovery mode "annotated"
+                .addAsWebInfResource(new BeansXml(BeanDiscoveryMode.ANNOTATED), "beans.xml")
                 .addAsServiceProvider(BuildCompatibleExtension.class, LangModelExtension.class)
-                // add this class into the deployment so that it's subject to discovery
-                .addClasses(LangModelVerifier.class);
+                .addPackage(LangModelTckTest.class.getPackage())
+                // LangModelVerifier and any classes it references need to be part of the deployment as well
+                .addPackage(LangModelVerifier.class.getPackage());
     }
 
     @Test

--- a/lang-model-tck/src/test/resources/wildfly-arquillian.xml
+++ b/lang-model-tck/src/test/resources/wildfly-arquillian.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7" />
+
+    <engine>
+        <!--property name="deploymentExportPath">target/</property-->
+    </engine>
+
+    <container qualifier="wildfly" default="true">
+        <configuration>
+            <!-- Standard setup should do the trick here -->
+            <property name="serverConfig">standalone-full.xml</property>
+            <!-- ARQ-649 workaround -->
+            <property name="outputToConsole">false</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="javaVmArguments">-Xms128m -Xmx768m ${additional.vm.args} ${jacoco.agent}</property>
+            <property name="jbossArguments">${additional.jboss.args}</property>
+            <property name="managementAddress">${node.address}</property>
+        </configuration>
+    </container>
+</arquillian>


### PR DESCRIPTION
Changes to how we execute lang model TCKs.

There are now profiles that allow for embedded and incontainer execution (with `-Dincontainer` just like in other modules).
I also slightly changed the deployment we use so that we can use `annotated` instead of `all` discovery mode.

I kept JMX protocol because otherwise I had issues executing the test against already running containers due to assertions not being enabled (no idea why?).