### PR TITLE
Add support for generic field injection.

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -85,7 +85,12 @@
             <artifactId>bcel</artifactId>
             <optional>true</optional>
         </dependency>
-
+        
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId> 
+		</dependency>
+        
         <!-- test dependencies -->
 
         <dependency>

--- a/impl/src/main/java/org/jboss/weld/manager/InjectionTargetFactoryImpl.java
+++ b/impl/src/main/java/org/jboss/weld/manager/InjectionTargetFactoryImpl.java
@@ -58,6 +58,7 @@ public class InjectionTargetFactoryImpl<T> implements WeldInjectionTargetFactory
 
     private volatile EnhancedAnnotatedType<T> annotatedType;
     private volatile AnnotatedTypeConfiguratorImpl<T> configurator;
+    public static ThreadLocal<Class<?>> javaClassThreadLocal = new ThreadLocal<>();
 
     protected InjectionTargetFactoryImpl(AnnotatedType<T> type, BeanManagerImpl manager) {
         this.manager = manager;
@@ -80,6 +81,7 @@ public class InjectionTargetFactoryImpl<T> implements WeldInjectionTargetFactory
     private WeldInjectionTarget<T> createInjectionTarget(Bean<T> bean, boolean interceptor) {
         try {
             initAnnotatedType();
+            javaClassThreadLocal.set(originalAnnotatedType.getJavaClass());
             return validate(createInjectionTarget(annotatedType, bean, interceptor));
         } catch (Throwable e) {
             throw new IllegalArgumentException(e);

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <weld.api.version>6.0.Alpha2</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>5.0.1.Final</wildfly.arquillian.version>
+        <guava.version>33.0.0-jre</guava.version>
     </properties>
 
     <modules>
@@ -472,6 +473,13 @@
                 <version>${spotbugs-annotations-version}</version>
                 <optional>true</optional>
             </dependency>
+            
+             <dependency>
+    			<groupId>com.google.guava</groupId>
+    			<artifactId>guava</artifactId> 
+                <version>${guava.version}</version>
+    		</dependency>
+            
         </dependencies>
 
     </dependencyManagement>


### PR DESCRIPTION
weld not support  generic field injection yet.
For example:
```
public interface IService {
	void print();
}
@ApplicationScoped
public class ServiceImpl1 implements IService {
	@Override
	public void print() {
		System.out.println("-------ServiceImpl1---------");
	}
}
public abstract class AbstractCDIClass<T extends IService> {
	@Inject
	private T service;
	
	@Test
	public void test() {
		service.print();
	}
}
@ApplicationScoped
public class CDIImpl1 extends AbstractCDIClass<ServiceImpl1> {
	@Deployment
	public static JavaArchive getJavaArchive() {
		return ShrinkWrap.create(JavaArchive.class).addAsManifestResource("META-INF/beans.xml").addClass(CDIImpl1.class)
				.addClass(ServiceImpl1.class);

	}
}
```
If we run CDIImpl1,it will throw following exception :
```
org.jboss.weld.exceptions.DefinitionException: WELD-001407: Cannot declare an injection point with a type variable: [BackedAnnotatedField] @Inject private AbstractCDIClass.service
	at AbstractCDIClass.service(AbstractCDIClass.java:0)
  StackTrace
	at org.jboss.weld.bootstrap.Validator.validateInjectionPointForDefinitionErrors(Validator.java:301)
	at org.jboss.weld.bootstrap.Validator.validateInjectionPoint(Validator.java:287)
	at org.jboss.weld.bootstrap.Validator.validateProducer(Validator.java:425)
	at org.jboss.weld.injection.producer.InjectionTargetService.validateProducer(InjectionTargetService.java:36)
	at org.jboss.weld.manager.InjectionTargetFactoryImpl.validate(InjectionTargetFactoryImpl.java:153)
	at org.jboss.weld.manager.InjectionTargetFactoryImpl.createInjectionTarget(InjectionTargetFactoryImpl.java:81)
```
Or refer to this [stackoverflow question](https://stackoverflow.com/questions/7856253/using-inject-with-generic-type).

Could you please share your thoughts about the potential significance and value of the changes proposed in my PR? I would greatly appreciate any feedback or insights you could provide.
Thank you for your attention and guidance. 