### PR TITLE
WELD-2774 Implement BM methods for event/bean assignability

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerProxy.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerProxy.java
@@ -193,6 +193,18 @@ public class BeanManagerProxy extends ForwardingBeanManager implements WeldManag
     }
 
     @Override
+    public boolean isMatchingBean(Set<Type> beanTypes, Set<Annotation> beanQualifiers, Type requiredType,
+            Set<Annotation> requiredQualifiers) {
+        return delegate().isMatchingBean(beanTypes, beanQualifiers, requiredType, requiredQualifiers);
+    }
+
+    @Override
+    public boolean isMatchingEvent(Type eventType, Set<Annotation> eventQualifiers, Type observedEventType,
+            Set<Annotation> observedEventQualifiers) {
+        return delegate().isMatchingEvent(eventType, eventQualifiers, observedEventType, observedEventQualifiers);
+    }
+
+    @Override
     public Bean<?> getPassivationCapableBean(BeanIdentifier identifier) {
         return delegate().getPassivationCapableBean(identifier);
     }

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/BeanAttributesConfiguratorImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/configurator/BeanAttributesConfiguratorImpl.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.BeanAttributes;
 import jakarta.enterprise.inject.spi.configurator.BeanAttributesConfigurator;
@@ -222,7 +221,8 @@ public class BeanAttributesConfiguratorImpl<T> implements BeanAttributesConfigur
 
     @Override
     public BeanAttributes<T> complete() {
-        return new ImmutableBeanAttributes<T>(ImmutableSet.copyOf(stereotypes), isAlternative, name, initQualifiers(qualifiers),
+        return new ImmutableBeanAttributes<T>(ImmutableSet.copyOf(stereotypes), isAlternative, name,
+                Bindings.normalizeBeanQualifiers(qualifiers),
                 ImmutableSet.copyOf(types),
                 initScope());
     }
@@ -256,29 +256,6 @@ public class BeanAttributesConfiguratorImpl<T> implements BeanAttributesConfigur
             }
         }
         return Dependent.class;
-    }
-
-    private Set<Annotation> initQualifiers(Set<Annotation> qualifiers) {
-        if (qualifiers.isEmpty()) {
-            return Bindings.DEFAULT_QUALIFIERS;
-        }
-        Set<Annotation> normalized = new HashSet<Annotation>(qualifiers);
-        normalized.remove(Any.Literal.INSTANCE);
-        normalized.remove(Default.Literal.INSTANCE);
-        if (normalized.isEmpty()) {
-            normalized = Bindings.DEFAULT_QUALIFIERS;
-        } else {
-            ImmutableSet.Builder<Annotation> builder = ImmutableSet.builder();
-            if (normalized.size() == 1) {
-                if (normalized.iterator().next().annotationType().equals(Named.class)) {
-                    builder.add(Default.Literal.INSTANCE);
-                }
-            }
-            builder.add(Any.Literal.INSTANCE);
-            builder.addAll(qualifiers);
-            normalized = builder.build();
-        }
-        return normalized;
     }
 
 }

--- a/impl/src/main/java/org/jboss/weld/logging/BeanManagerLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BeanManagerLogger.java
@@ -128,4 +128,13 @@ public interface BeanManagerLogger extends WeldLogger {
     @Message(id = 1336, value = "InjectionTargetFactory.configure() may not be called after createInjectionTarget() invocation. AnnotatedType used: {0}", format = Format.MESSAGE_FORMAT)
     IllegalStateException unableToConfigureInjectionTargetFactory(Object param1);
 
+    @Message(id = 1337, value = "BeanContainer#{0} requires all parameters to be non-null.", format = Format.MESSAGE_FORMAT)
+    IllegalArgumentException assignabilityMethodIllegalArgs(Object param1);
+
+    @Message(id = 1338, value = "All annotations passed into BeanContainer#{0} have to be CDI Qualifiers. Following annotation was not recognized as a qualifier: {1}", format = Format.MESSAGE_FORMAT)
+    IllegalArgumentException annotationNotAQualifier(Object param1, Object param2);
+
+    @Message(id = 1339, value = "Provided event type {0} cannot contain unresolvable type parameter", format = Format.MESSAGE_FORMAT)
+    IllegalArgumentException eventTypeUnresolvableWildcard(Object param1);
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <arquillian.tomcat.version>1.2.0.Final</arquillian.tomcat.version>
         <atinject.tck.version>2.0.1</atinject.tck.version>
         <!-- Version of the CDI 4.x release TCK -->
-        <cdi.tck-4-1.version>4.1.0-M1</cdi.tck-4-1.version>
+        <cdi.tck-4-1.version>4.1.0-SNAPSHOT</cdi.tck-4-1.version>
         <!-- By default, each mvn profile uses corresponding file from TCK repo, see jboss-tck-runner/pom.xml -->
         <!-- We can also use our own file, needed for relaxed mode testing (see WeldMethodInterceptor) -->
         <!-- Our variant is under src/test/tck/tck-tests.xml -->
@@ -88,8 +88,8 @@
         <shrinkwrap.version>1.2.6</shrinkwrap.version>
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
         <shrinkwrap.resolver.version>3.3.0</shrinkwrap.resolver.version>
-        <testng.version>7.4.0</testng.version>
-        <weld.api.version>6.0.Alpha2</weld.api.version>
+        <testng.version>7.9.0</testng.version>
+        <weld.api.version>6.0-SNAPSHOT</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>5.0.1.Final</wildfly.arquillian.version>
     </properties>


### PR DESCRIPTION
The PR is going to fail CI until we get a CDI API release and ideally a TCK release to have tests.

There are no Weld specific tests for this as Weld doesn't add anything beyond what's in the TCK coverage via https://github.com/jakartaee/cdi-tck/pull/526