### PR TITLE
WELD-2741 Detecting a passivating non-normal scope should lead to deployment exception instead of definition

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/AbstractDefinitionContainerEvent.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/AbstractDefinitionContainerEvent.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.bootstrap.events;
 
 import org.jboss.weld.exceptions.DefinitionException;
+import org.jboss.weld.exceptions.DeploymentException;
 import org.jboss.weld.logging.BootstrapLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 import org.jboss.weld.util.Preconditions;
@@ -43,7 +44,12 @@ public abstract class AbstractDefinitionContainerEvent extends AbstractContainer
     public void fire() {
         super.fire();
         if (!getErrors().isEmpty()) {
-            throw new DefinitionException(getErrors());
+            if (getErrors().size() == 1 && getErrors().get(0) instanceof DeploymentException) {
+                // if the throwable was deployment exception, rethrow that
+                    throw (DeploymentException) getErrors().get(0);
+            } else {
+                throw new DefinitionException(getErrors());
+            }
         }
     }
 }

--- a/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BootstrapLogger.java
@@ -103,7 +103,7 @@ public interface BootstrapLogger extends WeldLogger {
     IllegalStateException unspecifiedRequiredService(Object service, Object target);
 
     @Message(id = 118, value = "Only normal scopes can be passivating. Scope {0}", format = Format.MESSAGE_FORMAT)
-    DefinitionException passivatingNonNormalScopeIllegal(Object param1);
+    DeploymentException passivatingNonNormalScopeIllegal(Object param1);
 
     @LogMessage(level = Level.INFO)
     @Message(id = 119, value = "Not generating any bean definitions from {0} because of underlying class loading error: Type {1} not found.  If this is unexpected, enable DEBUG logging to see the full error.", format = Format.MESSAGE_FORMAT)

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <!-- Might be used to override the version declared in weld-parent -->
         <!-- build.config.version>9</build.config.version-->
         <!-- Version of the CDI 4.x release TCK -->
-        <cdi.tck-4-0.version>4.0.7</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.9</cdi.tck-4-0.version>
         <classfilewriter.version>1.2.5.Final</classfilewriter.version>
         <spotbugs-maven-plugin.version>4.7.2.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.7.2</spotbugs-annotations-version>


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WELD-2741

Also bumps the TCK version.

The TCK test asserting this is currently excluded but was already changed to expect this behavior, see https://github.com/jakartaee/cdi-tck/issues/431 and [code](https://github.com/jakartaee/cdi-tck/blob/master/impl/src/main/java/org/jboss/cdi/tck/tests/full/extensions/lifecycle/bbd/broken/passivatingScope/AddingPassivatingScopeTest.java)