### PR TITLE
WELD-2755 Remove usage of ThreadGroup from Weld executors

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -2,7 +2,7 @@ name: Weld CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ 5.1 ]
     # Do not run for non-code changes
     paths-ignore:
       - '.gitignore'
@@ -24,13 +24,7 @@ jobs:
           distribution: 'temurin'
       - name: Download WildFly
         run: |
-          # wget https://ci.wildfly.org/guestAuth/repository/download/WF_WildflyPreviewNightly/latest.lastSuccessful/wildfly-preview-latest-SNAPSHOT.zip
-          # unzip wildfly-preview-latest-SNAPSHOT.zip
-          wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastSuccessful/wildfly-latest-SNAPSHOT.zip
-          unzip wildfly-latest-SNAPSHOT.zip
-          # ZIP contains two more ZIPs, sources and actual WFLY
-          rm wildfly-*-src.zip
-          rm wildfly-latest-SNAPSHOT.zip
+          wget https://github.com/wildfly/wildfly/releases/download/29.0.1.Final/wildfly-29.0.1.Final.zip
           unzip wildfly-*.zip -d container
           cd container
           mv ./* wildfly/

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/options/timeout/IncompleteCustomExecutorServices.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/event/options/timeout/IncompleteCustomExecutorServices.java
@@ -32,7 +32,7 @@ public class IncompleteCustomExecutorServices extends AbstractExecutorServices {
     static final String PREFIX = "weld-worker-test";
 
     private final transient ExecutorService taskExecutor = Executors
-            .newSingleThreadExecutor(new DaemonThreadFactory(new ThreadGroup(DaemonThreadFactory.WELD_WORKERS), PREFIX));
+            .newSingleThreadExecutor(new DaemonThreadFactory(PREFIX));
 
     public ExecutorService getTaskExecutor() {
         return taskExecutor;

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/ContainerLifecycleEventPreloader.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/ContainerLifecycleEventPreloader.java
@@ -56,7 +56,7 @@ public class ContainerLifecycleEventPreloader {
 
     public ContainerLifecycleEventPreloader(int threadPoolSize, ObserverNotifier notifier) {
         this.executor = Executors.newFixedThreadPool(threadPoolSize,
-                new DaemonThreadFactory(new ThreadGroup("weld-preloaders"), "weld-preloader-"));
+                new DaemonThreadFactory("weld-preloader-"));
         this.notifier = notifier;
     }
 

--- a/impl/src/main/java/org/jboss/weld/executor/AbstractExecutorServices.java
+++ b/impl/src/main/java/org/jboss/weld/executor/AbstractExecutorServices.java
@@ -41,7 +41,7 @@ public abstract class AbstractExecutorServices implements ExecutorServices {
     private static final long SHUTDOWN_TIMEOUT = 60L;
 
     private final ScheduledExecutorService timerExecutor = Executors.newScheduledThreadPool(1,
-            new DaemonThreadFactory(new ThreadGroup(DaemonThreadFactory.WELD_WORKERS), "weld-timer-"));
+            new DaemonThreadFactory("weld-timer-"));
 
     /**
      * Returns a singleton instance of ScheduledExecutorService.

--- a/impl/src/main/java/org/jboss/weld/executor/DaemonThreadFactory.java
+++ b/impl/src/main/java/org/jboss/weld/executor/DaemonThreadFactory.java
@@ -27,20 +27,16 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class DaemonThreadFactory implements ThreadFactory {
 
-    public static final String WELD_WORKERS = "weld-workers";
-
     private final AtomicInteger threadNumber = new AtomicInteger(1);
     private final String threadNamePrefix;
-    private final ThreadGroup threadGroup;
 
-    public DaemonThreadFactory(ThreadGroup threadGroup, String threadNamePrefix) {
-        this.threadGroup = threadGroup;
+    public DaemonThreadFactory(String threadNamePrefix) {
         this.threadNamePrefix = threadNamePrefix;
     }
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread thread = new Thread(threadGroup, r, threadNamePrefix + threadNumber.getAndIncrement());
+        Thread thread = new Thread(r, threadNamePrefix + threadNumber.getAndIncrement());
         thread.setDaemon(true);
         return thread;
     }

--- a/impl/src/main/java/org/jboss/weld/executor/FixedThreadPoolExecutorServices.java
+++ b/impl/src/main/java/org/jboss/weld/executor/FixedThreadPoolExecutorServices.java
@@ -37,7 +37,7 @@ public class FixedThreadPoolExecutorServices extends AbstractExecutorServices {
     public FixedThreadPoolExecutorServices(int threadPoolSize) {
         this.threadPoolSize = threadPoolSize;
         this.executor = Executors.newFixedThreadPool(threadPoolSize,
-                new DaemonThreadFactory(new ThreadGroup(DaemonThreadFactory.WELD_WORKERS), "weld-worker-"));
+                new DaemonThreadFactory("weld-worker-"));
         BootstrapLogger.LOG.threadsInUse(threadPoolSize);
     }
 

--- a/impl/src/main/java/org/jboss/weld/executor/TimingOutFixedThreadPoolExecutorServices.java
+++ b/impl/src/main/java/org/jboss/weld/executor/TimingOutFixedThreadPoolExecutorServices.java
@@ -47,7 +47,7 @@ public class TimingOutFixedThreadPoolExecutorServices extends AbstractExecutorSe
         this.executor = new ThreadPoolExecutor(threadPoolSize, threadPoolSize,
                 keepAliveTime, TimeUnit.SECONDS,
                 new LinkedBlockingQueue<Runnable>(),
-                new DaemonThreadFactory(new ThreadGroup(DaemonThreadFactory.WELD_WORKERS), "weld-worker-"));
+                new DaemonThreadFactory("weld-worker-"));
         // Terminate threads if no new tasks arrive within the keep-alive time
         this.executor.allowCoreThreadTimeOut(true);
 

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/stage/CustomExecutorServices.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/async/stage/CustomExecutorServices.java
@@ -27,7 +27,7 @@ public class CustomExecutorServices extends AbstractExecutorServices {
     static final String PREFIX = "weld-worker-test";
 
     private final transient ExecutorService taskExecutor = Executors
-            .newSingleThreadExecutor(new DaemonThreadFactory(new ThreadGroup(DaemonThreadFactory.WELD_WORKERS), PREFIX));
+            .newSingleThreadExecutor(new DaemonThreadFactory(PREFIX));
 
     /**
      * Provides access to the executor service used for asynchronous tasks.


### PR DESCRIPTION
Backport of WELD-2755.
Also corrects CI settings to execute on this branch.