### PR TITLE
WELD-2775 Make sure BM#getEvent() adds @Default qualifier correctly

### DIFF
--- a/impl/src/main/java/org/jboss/weld/event/EventMetadataImpl.java
+++ b/impl/src/main/java/org/jboss/weld/event/EventMetadataImpl.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Type;
 import java.util.Set;
 
 import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Default;
 import jakarta.enterprise.inject.spi.EventMetadata;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 
@@ -59,6 +60,9 @@ public final class EventMetadataImpl implements EventMetadata {
     public Set<Annotation> getQualifiers() {
         ImmutableSet.Builder<Annotation> builder = ImmutableSet.<Annotation> builder();
         builder.add(Any.Literal.INSTANCE);
+        if ((qualifiers != null && qualifiers.isEmpty()) || (qualifierArray != null && qualifierArray.length == 0)) {
+            builder.add(Default.Literal.INSTANCE);
+        }
         if (qualifiers != null) {
             return builder.addAll(qualifiers).build();
         } else if (qualifierArray != null) {

--- a/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/BeanManagerImpl.java
@@ -1361,7 +1361,7 @@ public class BeanManagerImpl implements WeldManager, Serializable {
         }
 
         // there are no qualifiers by default
-        // ResolvableBuilder.create() takes care of adding @Default if there is no qualifier selected
+        // @Default and @Any are added as needed in ObserverQualifier#buildEventResolvable
         @Override
         public Set<Annotation> getQualifiers() {
             return Collections.emptySet();

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/ObservingBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/ObservingBean.java
@@ -1,0 +1,92 @@
+package org.jboss.weld.tests.event;
+
+import java.lang.annotation.Annotation;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.EventMetadata;
+
+@ApplicationScoped
+public class ObservingBean {
+
+    private volatile int defaultObjectNotified = 0;
+    private volatile int defaultObjectAsyncNotified = 0;
+    private volatile int defaultPayloadNotified = 0;
+    private volatile int defaultPayloadAsyncNotified = 0;
+    private volatile Set<Annotation> defaultObjectQualifiers;
+    private volatile Set<Annotation> defaultObjectAsyncQualifiers;
+    private volatile Set<Annotation> defaultPayloadQualifiers;
+    private volatile Set<Annotation> defaultPayloadAsyncQualifiers;
+
+    public void observeDefaultObject(@Observes @Default Object payload, EventMetadata em) {
+        // object type is very broad, only look for Payload runtime type
+        if (em.getType().equals(Payload.class)) {
+            this.defaultObjectNotified++;
+            this.defaultObjectQualifiers = em.getQualifiers();
+        }
+    }
+
+    public void observeDefaultPayload(@Observes @Default Payload payload, EventMetadata em) {
+        this.defaultPayloadNotified++;
+        this.defaultPayloadQualifiers = em.getQualifiers();
+    }
+
+    public void observeDefaultObjectAsync(@ObservesAsync @Default Object payload, EventMetadata em) {
+        // object type is very broad, only look for Payload runtime type
+        if (em.getType().equals(Payload.class)) {
+            this.defaultObjectAsyncNotified++;
+            this.defaultObjectAsyncQualifiers = em.getQualifiers();
+        }
+    }
+
+    public void observeDefaultPayloadAsync(@ObservesAsync @Default Payload payload, EventMetadata em) {
+        this.defaultPayloadAsyncNotified++;
+        this.defaultPayloadAsyncQualifiers = em.getQualifiers();
+    }
+
+    public int getDefaultObjectNotified() {
+        return defaultObjectNotified;
+    }
+
+    public int getDefaultPayloadNotified() {
+        return defaultPayloadNotified;
+    }
+
+    public Set<Annotation> getDefaultObjectQualifiers() {
+        return defaultObjectQualifiers;
+    }
+
+    public Set<Annotation> getDefaultPayloadQualifiers() {
+        return defaultPayloadQualifiers;
+    }
+
+    public int getDefaultObjectAsyncNotified() {
+        return defaultObjectAsyncNotified;
+    }
+
+    public int getDefaultPayloadAsyncNotified() {
+        return defaultPayloadAsyncNotified;
+    }
+
+    public Set<Annotation> getDefaultObjectAsyncQualifiers() {
+        return defaultObjectAsyncQualifiers;
+    }
+
+    public Set<Annotation> getDefaultPayloadAsyncQualifiers() {
+        return defaultPayloadAsyncQualifiers;
+    }
+
+    public void reset() {
+        this.defaultPayloadNotified = 0;
+        this.defaultPayloadAsyncNotified = 0;
+        this.defaultObjectNotified = 0;
+        this.defaultObjectAsyncNotified = 0;
+        this.defaultObjectQualifiers = null;
+        this.defaultObjectAsyncQualifiers = null;
+        this.defaultPayloadQualifiers = null;
+        this.defaultPayloadAsyncQualifiers = null;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/Payload.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/Payload.java
@@ -1,0 +1,5 @@
+package org.jboss.weld.tests.event;
+
+// serves as an event payload
+public class Payload {
+}


### PR DESCRIPTION
Attempts to fix the missing `@Default` qualifier when firing events via `BeanManager.getEvent()` API.