### PR TITLE
WELD-2758 Proxies for non-public class-based beans should reside in bean's package if possible

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -260,6 +260,13 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
             }
             interfaces.add(mostSpecificClass.getSimpleName());
         }
+        // if the bean class is a non-public one (i.e. pack private), we prioritize placing proxy in the same package
+        // we skip built-in beans are those are often for jakarta.* classes and end up in Weld's default package anyway
+        if (proxyPackage == null && bean != null
+                && !Modifier.isPublic(bean.getBeanClass().getModifiers())
+                && !(bean instanceof AbstractBuiltInBean)) {
+            proxyPackage = bean.getBeanClass().getPackage().getName();
+        }
         final Set<String> declaringClasses = new HashSet<>();
         for (Class<?> type : typeInfo.getInterfaces()) {
             Class<?> declaringClass = type.getDeclaringClass();
@@ -271,7 +278,7 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
                 proxyPackage = typeInfo.getPackageNameForClass(type);
             }
         }
-        // no need to sort the set, because we copied and already sorted one
+        // no need to sort the set, because we copied already sorted set
         Iterator<String> iterator = interfaces.iterator();
         while (iterator.hasNext()) {
             name.append(iterator.next());

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/ProxyForInterceptedPackagePrivateBeanTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/ProxyForInterceptedPackagePrivateBeanTest.java
@@ -1,0 +1,40 @@
+package org.jboss.weld.tests.classDefining.packPrivate;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.tests.classDefining.packPrivate.api.Alpha;
+import org.jboss.weld.tests.classDefining.packPrivate.interceptor.MyInterceptor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * See WELD-2758
+ */
+@RunWith(Arquillian.class)
+public class ProxyForInterceptedPackagePrivateBeanTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap
+                .create(BeanArchive.class, Utils.getDeploymentNameAsHash(ProxyForInterceptedPackagePrivateBeanTest.class))
+                .addPackages(true, ProxyForInterceptedPackagePrivateBeanTest.class.getPackage());
+    }
+
+    @Inject
+    Instance<Object> instance;
+
+    @Test
+    public void testProxyCanBeCreated() {
+        Instance<Alpha> select = instance.select(Alpha.class);
+        Assert.assertTrue(select.isResolvable());
+        Assert.assertEquals(MyInterceptor.class.getSimpleName() + Alpha.class.getSimpleName(), select.get().ping());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/api/Alpha.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/api/Alpha.java
@@ -1,0 +1,6 @@
+package org.jboss.weld.tests.classDefining.packPrivate.api;
+
+public interface Alpha {
+
+    String ping();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/impl/AlphaImpl.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/impl/AlphaImpl.java
@@ -1,0 +1,20 @@
+package org.jboss.weld.tests.classDefining.packPrivate.impl;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Typed;
+
+import org.jboss.weld.tests.classDefining.packPrivate.api.Alpha;
+import org.jboss.weld.tests.classDefining.packPrivate.interceptor.SomeBinding;
+
+/**
+ * Class is intentionally package private, @Typed to just the interface type and normal scoped to enforce client proxy
+ */
+@ApplicationScoped
+@SomeBinding
+@Typed(Alpha.class)
+class AlphaImpl implements Alpha {
+    @Override
+    public String ping() {
+        return Alpha.class.getSimpleName();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/interceptor/MyInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/interceptor/MyInterceptor.java
@@ -1,0 +1,17 @@
+package org.jboss.weld.tests.classDefining.packPrivate.interceptor;
+
+import jakarta.annotation.Priority;
+import jakarta.interceptor.AroundInvoke;
+import jakarta.interceptor.Interceptor;
+import jakarta.interceptor.InvocationContext;
+
+@Interceptor
+@SomeBinding
+@Priority(Interceptor.Priority.APPLICATION)
+public class MyInterceptor {
+
+    @AroundInvoke
+    public Object intercept(InvocationContext context) throws Exception {
+        return this.getClass().getSimpleName() + context.proceed();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/interceptor/SomeBinding.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/classDefining/packPrivate/interceptor/SomeBinding.java
@@ -1,0 +1,11 @@
+package org.jboss.weld.tests.classDefining.packPrivate.interceptor;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.interceptor.InterceptorBinding;
+
+@Retention(RetentionPolicy.RUNTIME)
+@InterceptorBinding
+public @interface SomeBinding {
+}


### PR DESCRIPTION
https://issues.redhat.com/browse/WELD-2758

5.1 counterpart of https://github.com/weld/core/pull/2886