### PR TITLE
WELD-2643 BM#isQualifier(), avoid logging WARN message when it is not needed

### DIFF
--- a/impl/src/main/java/org/jboss/weld/metadata/cache/QualifierModel.java
+++ b/impl/src/main/java/org/jboss/weld/metadata/cache/QualifierModel.java
@@ -61,10 +61,14 @@ public class QualifierModel<T extends Annotation> extends AbstractBindingModel<T
     @Override
     protected void initValid(EnhancedAnnotation<T> annotatedAnnotation) {
         super.initValid(annotatedAnnotation);
-        for (EnhancedAnnotatedMethod<?, ?> annotatedMethod : annotatedAnnotation.getMembers()) {
-            if ((Reflections.isArrayType(annotatedMethod.getJavaClass()) || Annotation.class.isAssignableFrom(annotatedMethod.getJavaClass())) && !getNonBindingMembers().contains(annotatedMethod.slim())) {
-                MetadataLogger.LOG.nonBindingMemberType(annotatedMethod);
-                super.valid = false;
+        // The annotation either has @Qualifier or was registered via extension
+        // Only check annotation method in case the annotation itself is valid
+        if (isValid()) {
+            for (EnhancedAnnotatedMethod<?, ?> annotatedMethod : annotatedAnnotation.getMembers()) {
+                if ((Reflections.isArrayType(annotatedMethod.getJavaClass()) || Annotation.class.isAssignableFrom(annotatedMethod.getJavaClass())) && !getNonBindingMembers().contains(annotatedMethod.slim())) {
+                    MetadataLogger.LOG.nonBindingMemberType(annotatedMethod);
+                    super.valid = false;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR avoids logging WARN about non-binding member types for qualifiers which are invalid anyway since they don't have `@Qualifier` and weren't registered via an extension.

There is no test attached since the only difference is a log output (or rather, the absence of it) but I used `ManagerAnnotationTest` to test this in various scenarios.