### PR TITLE
Add relaxed mode testing into CI runs

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -201,6 +201,78 @@ jobs:
           name: server-log-cdi-tck-jdk${{matrix.java.name}}
           path: 'server-log.tgz'
 
+  # relaxed mode, w/ and w/o Wildfly, single JDK version
+  relaxed-mode-test:
+    name: "Relaxed mode testing - JDK ${{matrix.java.name}}"
+    runs-on: ubuntu-latest
+    needs: build-jdk11
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - { name: "11",
+              java-version: 11,
+          }
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK ${{ matrix.java.name }}
+        uses: actions/setup-java@v1.4.3
+        with:
+          java-version: ${{ matrix.java.java-version }}
+
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v1
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Download Patched WildFly
+        uses: actions/download-artifact@v1
+        with:
+          name: wildfly-patched-zip
+          path: .
+      - name: Extract WildFly
+        run: unzip wildfly.zip
+      - name: Build with Maven w/ WildFly
+        run: |
+          JBOSS_HOME=`pwd`'/wildfly'
+          export JBOSS_HOME=`echo $JBOSS_HOME`
+          mvn clean verify -Dincontainer -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dcdi.tck.suite.xml.file=src/test/tck/tck-tests-web.xml -Dadditional.vm.args="-Dorg.jboss.weld.construction.relaxed=true" -f jboss-tck-runner/pom.xml
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: |
+          find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+          find . -name 'server.log' -type f | tar -czf server-log.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-cdi-tck-jdk${{matrix.java.name}}-incontainer-relaxed
+          path: 'test-reports.tgz'
+      - name: Upload server log artifact (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: server-log-cdi-tck-jdk${{matrix.java.name}}
+          path: 'server-log.tgz'
+      - name: Build with Maven, no WildFly
+        run: |
+          mvn clean verify -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dcdi.tck.suite.xml.file=src/test/tck/tck-tests.xml -Dorg.jboss.weld.construction.relaxed=true
+      - name: Prepare failure archive (if maven failed)
+        if: failure()
+        shell: bash
+        run: find . -name '*-reports' -type d | tar -czf test-reports.tgz -T -
+      - name: Upload failure Archive (if maven failed)
+        uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: test-reports-cdi-tck-jdk${{matrix.java.name}}-relaxed
+          path: 'test-reports.tgz'
+
   # Weld no-container tests, includes junit, Weld SE tests plus CDI TCKs and integration tests that don't require EE container
   no-container-tests:
     name: "Weld Tests w/o Container - JDK ${{matrix.java.name}}"

--- a/jboss-tck-runner/pom.xml
+++ b/jboss-tck-runner/pom.xml
@@ -293,6 +293,9 @@
                     <name>!incontainer</name>
                 </property>
             </activation>
+            <properties>
+                <cdi.tck.suite.xml.file>target/suites/tck-core-suite.xml</cdi.tck.suite.xml.file>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.jboss.arquillian.container</groupId>
@@ -349,7 +352,7 @@
                                 <argLine>${travis.surefire.argLine}</argLine>
                             </systemPropertyVariables>
                             <suiteXmlFiles>
-                                <suiteXmlFile>target/suites/tck-core-suite.xml</suiteXmlFile>
+                                <suiteXmlFile>${cdi.tck.suite.xml.file}</suiteXmlFile>
                             </suiteXmlFiles>
                         </configuration>
                     </plugin>
@@ -369,6 +372,7 @@
             </activation>
             <properties>
                 <excluded.groups>se</excluded.groups>
+                <cdi.tck.suite.xml.file>target/suites/tck-web-suite.xml</cdi.tck.suite.xml.file>
             </properties>
             <dependencies>
                 <dependency>
@@ -524,7 +528,7 @@
                                 </additional.vm.args>
                             </systemProperties>
                             <suiteXmlFiles>
-                                <suiteXmlFile>target/suites/tck-web-suite.xml</suiteXmlFile>
+                                <suiteXmlFile>${cdi.tck.suite.xml.file}</suiteXmlFile>
                             </suiteXmlFiles>
                         </configuration>
                     </plugin>
@@ -541,6 +545,9 @@
                     <value>se</value>
                 </property>
             </activation>
+            <properties>
+                <cdi.tck.suite.xml.file>target/suites/tck-core-suite.xml</cdi.tck.suite.xml.file>
+            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.wildfly.arquillian</groupId>
@@ -596,7 +603,7 @@
                                 <libPath>${project.build.outputDirectory}</libPath>
                             </systemPropertyVariables>
                             <suiteXmlFiles>
-                                <suiteXmlFile>target/suites/tck-core-suite.xml</suiteXmlFile>
+                                <suiteXmlFile>${cdi.tck.suite.xml.file}</suiteXmlFile>
                             </suiteXmlFiles>
                         </configuration>
                     </plugin>

--- a/jboss-tck-runner/src/test/tck/tck-tests-web.xml
+++ b/jboss-tck-runner/src/test/tck/tck-tests-web.xml
@@ -1,0 +1,45 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
+<!-- CDI TCK TestNG configuration for Weld -->
+<!-- Used mainly for WeldMethodInterceptor in combination with relaxed construction mode -->
+<!-- This version is for the web profile of TCKs (with EJB tests and other EE deps) -->
+<suite name="Weld / JBoss AS run of CDI TCK" verbose="0" configfailurepolicy="continue">
+
+    <listeners>
+        <listener class-name="org.jboss.cdi.tck.impl.testng.ConfigurationLoggingListener"/>
+        <listener class-name="org.jboss.weld.tck.WeldMethodInterceptor"/>
+        <listener class-name="org.jboss.cdi.tck.impl.testng.ProgressLoggingTestListener"/>
+        <!-- The default JUnit XML reporter is disabled -->
+        <listener class-name="org.testng.reporters.SuiteHTMLReporter"/>
+        <listener class-name="org.testng.reporters.FailedReporter"/>
+        <listener class-name="org.testng.reporters.XMLReporter"/>
+        <listener class-name="org.testng.reporters.EmailableReporter"/>
+        <listener class-name="org.testng.reporters.TestHTMLReporter" />
+    </listeners>
+
+    <test name="CDI TCK">
+
+        <packages>
+            <package name="org.jboss.cdi.tck.tests.*" />
+            <package name="org.jboss.cdi.tck.interceptors.tests.*" />
+        </packages>
+
+        <classes>
+
+            <!-- Issues in the spec -->
+
+            <!-- Issues in the TCK -->
+            <!-- CDITCK-597; test is only part of web profile of TCK and excluded there as well -->
+            <class name="org.jboss.cdi.tck.tests.deployment.packaging.ejb.EJBJarDeploymentTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+
+            <!-- Issues in Weld (the RI) -->
+
+            <!-- Issues in WildFly -->
+
+        </classes>
+    </test>
+
+</suite>

--- a/jboss-tck-runner/src/test/tck/tck-tests.xml
+++ b/jboss-tck-runner/src/test/tck/tck-tests.xml
@@ -1,5 +1,7 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 <!-- CDI TCK TestNG configuration for Weld -->
+<!-- Used mainly for WeldMethodInterceptor in combination with relaxed construction mode -->
+<!-- This version is for the no-container TCKs (no EJB tests and other EE deps) -->
 <suite name="Weld / JBoss AS run of CDI TCK" verbose="0" configfailurepolicy="continue">
 
     <listeners>

--- a/pom.xml
+++ b/pom.xml
@@ -60,10 +60,12 @@
         <arquillian.tomcat.version>1.2.0.Final</arquillian.tomcat.version>
         <arquillian.jetty.version>1.0.0.Final</arquillian.jetty.version>
         <atinject.tck.version>2.0.1</atinject.tck.version>
-        <!-- Might be used to override the version declared in weld-parent -->
-        <!-- build.config.version>9</build.config.version-->
         <!-- Version of the CDI 4.x release TCK -->
         <cdi.tck-4-0.version>4.0.9</cdi.tck-4-0.version>
+        <!-- By default, each mvn profile uses corresponding file from TCK repo, see jboss-tck-runner/pom.xml -->
+        <!-- We can also use our own file, needed for relaxed mode testing (see WeldMethodInterceptor) -->
+        <!-- Our variant is under src/test/tck/tck-tests.xml -->
+        <cdi.tck.suite.xml.file></cdi.tck.suite.xml.file>
         <classfilewriter.version>1.2.5.Final</classfilewriter.version>
         <spotbugs-maven-plugin.version>4.7.2.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.7.2</spotbugs-annotations-version>


### PR DESCRIPTION
Introduce POM property to be able to switch TCK suite XML file.

Introduce a separate XML file for TCKs with web profile and without it.
This is because an XML file with exclusion not present in given TCK profile results in an error (there are two such files already in the CDI TCK anyway).

Add relaxed mode testing into CI - this isn't a complete matrix. Inatead, it is a TCK run against WFLY and a full run of our TS w/o container.