### PR TITLE
WELD-2742 Avoid firing PIT multiple times if previously specialized bean was re-enabled

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployer.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/BeanDeployer.java
@@ -317,6 +317,13 @@ public class BeanDeployer extends AbstractBeanDeployer<BeanDeployerEnvironment> 
         processBeanAttributes(beans);
     }
 
+    private void processSpecializingBeans(Iterable<? extends AbstractBean<?, ?>> previouslySpecializedBeans) {
+        // For a set of previously specialized beans that are re-enabled, we need to fire PP followed by PBA
+        // Note that this is intentionally different from processBeans() method which also contains PIT event
+        processProducerEvents(previouslySpecializedBeans);
+        processBeanAttributes(previouslySpecializedBeans);
+    }
+
     protected void processBeanAttributes(Iterable<? extends AbstractBean<?, ?>> beans) {
         if (!containerLifecycleEvents.isProcessBeanAttributesObserved()) {
             return;
@@ -344,7 +351,7 @@ public class BeanDeployer extends AbstractBeanDeployer<BeanDeployerEnvironment> 
             getEnvironment().vetoBean(bean);
         }
         // if a specializing bean was vetoed, let's process the specializing bean now
-        processBeans(previouslySpecializedBeans);
+        processSpecializingBeans(previouslySpecializedBeans);
     }
 
     public void createProducersAndObservers() {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VerifyingExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VerifyingExtension.java
@@ -23,12 +23,14 @@ import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.BeanAttributes;
 import jakarta.enterprise.inject.spi.Extension;
 import jakarta.enterprise.inject.spi.ProcessBeanAttributes;
+import jakarta.enterprise.inject.spi.ProcessInjectionTarget;
 
 public class VerifyingExtension implements Extension {
 
     private BeanAttributes<Alpha> alpha;
     private BeanAttributes<Bravo> bravo;
     private BeanAttributes<Charlie> charlie;
+    private int bravoPitInvocations = 0;
 
     public void alpha(@Observes ProcessBeanAttributes<Alpha> event) {
         Set<Type> types = event.getBeanAttributes().getTypes();
@@ -50,6 +52,10 @@ public class VerifyingExtension implements Extension {
         }
     }
 
+    public void pitBravo(@Observes ProcessInjectionTarget<Bravo> bravoPit) {
+        bravoPitInvocations++;
+    }
+
     public BeanAttributes<Alpha> getAlpha() {
         return alpha;
     }
@@ -60,5 +66,9 @@ public class VerifyingExtension implements Extension {
 
     public BeanAttributes<Charlie> getCharlie() {
         return charlie;
+    }
+
+    public int getBravoPitInvocations() {
+        return bravoPitInvocations;
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VetoTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/extensions/lifecycle/processBeanAttributes/specialization/VetoTest.java
@@ -63,5 +63,8 @@ public class VetoTest {
         assertNull(extension.getAlpha());
         assertNotNull(extension.getBravo());
         assertNotNull(extension.getCharlie());
+
+        // verify that PIT<Bravo> is only fired once even during specialization, see WELD-2742
+        assertEquals(1, extension.getBravoPitInvocations());
     }
 }


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WELD-2742

Relevant CDI spec part - https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#bean_discovery_steps_full
PIT should be fired once and regardless of whether the bean is enabled or not whereas PP and PBA are conditional and only fired for enabled beans.

I've altered an existing test so that it captures how many times we fire `PIT<Bravo>`.
Before the change, this was twice (we re-fired PIT for each re-enabled bean), now it is correctly only once.