### PR TITLE
WELD-2752 WeldInitialListener will now only attempt context destruction if init was successful

### DIFF
--- a/modules/web/src/main/java/org/jboss/weld/module/web/servlet/WeldInitialListener.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/servlet/WeldInitialListener.java
@@ -110,7 +110,10 @@ public class WeldInitialListener extends AbstractServletListener {
 
     @Override
     public void contextDestroyed(ServletContextEvent sce) {
-        lifecycle.contextDestroyed(sce.getServletContext());
+        // null means an error while starting the app; for instance and exception in ServletContainerInitializer#onStartup
+        if (this.lifecycle != null) {
+            lifecycle.contextDestroyed(sce.getServletContext());
+        }
     }
 
     @Override


### PR DESCRIPTION
JIRA - https://issues.redhat.com/browse/WELD-2752

Lifecycle can be `null` if deployed app failed to start. In such case we want to skip context destruction to avoid throwing NPE.