### PR TITLE
WELD-2750 Tweak how parent-child creational contexts are created. Use WeakReference to keep track of destroyed instance.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -777,7 +777,13 @@ public class BeanManagerImpl implements WeldManager, Serializable {
                     }
                 }
             }
-            return getReference(resolvedBean, requestedType, creationalContext, delegateInjectionPoint);
+            // #getReference always creates a child CC and links it to the CC we pass an argument
+            // This is exactly what we want for dependent beans but all other beans shouldn't have that
+            if (Dependent.class.equals(resolvedBean.getScope())) {
+                return getReference(resolvedBean, requestedType, creationalContext, delegateInjectionPoint);
+            } else {
+                return getReference(resolvedBean, requestedType, createCreationalContext(null), delegateInjectionPoint);
+            }
 
         } finally {
             stack.pop();


### PR DESCRIPTION
Attempts to solve a memory leak in dependent instance handling.
See the JIRA ([WELD-2750](https://issues.redhat.com/browse/WELD-2750)) for detailed description and a reproducer.

First commit:
* Makes sure the set of destroyed instance we keep in each CC is a `WeakReference` allowing GC to collect them. 
* Also changes how we create CC for non-dependent beans when obtaining injectable reference - we no longer unconditionally create child CC as that implies linked them together and potentially holding a reference to an already destroyed instance.

Second commit:
* An improvement on the second step of first commit - tries to avoid creating any superfluous CC when not needed. A side effect is that `BeanManagerImpl#getReference` can no longer return `null`. 
  * However, after browsing code I didn't see any such usage anyway - CI might still prove me wrong though as I only ran non-container tests locally :)