### PR TITLE
WELD-2773 Incorrect producer field inheritance

### DIFF
--- a/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
+++ b/impl/src/main/java/org/jboss/weld/annotated/enhanced/jlr/EnhancedAnnotatedTypeImpl.java
@@ -195,12 +195,12 @@ public class EnhancedAnnotatedTypeImpl<T> extends AbstractEnhancedAnnotated<T, C
                 EnhancedAnnotatedField<?, ? super T> weldField = EnhancedAnnotatedFieldImpl.of(annotatedField, this,
                         classTransformer);
                 fieldsTemp.add(weldField);
-                if (annotatedField.getDeclaringType().getJavaClass().equals(javaClass)) {
+                if (annotatedField.getJavaMember().getDeclaringClass().equals(javaClass)) {
                     declaredFieldsTemp.add(weldField);
                 }
                 for (Annotation annotation : weldField.getAnnotations()) {
                     annotatedFields.put(annotation.annotationType(), weldField);
-                    if (annotatedField.getDeclaringType().getJavaClass().equals(javaClass)) {
+                    if (annotatedField.getJavaMember().getDeclaringClass().equals(javaClass)) {
                         declaredAnnotatedFields.put(annotation.annotationType(), weldField);
                     }
                 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/FieldProducerBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/FieldProducerBean.java
@@ -1,0 +1,13 @@
+package org.jboss.weld.tests.producer.field;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+
+@Dependent
+public class FieldProducerBean {
+
+    @Produces
+    @ApplicationScoped
+    FieldProducerExtensionTest.Foo p = new FieldProducerExtensionTest.Foo();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/FieldProducerBeanSubclass.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/FieldProducerBeanSubclass.java
@@ -1,0 +1,7 @@
+package org.jboss.weld.tests.producer.field;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class FieldProducerBeanSubclass extends FieldProducerBean {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/FieldProducerExtensionTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/FieldProducerExtensionTest.java
@@ -1,0 +1,57 @@
+package org.jboss.weld.tests.producer.field;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Field producer should not be inherited into bean subclass. In this scenario, a CDI extension modifies the type
+ * which leads to a registration of a new annotated type that we need to correctly parse.
+ *
+ * See https://issues.redhat.com/browse/WELD-2773
+ */
+@RunWith(Arquillian.class)
+public class FieldProducerExtensionTest {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(FieldProducerExtensionTest.class))
+                .addPackage(FieldProducerExtensionTest.class.getPackage())
+                .addAsServiceProvider(Extension.class, MyExtension.class);
+    }
+
+    @Inject
+    Instance<Object> instance;
+
+    @Inject
+    Foo foo;
+
+    @Test
+    public void test() {
+        // assert extension works
+        Assert.assertEquals(2, MyExtension.extensionTriggered);
+        // assert producer works
+        Assert.assertNotNull(foo);
+
+        // assert both beans are there
+        List<? extends Instance.Handle<FieldProducerBean>> collect = instance.select(FieldProducerBean.class).handlesStream()
+                .collect(Collectors.toList());
+        Assert.assertEquals(2, collect.size());
+    }
+
+    public static class Foo {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/MyExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/producer/field/MyExtension.java
@@ -1,0 +1,15 @@
+package org.jboss.weld.tests.producer.field;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.spi.Extension;
+import jakarta.enterprise.inject.spi.ProcessAnnotatedType;
+
+public class MyExtension implements Extension {
+
+    public static int extensionTriggered = 0;
+
+    public void observe(@Observes ProcessAnnotatedType<? extends FieldProducerBean> pat) {
+        extensionTriggered++;
+        pat.configureAnnotatedType();
+    }
+}


### PR DESCRIPTION
Related to https://github.com/weld/core/pull/2903

This is a minimal change which corrects how we identify declaring class for a non-discovered annotated type (one that was tempered with by an extension for instance).