### PR TITLE
WELD-2738 Bean type assignability for recursive generic types

### DIFF
--- a/impl/src/main/java/org/jboss/weld/resolution/AbstractAssignabilityRules.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/AbstractAssignabilityRules.java
@@ -54,7 +54,7 @@ public abstract class AbstractAssignabilityRules implements AssignabilityRules {
      * Standard Java covariant assignability rules are applied to all other types of bounds.
      * This is not explicitly mentioned in the specification but is implied.
      */
-    protected Type[] getUppermostTypeVariableBounds(TypeVariable<?> bound) {
+    static Type[] getUppermostTypeVariableBounds(TypeVariable<?> bound) {
         if (bound.getBounds()[0] instanceof TypeVariable<?>) {
             return getUppermostTypeVariableBounds((TypeVariable<?>) bound.getBounds()[0]);
         }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/DuplicateRecursion.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/DuplicateRecursion.java
@@ -1,0 +1,9 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+public class DuplicateRecursion {
+    interface FooBar<T extends FooBar<?, U>, U extends Comparable<U>> {
+    }
+
+    static class FooBarImpl implements FooBar<FooBarImpl, String> {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/MutualRecursion.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/MutualRecursion.java
@@ -1,0 +1,21 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+public class MutualRecursion {
+    interface Graph<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Edge<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    interface Node<G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> {
+    }
+
+    static class Map implements Graph<Map, Route, City> {
+    }
+
+    static class Route implements Edge<Map, Route, City> {
+    }
+
+    static class City implements Node<Map, Route, City> {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Dependent
+public class RecursiveGenericProducer {
+
+    @Produces
+    @Dependent
+    <T extends Comparable<T>> List<T> produce() {
+        return new ArrayList<T>();
+    }
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericProducer.java
@@ -2,6 +2,10 @@ package org.jboss.weld.tests.assignability.recursiveGenerics;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.Produces;
+import org.jboss.weld.tests.assignability.recursiveGenerics.DuplicateRecursion.FooBar;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Edge;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Graph;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Node;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,4 +19,15 @@ public class RecursiveGenericProducer {
         return new ArrayList<T>();
     }
 
+    @Produces
+    @Dependent
+    <T extends FooBar<T, U>, U extends Comparable<U>> FooBar<T, U> produceFooBar() {
+        return null;
+    }
+
+    @Produces
+    @Dependent
+    <G extends Graph<G, E, N>, E extends Edge<G, E, N>, N extends Node<G, E, N>> Graph<G, E, N> produceGraph() {
+        return null;
+    }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
@@ -1,0 +1,47 @@
+package org.jboss.weld.tests.assignability.recursiveGenerics;
+
+import static org.junit.Assert.assertEquals;
+
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.util.TypeLiteral;
+import jakarta.inject.Inject;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.Set;
+
+/**
+ *
+ */
+@SuppressWarnings("serial")
+@RunWith(Arquillian.class)
+public class RecursiveGenericsAssignabilityTest {
+
+    @Inject
+    private BeanManager beanManager;
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(RecursiveGenericsAssignabilityTest.class))
+            .addPackage(RecursiveGenericsAssignabilityTest.class.getPackage());
+    }
+
+    @Test
+    public <T extends Comparable<T>> void testResursiveGenericAssignability() {
+        // @Inject List<String> should work
+        Set<Bean<?>> beans = beanManager.getBeans(new TypeLiteral<List<String>>(){}.getType());
+        assertEquals(1, beans.size());
+
+        // @Inject List<Object> should NOT work, Object is not Comparable
+        beans = beanManager.getBeans(new TypeLiteral<List<Object>>(){}.getType());
+        assertEquals(0, beans.size());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/assignability/recursiveGenerics/RecursiveGenericsAssignabilityTest.java
@@ -12,15 +12,18 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.assignability.recursiveGenerics.DuplicateRecursion.FooBar;
+import org.jboss.weld.tests.assignability.recursiveGenerics.DuplicateRecursion.FooBarImpl;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.City;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Graph;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Map;
+import org.jboss.weld.tests.assignability.recursiveGenerics.MutualRecursion.Route;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.List;
 import java.util.Set;
 
-/**
- *
- */
 @SuppressWarnings("serial")
 @RunWith(Arquillian.class)
 public class RecursiveGenericsAssignabilityTest {
@@ -35,7 +38,7 @@ public class RecursiveGenericsAssignabilityTest {
     }
 
     @Test
-    public <T extends Comparable<T>> void testResursiveGenericAssignability() {
+    public void testResursiveGenericAssignability() {
         // @Inject List<String> should work
         Set<Bean<?>> beans = beanManager.getBeans(new TypeLiteral<List<String>>(){}.getType());
         assertEquals(1, beans.size());
@@ -43,5 +46,13 @@ public class RecursiveGenericsAssignabilityTest {
         // @Inject List<Object> should NOT work, Object is not Comparable
         beans = beanManager.getBeans(new TypeLiteral<List<Object>>(){}.getType());
         assertEquals(0, beans.size());
+
+        // @Inject FooBar<FooBarImpl, String>> should work
+        beans = beanManager.getBeans(new TypeLiteral<FooBar<FooBarImpl, String>>(){}.getType());
+        assertEquals(1, beans.size());
+
+        // @Inject Graph<Map, Route, City>> should work
+        beans = beanManager.getBeans(new TypeLiteral<Graph<Map, Route, City>>(){}.getType());
+        assertEquals(1, beans.size());
     }
 }


### PR DESCRIPTION
A draft of how to handle recursive generic bean types.

The approach lies in special casing this scenario once we get to covariant type assignability checks.
We need to detect the recursion and then we assume assignability.