### PR TITLE
WELD-2747 Avoid calling SessionObjectReference.isRemoved() on every invocation.

### DIFF
--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/enterprise/weld1234/Weld1234Test.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/enterprise/weld1234/Weld1234Test.java
@@ -31,7 +31,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -57,9 +56,8 @@ public class Weld1234Test {
         } catch (Exception e) {
         }
 
-        // check if toString() still works
-        String toString = exceptionGenerator.toString();
-        assertTrue(toString.contains("REMOVED"));
+        // Verify that toString() still works
+        exceptionGenerator.toString();
 
         try {
             // check if other methods throw NoSuchEJBException


### PR DESCRIPTION
https://issues.redhat.com/browse/WELD-1234

SessionObjectReference.isRemoved() can be expensive.  Let's avoid calling this per invocation, and instead return the fabricated toString() if the EJB was not found.
See https://github.com/wildfly/wildfly/pull/16885 for context.