### PR TITLE
Fix tests with custom CDI providers

### DIFF
--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/provider/custom/CustomCDIProviderTest.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/provider/custom/CustomCDIProviderTest.java
@@ -31,6 +31,9 @@ public class CustomCDIProviderTest extends WeldSETest {
 
     @Test
     public void testCustomCDIProvider() {
+        // Other tests running prior to this one might have set the provider already
+        // repeated set invocation leads to an exception, so we do a cautious unset
+        TestCDI.unsetCDIProvider();
         try {
             CustomCDIProvider.reset();
             CDI.setCDIProvider(new CustomCDIProvider());

--- a/environments/servlet/tests/base/src/main/java/org/jboss/weld/environment/servlet/test/provider/CustomCDIProviderTest.java
+++ b/environments/servlet/tests/base/src/main/java/org/jboss/weld/environment/servlet/test/provider/CustomCDIProviderTest.java
@@ -38,6 +38,9 @@ public class CustomCDIProviderTest {
 
     @Test
     public void testCustomCDIProvider() {
+        // Other tests running prior to this one might have set the provider already
+        // repeated set invocation leads to an exception, so we do a cautious unset
+        TestCDI.unsetCDIProvider();
         try {
             CustomCDIProvider.reset();
             CDI.setCDIProvider(new CustomCDIProvider());


### PR DESCRIPTION
This fix is not really an issue with current deps but recent changes to the `CDI` API class expose this problem (there is now an exception thrown on repeated set invocation).