### PR TITLE
WELD-2768 support explicitly declaring @Priority on producers

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/AbstractProducerBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/AbstractProducerBean.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Type;
 import java.util.Set;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.AnnotatedMember;
@@ -59,6 +60,7 @@ public abstract class AbstractProducerBean<X, T, S extends Member> extends Abstr
     // Passivation flags
     private boolean passivationCapableBean;
     private boolean passivationCapableDependency;
+    protected Integer explicitPriority;
 
     /**
      * Constructor
@@ -217,4 +219,15 @@ public abstract class AbstractProducerBean<X, T, S extends Member> extends Abstr
 
     @Override
     public abstract EnhancedAnnotatedMember<T, ?, S> getEnhancedAnnotated();
+
+    @Override
+    public Integer getPriority() {
+        return explicitPriority;
+    }
+
+    // requires initialized getAnnotated() hence subclasses need to invoke this manually
+    protected void processExplicitPriority() {
+        Priority annotation = getAnnotated() == null ? null : getAnnotated().getAnnotation(Priority.class);
+        this.explicitPriority = annotation == null ? null : annotation.value();
+    }
 }

--- a/impl/src/main/java/org/jboss/weld/bean/ProducerField.java
+++ b/impl/src/main/java/org/jboss/weld/bean/ProducerField.java
@@ -96,6 +96,7 @@ public class ProducerField<X, T> extends AbstractProducerBean<X, T, Field> {
                 return ProducerField.this;
             }
         });
+        processExplicitPriority();
     }
 
     @Override

--- a/impl/src/main/java/org/jboss/weld/bean/ProducerMethod.java
+++ b/impl/src/main/java/org/jboss/weld/bean/ProducerMethod.java
@@ -97,6 +97,7 @@ public class ProducerMethod<X, T> extends AbstractProducerBean<X, T, Method> {
                 return ProducerMethod.this;
             }
         });
+        processExplicitPriority();
     }
 
     @Override

--- a/impl/src/main/java/org/jboss/weld/bean/WeldBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/WeldBean.java
@@ -35,9 +35,11 @@ public interface WeldBean<T> extends Bean<T> {
     BeanIdentifier getIdentifier();
 
     /**
-     * Used for custom beans registered via WeldBeanConfigurator.
+     * Used for custom beans registered via WeldBeanConfigurator and for {@link ProducerField} and {@link ProducerMethod}
+     * if they explicitly declare the {@link jakarta.annotation.Priority} annotation.
+     * All other implementations will return {@code null} by default.
      *
-     * @return bean priority or null if not set or overriden
+     * @return bean priority or null if not set or overridden
      */
     default Integer getPriority() {
         return null;

--- a/impl/src/main/java/org/jboss/weld/resolution/AbstractTypeSafeBeanResolver.java
+++ b/impl/src/main/java/org/jboss/weld/resolution/AbstractTypeSafeBeanResolver.java
@@ -110,9 +110,18 @@ public abstract class AbstractTypeSafeBeanResolver<T extends Bean<?>, C extends 
         public Set<Bean<?>> resolveAlternatives(Set<Bean<?>> alternatives) {
             int highestPriority = Integer.MIN_VALUE;
             Set<Bean<?>> selectedAlternativesWithHighestPriority = new HashSet<Bean<?>>();
-
             for (Bean<?> bean : alternatives) {
-                Integer priority = beanManager.getEnabled().getAlternativePriority(bean.getBeanClass());
+                Integer priority;
+                if (bean instanceof AbstractProducerBean) {
+                    // first check for explicit priority declaration on producers
+                    priority = ((AbstractProducerBean<?, ?, ?>) bean).getPriority();
+                    // if not found, fall back to priority on declaring bean
+                    if (priority == null) {
+                        priority = beanManager.getEnabled().getAlternativePriority(bean.getBeanClass());
+                    }
+                } else {
+                    priority = beanManager.getEnabled().getAlternativePriority(bean.getBeanClass());
+                }
                 if (priority == null) {
                     // not all the beans left are alternatives with a priority - we are not able to resolve
                     return ImmutableSet.copyOf(alternatives);

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Alpha.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Alpha.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+public class Alpha {
+
+    private String s;
+
+    public Alpha(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/AltBeanProducingAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/AltBeanProducingAlternative.java
@@ -1,0 +1,26 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@Alternative
+@Priority(1)
+@ApplicationScoped
+public class AltBeanProducingAlternative {
+
+    @Alternative
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByMethod
+    Beta producer1() {
+        return new Beta(ProducerExplicitPriorityTest.ALT2);
+    }
+
+    @Alternative
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByField
+    Beta producer2 = new Beta(ProducerExplicitPriorityTest.ALT2);
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/AltBeanProducingPrioritizedNonAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/AltBeanProducingPrioritizedNonAlternative.java
@@ -1,0 +1,24 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class AltBeanProducingPrioritizedNonAlternative {
+
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByMethod
+    Delta producer1() {
+        return new Delta(ProducerExplicitPriorityTest.ALT2);
+    }
+
+    @Priority(20) // should override class-level priority value and hence end up having the highest priority
+    @Produces
+    @ProducedByField
+    Delta producer2 = new Delta(ProducerExplicitPriorityTest.ALT2);
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Beta.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Beta.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+public class Beta {
+
+    private String s;
+
+    public Beta(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Delta.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Delta.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+public class Delta {
+
+    private String s;
+
+    public Delta(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Gamma.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/Gamma.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+public class Gamma {
+
+    private String s;
+
+    public Gamma(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/NonAltBeanProducingAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/NonAltBeanProducingAlternative.java
@@ -1,0 +1,67 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class NonAltBeanProducingAlternative {
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByMethod
+    Alpha producer1() {
+        return new Alpha(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByMethod
+    Beta producer2() {
+        return new Beta(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByField
+    Alpha producer3 = new Alpha(ProducerExplicitPriorityTest.ALT);
+
+    @Alternative
+    @Priority(10)
+    @Produces
+    @ProducedByField
+    Beta producer4 = new Beta(ProducerExplicitPriorityTest.ALT);
+
+    @Produces
+    @ProducedByMethod
+    @Alternative
+    @Priority(10)
+    Gamma producer5() {
+        return new Gamma(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Produces
+    @ProducedByField
+    @Alternative
+    @Priority(10)
+    Gamma producer6 = new Gamma(ProducerExplicitPriorityTest.ALT);
+
+    @Produces
+    @ProducedByMethod
+    @Alternative
+    @Priority(10)
+    Delta producer7() {
+        return new Delta(ProducerExplicitPriorityTest.ALT);
+    }
+
+    @Produces
+    @ProducedByField
+    @Alternative
+    @Priority(10)
+    Delta producer8 = new Delta(ProducerExplicitPriorityTest.ALT);
+
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/NonAltBeanWithPrioProducingAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/NonAltBeanWithPrioProducingAlternative.java
@@ -1,0 +1,23 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Priority(500)
+public class NonAltBeanWithPrioProducingAlternative {
+
+    @Produces
+    @ProducedByMethod
+    @Alternative
+    Gamma producer5() {
+        return new Gamma(ProducerExplicitPriorityTest.ALT2);
+    }
+
+    @Produces
+    @ProducedByField
+    @Alternative
+    Gamma producer6 = new Gamma(ProducerExplicitPriorityTest.ALT2);
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/ProducedByField.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/ProducedByField.java
@@ -1,0 +1,11 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProducedByField {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/ProducedByMethod.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/ProducedByMethod.java
@@ -1,0 +1,11 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import jakarta.inject.Qualifier;
+
+@Qualifier
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ProducedByMethod {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/ProducerExplicitPriorityTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/ProducerExplicitPriorityTest.java
@@ -1,0 +1,87 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ProducerExplicitPriorityTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ProducerExplicitPriorityTest.class))
+                .addPackage(ProducerExplicitPriorityTest.class.getPackage());
+    }
+
+    public static final String DEFAULT = "default";
+    public static final String ALT = "alternative";
+    public static final String ALT2 = "alternative2";
+
+    @Inject
+    @ProducedByMethod
+    Alpha alphaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Alpha alphaFieldProducer;
+
+    @Inject
+    @ProducedByMethod
+    Beta betaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Beta betaFieldProducer;
+
+    @Inject
+    @ProducedByMethod
+    Gamma gammaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Gamma gammaFieldProducer;
+
+    @Inject
+    @ProducedByMethod
+    Delta deltaMethodProducer;
+
+    @Inject
+    @ProducedByField
+    Delta deltaFieldProducer;
+
+    @Test
+    public void testAlternativeProducerWithPriority() {
+        assertNotNull(alphaMethodProducer);
+        assertNotNull(alphaFieldProducer);
+
+        assertEquals(ALT, alphaMethodProducer.ping());
+        assertEquals(ALT, alphaFieldProducer.ping());
+    }
+
+    @Test
+    public void testPriorityOnProducerOverPriorityOnClass() {
+        assertNotNull(betaMethodProducer);
+        assertNotNull(betaFieldProducer);
+        assertNotNull(gammaFieldProducer);
+        assertNotNull(gammaMethodProducer);
+        assertNotNull(deltaFieldProducer);
+        assertNotNull(deltaMethodProducer);
+
+        assertEquals(ALT2, betaMethodProducer.ping());
+        assertEquals(ALT2, betaFieldProducer.ping());
+        assertEquals(ALT2, gammaFieldProducer.ping());
+        assertEquals(ALT2, gammaMethodProducer.ping());
+        assertEquals(ALT2, deltaFieldProducer.ping());
+        assertEquals(ALT2, deltaMethodProducer.ping());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/RegularBeanProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/RegularBeanProducer.java
@@ -1,0 +1,49 @@
+package org.jboss.weld.tests.producer.alternative.priority;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+// produces standard (non-alternative) beans that should be replaced by alternatives
+@ApplicationScoped
+public class RegularBeanProducer {
+
+    @Produces
+    @ProducedByMethod
+    Alpha producer1() {
+        return new Alpha(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByMethod
+    Beta producer2() {
+        return new Beta(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByField
+    Alpha producer3 = new Alpha(ProducerExplicitPriorityTest.DEFAULT);
+
+    @Produces
+    @ProducedByField
+    Beta producer4 = new Beta(ProducerExplicitPriorityTest.DEFAULT);
+
+    @Produces
+    @ProducedByMethod
+    Gamma producer5() {
+        return new Gamma(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByField
+    Gamma producer6 = new Gamma(ProducerExplicitPriorityTest.DEFAULT);
+
+    @Produces
+    @ProducedByMethod
+    Delta producer7() {
+        return new Delta(ProducerExplicitPriorityTest.DEFAULT);
+    }
+
+    @Produces
+    @ProducedByField
+    Delta producer8 = new Delta(ProducerExplicitPriorityTest.DEFAULT);
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/Bar.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/Bar.java
@@ -1,0 +1,13 @@
+package org.jboss.weld.tests.producer.alternative.priority.complex;
+
+public class Bar {
+    private String s;
+
+    public Bar(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/Foo.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.producer.alternative.priority.complex;
+
+public class Foo {
+
+    private String s;
+
+    public Foo(String s) {
+        this.s = s;
+    }
+
+    public String ping() {
+        return s;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/GloballyEnabledAlt.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/GloballyEnabledAlt.java
@@ -1,0 +1,26 @@
+package org.jboss.weld.tests.producer.alternative.priority.complex;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Alternative
+@Priority(1)
+public class GloballyEnabledAlt {
+
+    @Produces
+    @Alternative
+    @Priority(50)
+    public Foo produceAltFoo() {
+        return new Foo(ProducerOnLocallyEnabledAltTest.ALT);
+    }
+
+    @Produces
+    @Alternative
+    @Priority(50)
+    public Bar produceAltBar() {
+        return new Bar(ProducerOnLocallyEnabledAltTest.ALT);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/LocallyEnabledAlternative.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/LocallyEnabledAlternative.java
@@ -1,0 +1,27 @@
+package org.jboss.weld.tests.producer.alternative.priority.complex;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+@Alternative
+// priority intentionally missing, enabled via beans.xml
+// all producers declared within this class have the highest priority in this test's deployment
+public class LocallyEnabledAlternative {
+
+    @Produces
+    @Alternative
+    @Priority(100)
+    public Foo produceAltFoo() {
+        return new Foo(ProducerOnLocallyEnabledAltTest.ALT2);
+    }
+
+    @Produces
+    // @Alternative deliberately left out
+    @Priority(100)
+    public Bar produceAltBar() {
+        return new Bar(ProducerOnLocallyEnabledAltTest.ALT2);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/ProducerOnLocallyEnabledAltTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/ProducerOnLocallyEnabledAltTest.java
@@ -1,0 +1,45 @@
+package org.jboss.weld.tests.producer.alternative.priority.complex;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import jakarta.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ProducerOnLocallyEnabledAltTest {
+
+    public static final String DEFAULT = "default";
+    public static final String ALT = "alternative";
+    public static final String ALT2 = "alternative2";
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ProducerOnLocallyEnabledAltTest.class))
+                .alternate(LocallyEnabledAlternative.class)
+                .addPackage(ProducerOnLocallyEnabledAltTest.class.getPackage());
+    }
+
+    @Inject
+    Bar bar;
+
+    @Inject
+    Foo foo;
+
+    @Test
+    public void testLocallyEnabledAlternativeHasHighestPrio() {
+        assertNotNull(bar);
+        assertNotNull(foo);
+
+        assertEquals(ALT2, foo.ping());
+        assertEquals(ALT2, bar.ping());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/RegularProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/alternative/priority/complex/RegularProducer.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.producer.alternative.priority.complex;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+
+@ApplicationScoped
+public class RegularProducer {
+
+    @Produces
+    public Foo produceFoo() {
+        return new Foo(ProducerOnLocallyEnabledAltTest.DEFAULT);
+    }
+
+    @Produces
+    public Bar produceBar() {
+        return new Bar(ProducerOnLocallyEnabledAltTest.DEFAULT);
+    }
+}


### PR DESCRIPTION
Weld implementation for https://github.com/jakartaee/cdi/issues/556
Tests for this are on a TCK PR - https://github.com/jakartaee/cdi-tck/pull/499 (and this PR passes them)
I don't mind adding tests here as well, but it would basically be a duplication of the same ones - WDYT @mkouba?