### PR TITLE
WELD-2761 Fix BeanManager not returning empty set if there are no con…

### DIFF
--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -658,7 +658,8 @@ public class BeanManagerImpl implements WeldManager, Serializable {
 
     @Override
     public Collection<Context> getContexts(Class<? extends Annotation> scopeType) {
-        return Collections.unmodifiableList(contexts.get(scopeType));
+        List<Context> found = this.contexts.get(scopeType);
+        return found != null ? Collections.unmodifiableList(found) : Collections.EMPTY_LIST;
     }
 
     public Context getUnwrappedContext(Class<? extends Annotation> scopeType) {

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/retrieval/CustomScope.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/retrieval/CustomScope.java
@@ -1,0 +1,19 @@
+package org.jboss.weld.tests.contexts.retrieval;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.NormalScope;
+
+@NormalScope
+@Inherited
+@Target({ TYPE, METHOD, FIELD })
+@Retention(RUNTIME)
+public @interface CustomScope {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/retrieval/WeldManagerGetContextsTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/retrieval/WeldManagerGetContextsTest.java
@@ -49,5 +49,9 @@ public class WeldManagerGetContextsTest {
         contexts = weldManager.getContexts(RequestScoped.class);
         Assert.assertEquals(4, contexts.size());
         Assert.assertEquals(1, contexts.stream().filter(c -> c.isActive()).count());
+
+        // try to get contexts for scope that has none registered
+        contexts = weldManager.getContexts(CustomScope.class);
+        Assert.assertEquals(0, contexts.size());
     }
 }


### PR DESCRIPTION
…texts for given scope via getContexts() methods