### PR TITLE
WELD-2762 Do not swallow exceptions occuring during HTTP session creation

### DIFF
--- a/modules/web/src/main/java/org/jboss/weld/module/web/context/beanstore/http/LazySessionBeanStore.java
+++ b/modules/web/src/main/java/org/jboss/weld/module/web/context/beanstore/http/LazySessionBeanStore.java
@@ -85,10 +85,10 @@ public class LazySessionBeanStore extends AbstractSessionBeanStore {
         try {
             return SessionHolder.getSession(request, create);
         } catch (IllegalStateException e) {
-            // If container can't create an underlying session, invalidate the
-            // current one
+            // If container can't create an underlying session, invalidate the current one
             detach();
-            return null;
+            // re-throw the exception to properly show cause and message
+            throw e;
         }
     }
 


### PR DESCRIPTION
I am not sure if this can lead to unexpected scenarios due to the fact that the bean store is lazy but at first sight it seems OK to propagate the exception as it is out of our control anyway.