### PR TITLE
WELD-2744 CFW update and needed changes to keep operating correctly on JDK 17+

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/DummyClassFactoryImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/DummyClassFactoryImpl.java
@@ -1,0 +1,28 @@
+package org.jboss.weld.bean.proxy;
+
+import org.jboss.classfilewriter.ClassFactory;
+import org.jboss.weld.bean.proxy.util.WeldDefaultProxyServices;
+
+import java.security.ProtectionDomain;
+
+/**
+ * A dummy implementation which has only one purpose - to avoid instantiating {@code DefaultClassFactory.INSTANCE}.
+ * The sole method in this class is never used as we define classes using different means that further vary
+ * between in-container (such as WildFly) and SE setups.
+ * <p>
+ * See {@link WeldDefaultProxyServices#defineClass(Class, String, byte[], int, int)} for details on how we define
+ * classes.
+ */
+class DummyClassFactoryImpl implements ClassFactory {
+
+    private DummyClassFactoryImpl() {
+    }
+
+    // final so that there's only one instance that's being referenced from anywhere
+    static final DummyClassFactoryImpl INSTANCE = new DummyClassFactoryImpl();
+
+    @Override
+    public Class<?> defineClass(ClassLoader loader, String name, byte[] b, int off, int len, ProtectionDomain protectionDomain) throws ClassFormatError {
+        throw new UnsupportedOperationException("DummyClasFactoryImpl should not be used to define classes");
+    }
+}

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -499,7 +499,10 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
 
     private ClassFile newClassFile(String name, int accessFlags, String superclass, String... interfaces) {
         try {
-            return new ClassFile(name, accessFlags, superclass, interfaces);
+            // We need to use a (non-deprecated) method that avoids instantiating DefaultClassFactory.INSTANCE
+            // If that happens, we will have module accessibility issues and the need to use --add-opens clausules
+            // NOTE: the CL and ClassFactory are never really used to define the class, see WeldDefaultProxyServices
+            return new ClassFile(name, accessFlags, superclass, ProxyFactory.class.getClassLoader(), DummyClassFactoryImpl.INSTANCE, interfaces);
         } catch (Exception e) {
             throw BeanLogger.LOG.unableToCreateClassFile(name, e.getCause());
         }

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/util/WeldDefaultProxyServices.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/util/WeldDefaultProxyServices.java
@@ -46,7 +46,7 @@ public class WeldDefaultProxyServices implements ProxyServices {
         ClassLoader originalLoader = originalClass.getClassLoader();
         if (originalLoader == null) {
             originalLoader = Thread.currentThread().getContextClassLoader();
-            // is it's still null we cannot solve this issue and we need to throw an exception
+            // if it's still null we cannot solve this issue, and we need to throw an exception
             if (originalLoader == null) {
                 throw BeanLogger.LOG.cannotDetermineClassLoader(className, originalClass);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <!-- We can also use our own file, needed for relaxed mode testing (see WeldMethodInterceptor) -->
         <!-- Our variant is under src/test/tck/tck-tests.xml -->
         <cdi.tck.suite.xml.file></cdi.tck.suite.xml.file>
-        <classfilewriter.version>1.2.5.Final</classfilewriter.version>
+        <classfilewriter.version>1.3.0.Final</classfilewriter.version>
         <spotbugs-maven-plugin.version>4.7.3.4</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.7.3</spotbugs-annotations-version>
         <groovy.version>3.0.13</groovy.version>


### PR DESCRIPTION
CFW in version 1.3.0.Final includes following commit - https://github.com/jbossas/jboss-classfilewriter/commit/4028c251ecfdc9ded83e508b013aa306276057a3

This means as soon as `DefaultClassFactory.INSTANCE` gets initialized, you need `--add-opens` to be able to execute the code in there - else you're getting an exception.
Even though we never use CFW to define classes, this still affects us because of the way we instantiate `ClassFile` in our `ProxyFactory` - we use a deprecated method that now gets re-routed to a default implementation of the class factory.

In order to bypass this, we need to use a variant of the `ClassFile` method where we specify CL as well as `ClassFactory` instance. This PR uses dummy variant to do just that.