### PR TITLE
WELD-2780 collection of changes for the invokers API

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <weld.api.bom.version>6.0.Beta2</weld.api.bom.version>
+        <weld.api.bom.version>6.0.Beta3</weld.api.bom.version>
         <gpg.plugin.version>3.2.0</gpg.plugin.version>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
         <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>

--- a/docs/reference/pom.xml
+++ b/docs/reference/pom.xml
@@ -112,7 +112,6 @@
                     <doctype>book</doctype>
                     <sourceDirectory>${basedir}/src/main/asciidoc</sourceDirectory>
                     <templateEngine>slim</templateEngine>
-                    <headerFooter>true</headerFooter>
                     <attributes>
                         <docinfo>true</docinfo>
                         <experimental>true</experimental>

--- a/docs/reference/src/main/asciidoc/extend.asciidoc
+++ b/docs/reference/src/main/asciidoc/extend.asciidoc
@@ -152,8 +152,11 @@ See also chapter http://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#configurators[
 
 ==== Weld-enriched container lifecycle events
 
-Apart from CDI-defined lifecycle events, Weld also offers enriched observable container lifecycle event - `WeldAfterBeanDiscovery`.
-Compared to `jakarta.enterprise.inject.spi.AfterBeanDiscovery`, it adds one extra method - `addInterceptor()`.
+Apart from CDI-defined lifecycle events, Weld also offers enriched observable container lifecycle events - `WeldAfterBeanDiscovery` and `WeldProcessManagedBean`.
+
+===== `WeldAfterBeanDiscovery`
+
+Compared to `jakarta.enterprise.inject.spi.AfterBeanDiscovery`, this interface adds one extra method - `addInterceptor()`.
 This method works in the same way as the aforementioned <<_configurators>>; you get back an `InterceptorConfigurator` instance, where you can set all the desired data.
 The interceptor is created automatically, once the methods exits and the configurator instance is not reusable.
 But if you need to create several interceptors, you can simply request several configurator instances.
@@ -179,6 +182,12 @@ public void afterBeanDiscovery(@Observes WeldAfterBeanDiscovery event) {
 The sample presents a simple interception use case where you supply `java.util.function.Function` as the interceptor body method.
 For more complex cases, you may also choose to use `interceptWithMetadata` method which accepts `java.util.function.BiFunction` instead.
 The second parameter of the `BiFunction` emulates `@Inject @Intercepted Bean<?>` allowing access to metadata.
+
+===== `WeldProcessManagedBean`
+
+Compared to specification defined API, `WeldProcessManagedBean` overrides its method for invoker creation granting access
+to `org.jboss.weld.invoke.WeldInvokerBuilder` which is an enhanced version enabling use of various transformers.
+This is captured in greater detail within <<weldinvoker>> chapter.
 
 === The `BeanManager` object
 

--- a/docs/reference/src/main/asciidoc/part5.asciidoc
+++ b/docs/reference/src/main/asciidoc/part5.asciidoc
@@ -29,4 +29,6 @@ include::weldmanager.asciidoc[]
 
 include::contexts.asciidoc[]
 
+include::weldinvoker.asciidoc[]
+
 include::ri-spi.asciidoc[]

--- a/docs/reference/src/main/asciidoc/weldinvoker.asciidoc
+++ b/docs/reference/src/main/asciidoc/weldinvoker.asciidoc
@@ -1,0 +1,88 @@
+ifdef::generate-index-link[]
+link:index.html[Weld {weldVersion} - CDI Reference Implementation]
+endif::[]
+
+[[weldinvoker]]
+== Enhanced `InvokerBuilder` API
+
+CDI 4.1 introduced `jakarta.enterprise.invoke.InvokerBuilder` API and Weld adds its own variant - `org.jboss.weld.invoke.WeldInvokerBuilder`.
+
+Main purpose of this API is to allow users to register various transformers for given method. This ranges from input transformers such as argument and instance transformer to output transformers which include return value and exception transformers. Last but not least, there is also invocation wrapper which provides the most flexibility by wrapping the whole invoker method call.
+
+Below is a list of methods available in `WeldInvokerBuilder`.
+
+[source.JAVA, java]
+-------------------------------------------------------------------------------------------------------------------------------------------------
+public interface WeldInvokerBuilder<T> extends InvokerBuilder<T> {
+
+    WeldInvokerBuilder<T> withInstanceLookup();
+    WeldInvokerBuilder<T> withArgumentLookup(int position);
+    WeldInvokerBuilder<T> withInstanceTransformer(Class<?> clazz, String methodName);
+    WeldInvokerBuilder<T> withArgumentTransformer(int position, Class<?> clazz, String methodName);
+    WeldInvokerBuilder<T> withReturnValueTransformer(Class<?> clazz, String methodName);
+    WeldInvokerBuilder<T> withExceptionTransformer(Class<?> clazz, String methodName);
+    WeldInvokerBuilder<T> withInvocationWrapper(Class<?> clazz, String methodName);
+}
+-------------------------------------------------------------------------------------------------------------------------------------------------
+
+A transformer is method defined by the `Class<?>` which declares it and its name as `String`.
+Transformers may be `static`, in which case they must be declared directly on the given class, or they may be instance methods, in which case they may be declared on the given class or inherited from any of its supertypes.
+Invocation wrappers must be `static` and must be declared directly on the given class.
+
+See javadoc of `WeldInvokerBuilder` for detailed documentation.
+
+=== How To Use
+
+Just like its CDI variant, `WeldInvokerBuilder` can be obtained either from Portable Extension or a Build Compatible Extension.
+While running Weld, all container provided implementations of `InvokerBuilder` will be instances of `WeldInvokerBuilder` so users can always just type cast from the original CDI API. However, that's not very convenient which is why the next two sections detail how to do it properly in whichever extension system you use.
+
+==== Build Compatible Extensions
+
+Standard way to create an invoker in these extensions is through method annotated `@Registration` with `jakarta.enterprise.inject.build.compatible.spi.InvokerFactory` as its parameter. Weld variant introduces a subclass of this parameter that should be used - `org.jboss.weld.invoke.WeldInvokerFactory`.
+That's all it takes; let's look at an example:
+
+[source.JAVA, java]
+-------------------------------------------------------------------------------------------------------------------------------------------------
+    private InvokerInfo staticArgTransformingInvoker;
+    private InvokerInfo argTransformingInvoker;
+
+
+    @Registration(types = TransformableBean.class)
+    public void createArgTransformationInvokers(BeanInfo b, WeldInvokerFactory invokers) {
+        Collection<MethodInfo> invokableMethods = b.declaringClass().methods();
+        // assume the bean has two methods - "ping" and "staticPing"
+        for (MethodInfo invokableMethod : invokableMethods) {
+            if (invokableMethod.name().contains("staticPing")) {
+                staticArgTransformingInvoker = invokers.createInvoker(b, invokableMethod)
+                        .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
+                        .withArgumentTransformer(1, ArgTransformer.class, "transform") // static Transformer method
+                        .build();
+            } else if (invokableMethod.name().contains("ping")) {
+                argTransformingInvoker = invokers.createInvoker(b, invokableMethod)
+                        .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
+                        .withArgumentTransformer(1, ArgTransformer.class, "transform") // static Transformer method
+                        .build();
+            }
+        }
+    }
+-------------------------------------------------------------------------------------------------------------------------------------------------
+
+==== Portable Extensions
+
+In Portable Extensions, the standard approach is to observe `ProcessManagedBean` event and its `createInvoker(...)` method.
+Weld offers a subclass of this event which should be used instead - `org.jboss.weld.bootstrap.event.WeldProcessManagedBean`.
+Below is an example code snippet:
+
+[source.JAVA, java]
+-------------------------------------------------------------------------------------------------------------------------------------------------
+    private Invoker<SomeBean, ?> transformReturnType;
+
+    public void createInvokers(@Observes WeldProcessManagedBean<SomeBean> pmb) {
+        Collection<AnnotatedMethod<? super SomeBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
+        // assuming there is only one method in SomeBean
+        AnnotatedMethod<? super SomeBean> invokableMethod = invokableMethods.iterator().next();
+        transformReturnType = pmb.createInvoker(invokableMethod)
+                .withReturnValueTransformer(Transformer.class, "transformReturn1")
+                .build();
+    }}
+-------------------------------------------------------------------------------------------------------------------------------------------------

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/ContainerLifecycleObserver.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/ContainerLifecycleObserver.java
@@ -57,6 +57,7 @@ import jakarta.enterprise.util.TypeLiteral;
 
 import org.jboss.weld.bootstrap.SyntheticExtension;
 import org.jboss.weld.bootstrap.event.WeldAfterBeanDiscovery;
+import org.jboss.weld.bootstrap.event.WeldProcessManagedBean;
 import org.jboss.weld.bootstrap.events.NotificationListener;
 import org.jboss.weld.environment.se.logging.WeldSELogger;
 import org.jboss.weld.event.ContainerLifecycleEventObserverMethod;
@@ -310,8 +311,8 @@ public final class ContainerLifecycleObserver<T> implements ContainerLifecycleEv
      * @see ProcessManagedBean
      */
     @SuppressWarnings("serial")
-    public static Builder<ProcessManagedBean<?>> processManagedBean() {
-        return processManagedBean(new TypeLiteral<ProcessManagedBean<?>>() {
+    public static Builder<WeldProcessManagedBean<?>> processManagedBean() {
+        return processManagedBean(new TypeLiteral<WeldProcessManagedBean<?>>() {
         }.getType());
     }
 
@@ -321,9 +322,9 @@ public final class ContainerLifecycleObserver<T> implements ContainerLifecycleEv
      * @return a new builder instance
      * @see ProcessManagedBean
      */
-    public static Builder<ProcessManagedBean<?>> processManagedBean(Type observedType) {
-        checkRawType(observedType, ProcessManagedBean.class);
-        return ContainerLifecycleObserver.<ProcessManagedBean<?>> of(observedType);
+    public static Builder<WeldProcessManagedBean<?>> processManagedBean(Type observedType) {
+        checkRawType(observedType, WeldProcessManagedBean.class);
+        return ContainerLifecycleObserver.<WeldProcessManagedBean<?>> of(observedType);
     }
 
     /**

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/AbstractProcessClassBean.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/AbstractProcessClassBean.java
@@ -26,12 +26,12 @@ import jakarta.enterprise.inject.spi.Decorator;
 import jakarta.enterprise.inject.spi.Interceptor;
 import jakarta.enterprise.inject.spi.ProcessBean;
 import jakarta.enterprise.invoke.Invoker;
-import jakarta.enterprise.invoke.InvokerBuilder;
 
 import org.jboss.weld.bean.ClassBean;
 import org.jboss.weld.exceptions.DeploymentException;
 import org.jboss.weld.invokable.InvokerBuilderImpl;
 import org.jboss.weld.invokable.TargetMethod;
+import org.jboss.weld.invoke.WeldInvokerBuilder;
 import org.jboss.weld.manager.BeanManagerImpl;
 
 public abstract class AbstractProcessClassBean<X, B extends ClassBean<X>> extends AbstractDefinitionContainerEvent
@@ -54,7 +54,7 @@ public abstract class AbstractProcessClassBean<X, B extends ClassBean<X>> extend
         return bean;
     }
 
-    public InvokerBuilder<Invoker<X, ?>> createInvoker(AnnotatedMethod<? super X> annotatedMethod) {
+    public WeldInvokerBuilder<Invoker<X, ?>> createInvoker(AnnotatedMethod<? super X> annotatedMethod) {
         checkWithinObserverNotification();
 
         ClassBean<X> bean = getBean();

--- a/impl/src/main/java/org/jboss/weld/bootstrap/events/ProcessManagedBeanImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/events/ProcessManagedBeanImpl.java
@@ -19,12 +19,13 @@ package org.jboss.weld.bootstrap.events;
 import java.lang.reflect.Type;
 
 import jakarta.enterprise.inject.spi.AnnotatedType;
-import jakarta.enterprise.inject.spi.ProcessManagedBean;
 
 import org.jboss.weld.bean.ManagedBean;
+import org.jboss.weld.bootstrap.event.WeldProcessManagedBean;
 import org.jboss.weld.manager.BeanManagerImpl;
 
-public class ProcessManagedBeanImpl<X> extends AbstractProcessClassBean<X, ManagedBean<X>> implements ProcessManagedBean<X> {
+public class ProcessManagedBeanImpl<X> extends AbstractProcessClassBean<X, ManagedBean<X>>
+        implements WeldProcessManagedBean<X> {
 
     protected static <X> void fire(BeanManagerImpl beanManager, ManagedBean<X> bean) {
         if (beanManager.isBeanEnabled(bean)) {
@@ -34,7 +35,7 @@ public class ProcessManagedBeanImpl<X> extends AbstractProcessClassBean<X, Manag
     }
 
     public ProcessManagedBeanImpl(BeanManagerImpl beanManager, ManagedBean<X> bean) {
-        super(beanManager, ProcessManagedBean.class, new Type[] { bean.getAnnotated().getBaseType() }, bean);
+        super(beanManager, WeldProcessManagedBean.class, new Type[] { bean.getAnnotated().getBaseType() }, bean);
     }
 
     public AnnotatedType<X> getAnnotatedBeanClass() {

--- a/impl/src/main/java/org/jboss/weld/invokable/AbstractInvokerBuilder.java
+++ b/impl/src/main/java/org/jboss/weld/invokable/AbstractInvokerBuilder.java
@@ -13,6 +13,7 @@ import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 import org.jboss.weld.invoke.WeldInvokerBuilder;
+import org.jboss.weld.logging.InvokerLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
 
 public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder<T> {
@@ -47,9 +48,7 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
     @Override
     public WeldInvokerBuilder<T> withArgumentLookup(int position) {
         if (position < 0 || position >= argLookup.length) {
-            // TODO better exception, use Logger interface
-            throw new IllegalArgumentException("Cannot lookup argument " + position
-                    + ", the number of method parameters is " + argLookup.length);
+            throw InvokerLogger.LOG.invalidArgumentPosition("argument lookup", position, argLookup.length);
         }
         argLookup[position] = true;
         return this;
@@ -58,8 +57,7 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
     @Override
     public WeldInvokerBuilder<T> withInstanceTransformer(Class<?> clazz, String methodName) {
         if (instanceTransformer != null) {
-            // TODO better exception, use Logger interface
-            throw new IllegalStateException("Instance transformer already set");
+            throw InvokerLogger.LOG.settingTransformerRepeatedly("Instance");
         }
         this.instanceTransformer = new TransformerMetadata(clazz, methodName, TransformerType.INSTANCE);
         return this;
@@ -68,13 +66,10 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
     @Override
     public WeldInvokerBuilder<T> withArgumentTransformer(int position, Class<?> clazz, String methodName) {
         if (position < 0 || position >= argTransformers.length) {
-            // TODO better exception, use Logger interface
-            throw new IllegalArgumentException("Cannot transform argument " + position
-                    + ", the number of method parameters is " + argLookup.length);
+            throw InvokerLogger.LOG.invalidArgumentPosition("argument transformer", position, argLookup.length);
         }
         if (argTransformers[position] != null) {
-            // TODO better exception, use Logger interface
-            throw new IllegalStateException("Argument transformer " + position + " already set");
+            throw InvokerLogger.LOG.settingTransformerRepeatedly("Argument");
         }
         this.argTransformers[position] = new TransformerMetadata(clazz, methodName, TransformerType.ARGUMENT);
         return this;
@@ -83,8 +78,7 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
     @Override
     public WeldInvokerBuilder<T> withReturnValueTransformer(Class<?> clazz, String methodName) {
         if (returnValueTransformer != null) {
-            // TODO better exception, use Logger interface
-            throw new IllegalStateException("Return value transformer already set");
+            throw InvokerLogger.LOG.settingTransformerRepeatedly("Return value");
         }
         this.returnValueTransformer = new TransformerMetadata(clazz, methodName, TransformerType.RETURN_VALUE);
         return this;
@@ -93,8 +87,7 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
     @Override
     public WeldInvokerBuilder<T> withExceptionTransformer(Class<?> clazz, String methodName) {
         if (exceptionTransformer != null) {
-            // TODO better exception, use Logger interface
-            throw new IllegalStateException("Exception transformer already set");
+            throw InvokerLogger.LOG.settingTransformerRepeatedly("Exception");
         }
         this.exceptionTransformer = new TransformerMetadata(clazz, methodName, TransformerType.EXCEPTION);
         return this;
@@ -103,8 +96,7 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
     @Override
     public WeldInvokerBuilder<T> withInvocationWrapper(Class<?> clazz, String methodName) {
         if (invocationWrapper != null) {
-            // TODO better exception, use Logger interface
-            throw new IllegalStateException("Invocation wrapper already set");
+            throw InvokerLogger.LOG.settingTransformerRepeatedly("Invocation wrapper");
         }
         this.invocationWrapper = new TransformerMetadata(clazz, methodName, TransformerType.WRAPPER);
         return this;
@@ -157,7 +149,7 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
                 instanceArguments++;
             } else {
                 // internal error, this should not pass validation
-                throw new IllegalStateException("Invalid instance transformer method: " + instanceTransformer);
+                throw InvokerLogger.LOG.invalidTransformerMethod("instance", instanceTransformer);
             }
         }
 
@@ -178,7 +170,7 @@ public abstract class AbstractInvokerBuilder<B, T> implements WeldInvokerBuilder
                 mh = MethodHandles.collectArguments(mh, position, argTransformerMethod);
             } else {
                 // internal error, this should not pass validation
-                throw new IllegalStateException("Invalid argument transformer method: " + argTransformers[i]);
+                throw InvokerLogger.LOG.invalidTransformerMethod("argument", argTransformers[i]);
             }
         }
 

--- a/impl/src/main/java/org/jboss/weld/logging/Category.java
+++ b/impl/src/main/java/org/jboss/weld/logging/Category.java
@@ -37,6 +37,7 @@ public enum Category {
     SERIALIZATION("Serialization"),
     CONFIGURATION("Configuration"),
     LITE_EXTENSION_TRANSLATOR("LiteExtensionTranslator"),
+    INVOKER("Invoker"),
     ;
 
     private static final String LOG_PREFIX = "org.jboss.weld.";

--- a/impl/src/main/java/org/jboss/weld/logging/InvokerLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/InvokerLogger.java
@@ -2,18 +2,67 @@ package org.jboss.weld.logging;
 
 import static org.jboss.weld.logging.WeldLogger.WELD_PROJECT_CODE;
 
+import org.jboss.logging.Logger;
+import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.weld.exceptions.DeploymentException;
 import org.jboss.weld.exceptions.IllegalArgumentException;
+import org.jboss.weld.exceptions.IllegalStateException;
 
 /**
- * Log messages for validation related classes.
+ * Log messages for {@link jakarta.enterprise.invoke.Invoker}, {@link jakarta.enterprise.invoke.InvokerBuilder}
+ * and related Weld classes.
  *
  * Message IDs: 002000 - 002099
  */
 @MessageLogger(projectCode = WELD_PROJECT_CODE)
 public interface InvokerLogger extends WeldLogger {
 
-    @Message(id = 2000, value = "TBD {0}", format = Message.Format.MESSAGE_FORMAT)
-    IllegalArgumentException tbd(Object param1);
+    InvokerLogger LOG = Logger.getMessageLogger(InvokerLogger.class, Category.INVOKER.getName());
+
+    @Message(id = 2000, value = "Cannot apply {0} to method argument with position {1}; total number of method parameters is {2}", format = Message.Format.MESSAGE_FORMAT)
+    IllegalArgumentException invalidArgumentPosition(String kindOfTransformer, int position, int argLookupLength);
+
+    @Message(id = 2001, value = "{0} transformer is already set! InvokerBuilder transformers cannot be set repeatedly.", format = Message.Format.MESSAGE_FORMAT)
+    IllegalArgumentException settingTransformerRepeatedly(String kindOfTransformer);
+
+    @Message(id = 2002, value = "Invalid {0} transformer method: {1}", format = Message.Format.MESSAGE_FORMAT)
+    IllegalStateException invalidTransformerMethod(String kindOfTransformer, Object transformerMetadata);
+
+    @Message(id = 2003, value = "No matching transformer method found for {0}. There has to be exactly one matching method.", format = Message.Format.MESSAGE_FORMAT)
+    IllegalStateException noMatchingTransformerMethod(Object transformerMetadata);
+
+    @Message(id = 2004, value = "Multiple matching transformer methods found for {0}. There has to be exactly one matching method; instead, following methods were found: {1}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException multipleMatchingTransformerMethod(Object transformerMetadata, Object listOfMatches);
+
+    @Message(id = 2005, value = "Unable to create method handle for method: {0}", format = Message.Format.MESSAGE_FORMAT)
+    RuntimeException cannotCreateMethodHandle(Object method, @Cause Throwable cause);
+
+    @Message(id = 2006, value = "All invocation transformers need to be public - {0}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException nonPublicTransformer(Object transformerMetadata);
+
+    @Message(id = 2007, value = "Input transformer {0} has a return value that is not assignable to expected class: {1}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException inputTransformerNotAssignable(Object transformerMetadata, Object clazz);
+
+    @Message(id = 2008, value = "Non-static input transformers are expected to have zero input parameters! Transformer: {0}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException nonStaticInputTransformerHasParams(Object transformerMetadata);
+
+    @Message(id = 2009, value = "Static input transformers can only have one or two parameters! Transformer: {0}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException staticInputTransformerParams(Object transformerMetadata);
+
+    @Message(id = 2010, value = "Static input transformers with two parameters can only have Consumer<Runnable> as their second parameter! Transformer: {0}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException staticInputTransformerIncorrectParams(Object transformerMetadata);
+
+    @Message(id = 2011, value = "Non-static output transformers are expected to have zero input parameters! Transformer: {0}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException nonStaticOutputTransformerHasParams(Object transformerMetadata);
+
+    @Message(id = 2012, value = "Static output transformers are expected to have one input parameter! Transformer: {0}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException staticOutputTransformerParams(Object transformerMetadata);
+
+    @Message(id = 2013, value = "Output transformer {0} parameter is not assignable to the expected class: {1}", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException outputTransformerNotAssignable(Object transformerMetadata, Object clazz);
+
+    @Message(id = 2014, value = "Invocation wrapper has unexpected parameters: {0} \nExpected param types are: {1}, Object[], Invoker.class", format = Message.Format.MESSAGE_FORMAT)
+    DeploymentException wrapperUnexpectedParams(Object transformerMetadata, Object clazz);
 }

--- a/impl/src/main/java/org/jboss/weld/util/Observers.java
+++ b/impl/src/main/java/org/jboss/weld/util/Observers.java
@@ -49,6 +49,7 @@ import jakarta.enterprise.inject.spi.ProcessSyntheticObserverMethod;
 
 import org.jboss.weld.bootstrap.SpecializationAndEnablementRegistry;
 import org.jboss.weld.bootstrap.event.WeldAfterBeanDiscovery;
+import org.jboss.weld.bootstrap.event.WeldProcessManagedBean;
 import org.jboss.weld.event.ContainerLifecycleEventObserverMethod;
 import org.jboss.weld.event.EventMetadataAwareObserverMethod;
 import org.jboss.weld.event.ObserverMethodImpl;
@@ -79,9 +80,8 @@ public class Observers {
     public static final Set<Class<?>> CONTAINER_LIFECYCLE_EVENT_TYPES = ImmutableSet.<Class<?>> builder()
             .addAll(CONTAINER_LIFECYCLE_EVENT_CANONICAL_SUPERTYPES)
             .addAll(ProcessSyntheticAnnotatedType.class, ProcessSessionBean.class, ProcessManagedBean.class,
-                    ProcessProducerMethod.class,
-                    ProcessProducerField.class, ProcessSyntheticBean.class, ProcessSyntheticObserverMethod.class,
-                    WeldAfterBeanDiscovery.class)
+                    ProcessProducerMethod.class, ProcessProducerField.class, ProcessSyntheticBean.class,
+                    ProcessSyntheticObserverMethod.class, WeldAfterBeanDiscovery.class, WeldProcessManagedBean.class)
             .build();
 
     private static final String NOTIFY_METHOD_NAME = "notify";

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
         <shrinkwrap.resolver.version>3.3.0</shrinkwrap.resolver.version>
         <testng.version>7.9.0</testng.version>
-        <weld.api.version>6.0-SNAPSHOT</weld.api.version>
+        <weld.api.version>6.0.Beta3</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>5.0.1.Final</wildfly.arquillian.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
         <shrinkwrap.resolver.version>3.3.0</shrinkwrap.resolver.version>
         <testng.version>7.9.0</testng.version>
-        <weld.api.version>6.0.Beta2</weld.api.version>
+        <weld.api.version>6.0-SNAPSHOT</weld.api.version>
         <weld.logging.tools.version>1.0.3.Final</weld.logging.tools.version>
         <wildfly.arquillian.version>5.0.1.Final</wildfly.arquillian.version>
     </properties>

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/BuildCompatExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/BuildCompatExtension.java
@@ -6,7 +6,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
 import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
-import jakarta.enterprise.inject.build.compatible.spi.InvokerFactory;
 import jakarta.enterprise.inject.build.compatible.spi.InvokerInfo;
 import jakarta.enterprise.inject.build.compatible.spi.Parameters;
 import jakarta.enterprise.inject.build.compatible.spi.Registration;
@@ -16,7 +15,7 @@ import jakarta.enterprise.inject.build.compatible.spi.SyntheticComponents;
 import jakarta.enterprise.invoke.Invoker;
 import jakarta.enterprise.lang.model.declarations.MethodInfo;
 
-import org.jboss.weld.invoke.WeldInvokerBuilder;
+import org.jboss.weld.invoke.WeldInvokerFactory;
 import org.jboss.weld.tests.invokable.common.ArgTransformer;
 import org.jboss.weld.tests.invokable.common.ExceptionTransformer;
 import org.jboss.weld.tests.invokable.common.FooArg;
@@ -134,7 +133,7 @@ public class BuildCompatExtension implements BuildCompatibleExtension {
     }
 
     @Registration(types = SimpleBean.class)
-    public void createNoTransformationInvokers(BeanInfo b, InvokerFactory invokers) {
+    public void createNoTransformationInvokers(BeanInfo b, WeldInvokerFactory invokers) {
         Collection<MethodInfo> invokableMethods = b.declaringClass().methods();
         Assert.assertEquals(4, invokableMethods.size());
         for (MethodInfo invokableMethod : invokableMethods) {
@@ -157,27 +156,25 @@ public class BuildCompatExtension implements BuildCompatibleExtension {
     }
 
     @Registration(types = TransformableBean.class)
-    public void createArgTransformationInvokers(BeanInfo b, InvokerFactory invokers) {
+    public void createArgTransformationInvokers(BeanInfo b, WeldInvokerFactory invokers) {
         Collection<MethodInfo> invokableMethods = b.declaringClass().methods();
         Assert.assertEquals(4, invokableMethods.size());
         for (MethodInfo invokableMethod : invokableMethods) {
             if (invokableMethod.name().contains("staticPing")) {
-                staticArgTransformingInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                staticArgTransformingInvoker = invokers.createInvoker(b, invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform") // static Transformer method
                         .build();
-                staticArgTransformerWithConsumerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b,
-                        invokableMethod))
+                staticArgTransformerWithConsumerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform2") // static Transformer method with Consumer
                         .build();
             } else if (invokableMethod.name().contains("ping")) {
-                argTransformingInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                argTransformingInvoker = invokers.createInvoker(b, invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform") // static Transformer method
                         .build();
-                argTransformerWithConsumerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b,
-                        invokableMethod))
+                argTransformerWithConsumerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform2") // static Transformer method with Consumer
                         .build();
@@ -186,20 +183,18 @@ public class BuildCompatExtension implements BuildCompatibleExtension {
     }
 
     @Registration(types = TransformableBean.class)
-    public void createInstanceTransformationInvokers(BeanInfo b, InvokerFactory invokers) {
+    public void createInstanceTransformationInvokers(BeanInfo b, WeldInvokerFactory invokers) {
         Collection<MethodInfo> invokableMethods = b.declaringClass().methods();
         Assert.assertEquals(4, invokableMethods.size());
         for (MethodInfo invokableMethod : invokableMethods) {
             if (invokableMethod.name().contains("ping")) {
-                instanceTransformerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                instanceTransformerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withInstanceTransformer(InstanceTransformer.class, "transform")
                         .build();
-                instanceTransformerWithConsumerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b,
-                        invokableMethod))
+                instanceTransformerWithConsumerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withInstanceTransformer(InstanceTransformer.class, "transform2")
                         .build();
-                instanceTransformerNoParamInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b,
-                        invokableMethod))
+                instanceTransformerNoParamInvoker = invokers.createInvoker(b, invokableMethod)
                         .withInstanceTransformer(TransformableBean.class, "setTransformed")
                         .build();
             }
@@ -207,24 +202,23 @@ public class BuildCompatExtension implements BuildCompatibleExtension {
     }
 
     @Registration(types = TransformableBean.class)
-    public void createReturnValueTransformationInvokers(BeanInfo b, InvokerFactory invokers) {
+    public void createReturnValueTransformationInvokers(BeanInfo b, WeldInvokerFactory invokers) {
         Collection<MethodInfo> invokableMethods = b.declaringClass().methods();
         Assert.assertEquals(4, invokableMethods.size());
         for (MethodInfo invokableMethod : invokableMethods) {
             if (invokableMethod.name().contains("ping")) {
-                returnTransformerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                returnTransformerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withReturnValueTransformer(ReturnValueTransformer.class, "transform")
                         .build();
-                returnTransformerNoParamInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                returnTransformerNoParamInvoker = invokers.createInvoker(b, invokableMethod)
                         .withReturnValueTransformer(String.class, "strip")
                         .build();
 
             } else if (invokableMethod.name().contains("staticPing")) {
-                staticReturnTransformerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                staticReturnTransformerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withReturnValueTransformer(ReturnValueTransformer.class, "transform")
                         .build();
-                staticReturnTransformerNoParamInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b,
-                        invokableMethod))
+                staticReturnTransformerNoParamInvoker = invokers.createInvoker(b, invokableMethod)
                         .withReturnValueTransformer(String.class, "strip")
                         .build();
             }
@@ -232,18 +226,17 @@ public class BuildCompatExtension implements BuildCompatibleExtension {
     }
 
     @Registration(types = TrulyExceptionalBean.class)
-    public void createExceptionTransformationInvokers(BeanInfo b, InvokerFactory invokers) {
+    public void createExceptionTransformationInvokers(BeanInfo b, WeldInvokerFactory invokers) {
         Collection<MethodInfo> invokableMethods = b.declaringClass().methods();
         Assert.assertEquals(2, invokableMethods.size());
         for (MethodInfo invokableMethod : invokableMethods) {
             if (invokableMethod.name().contains("ping")) {
-                exceptionTransformerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                exceptionTransformerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withExceptionTransformer(ExceptionTransformer.class, "transform")
                         .build();
 
             } else if (invokableMethod.name().contains("staticPing")) {
-                staticExceptionTransformerInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b,
-                        invokableMethod))
+                staticExceptionTransformerInvoker = invokers.createInvoker(b, invokableMethod)
                         .withExceptionTransformer(ExceptionTransformer.class, "transform")
                         .build();
             }
@@ -251,17 +244,17 @@ public class BuildCompatExtension implements BuildCompatibleExtension {
     }
 
     @Registration(types = SimpleBean.class)
-    public void createInvocationWrapperInvokers(BeanInfo b, InvokerFactory invokers) {
+    public void createInvocationWrapperInvokers(BeanInfo b, WeldInvokerFactory invokers) {
         Collection<MethodInfo> invokableMethods = b.declaringClass().methods();
         Assert.assertEquals(4, invokableMethods.size());
         for (MethodInfo invokableMethod : invokableMethods) {
             if (invokableMethod.name().contains("ping")) {
-                invocationWrapperInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                invocationWrapperInvoker = invokers.createInvoker(b, invokableMethod)
                         .withInvocationWrapper(InvocationWrapper.class, "transform")
                         .build();
 
             } else if (invokableMethod.name().contains("staticPing")) {
-                staticInvocationWrapperInvoker = ((WeldInvokerBuilder<InvokerInfo>) invokers.createInvoker(b, invokableMethod))
+                staticInvocationWrapperInvoker = invokers.createInvoker(b, invokableMethod)
                         .withInvocationWrapper(InvocationWrapper.class, "transform")
                         .build();
             }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/ObservingExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/ObservingExtension.java
@@ -5,10 +5,9 @@ import java.util.Collection;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.Extension;
-import jakarta.enterprise.inject.spi.ProcessManagedBean;
 import jakarta.enterprise.invoke.Invoker;
 
-import org.jboss.weld.invoke.WeldInvokerBuilder;
+import org.jboss.weld.bootstrap.event.WeldProcessManagedBean;
 import org.jboss.weld.tests.invokable.common.ArgTransformer;
 import org.jboss.weld.tests.invokable.common.ExceptionTransformer;
 import org.jboss.weld.tests.invokable.common.FooArg;
@@ -149,7 +148,7 @@ public class ObservingExtension implements Extension {
     private Invoker<SimpleBean, ?> invocationWrapperInvoker;
     private Invoker<SimpleBean, ?> staticInvocationWrapperInvoker;
 
-    public void createNoTransformationInvokers(@Observes ProcessManagedBean<SimpleBean> pmb) {
+    public void createNoTransformationInvokers(@Observes WeldProcessManagedBean<SimpleBean> pmb) {
         Collection<AnnotatedMethod<? super SimpleBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(4, invokableMethods.size());
         for (AnnotatedMethod<? super SimpleBean> invokableMethod : invokableMethods) {
@@ -169,29 +168,25 @@ public class ObservingExtension implements Extension {
         }
     }
 
-    public void createArgTransformationInvokers(@Observes ProcessManagedBean<TransformableBean> pmb) {
+    public void createArgTransformationInvokers(@Observes WeldProcessManagedBean<TransformableBean> pmb) {
         Collection<AnnotatedMethod<? super TransformableBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(4, invokableMethods.size());
         for (AnnotatedMethod<? super TransformableBean> invokableMethod : invokableMethods) {
             if (invokableMethod.getJavaMember().getName().contains("staticPing")) {
-                staticArgTransformingInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                staticArgTransformingInvoker = pmb.createInvoker(invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform") // static Transformer method
                         .build();
-                staticArgTransformerWithConsumerInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                staticArgTransformerWithConsumerInvoker = pmb.createInvoker(invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform2") // static Transformer method with Consumer
                         .build();
             } else if (invokableMethod.getJavaMember().getName().contains("ping")) {
-                argTransformingInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                argTransformingInvoker = pmb.createInvoker(invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform") // static Transformer method
                         .build();
-                argTransformerWithConsumerInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                argTransformerWithConsumerInvoker = pmb.createInvoker(invokableMethod)
                         .withArgumentTransformer(0, FooArg.class, "doubleTheString") // non-static Transformer method
                         .withArgumentTransformer(1, ArgTransformer.class, "transform2") // static Transformer method with Consumer
                         .build();
@@ -199,85 +194,75 @@ public class ObservingExtension implements Extension {
         }
     }
 
-    public void createInstanceTransformationInvokers(@Observes ProcessManagedBean<TransformableBean> pmb) {
+    public void createInstanceTransformationInvokers(@Observes WeldProcessManagedBean<TransformableBean> pmb) {
         Collection<AnnotatedMethod<? super TransformableBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(4, invokableMethods.size());
         for (AnnotatedMethod<? super TransformableBean> invokableMethod : invokableMethods) {
             if (invokableMethod.getJavaMember().getName().contains("ping")) {
-                instanceTransformerInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                instanceTransformerInvoker = pmb.createInvoker(invokableMethod)
                         .withInstanceTransformer(InstanceTransformer.class, "transform")
                         .build();
-                instanceTransformerWithConsumerInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                instanceTransformerWithConsumerInvoker = pmb.createInvoker(invokableMethod)
                         .withInstanceTransformer(InstanceTransformer.class, "transform2")
                         .build();
-                instanceTransformerNoParamInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                instanceTransformerNoParamInvoker = pmb.createInvoker(invokableMethod)
                         .withInstanceTransformer(TransformableBean.class, "setTransformed")
                         .build();
             }
         }
     }
 
-    public void createReturnValueTransformationInvokers(@Observes ProcessManagedBean<TransformableBean> pmb) {
+    public void createReturnValueTransformationInvokers(@Observes WeldProcessManagedBean<TransformableBean> pmb) {
         Collection<AnnotatedMethod<? super TransformableBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(4, invokableMethods.size());
         for (AnnotatedMethod<? super TransformableBean> invokableMethod : invokableMethods) {
             if (invokableMethod.getJavaMember().getName().contains("ping")) {
-                returnTransformerInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                returnTransformerInvoker = pmb.createInvoker(invokableMethod)
                         .withReturnValueTransformer(ReturnValueTransformer.class, "transform")
                         .build();
-                returnTransformerNoParamInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                returnTransformerNoParamInvoker = pmb.createInvoker(invokableMethod)
                         .withReturnValueTransformer(String.class, "strip")
                         .build();
 
             } else if (invokableMethod.getJavaMember().getName().contains("staticPing")) {
-                staticReturnTransformerInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                staticReturnTransformerInvoker = pmb.createInvoker(invokableMethod)
                         .withReturnValueTransformer(ReturnValueTransformer.class, "transform")
                         .build();
-                staticReturnTransformerNoParamInvoker = ((WeldInvokerBuilder<Invoker<TransformableBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                staticReturnTransformerNoParamInvoker = pmb.createInvoker(invokableMethod)
                         .withReturnValueTransformer(String.class, "strip")
                         .build();
             }
         }
     }
 
-    public void createExceptionTransformationInvokers(@Observes ProcessManagedBean<TrulyExceptionalBean> pmb) {
+    public void createExceptionTransformationInvokers(@Observes WeldProcessManagedBean<TrulyExceptionalBean> pmb) {
         Collection<AnnotatedMethod<? super TrulyExceptionalBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(2, invokableMethods.size());
         for (AnnotatedMethod<? super TrulyExceptionalBean> invokableMethod : invokableMethods) {
             if (invokableMethod.getJavaMember().getName().contains("ping")) {
-                exceptionTransformerInvoker = ((WeldInvokerBuilder<Invoker<TrulyExceptionalBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                exceptionTransformerInvoker = pmb.createInvoker(invokableMethod)
                         .withExceptionTransformer(ExceptionTransformer.class, "transform")
                         .build();
 
             } else if (invokableMethod.getJavaMember().getName().contains("staticPing")) {
-                staticExceptionTransformerInvoker = ((WeldInvokerBuilder<Invoker<TrulyExceptionalBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                staticExceptionTransformerInvoker = pmb.createInvoker(invokableMethod)
                         .withExceptionTransformer(ExceptionTransformer.class, "transform")
                         .build();
             }
         }
     }
 
-    public void createInvocationWrapperInvokers(@Observes ProcessManagedBean<SimpleBean> pmb) {
+    public void createInvocationWrapperInvokers(@Observes WeldProcessManagedBean<SimpleBean> pmb) {
         Collection<AnnotatedMethod<? super SimpleBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(4, invokableMethods.size());
         for (AnnotatedMethod<? super SimpleBean> invokableMethod : invokableMethods) {
             if (invokableMethod.getJavaMember().getName().contains("ping")) {
-                invocationWrapperInvoker = ((WeldInvokerBuilder<Invoker<SimpleBean, ?>>) pmb.createInvoker(invokableMethod))
+                invocationWrapperInvoker = pmb.createInvoker(invokableMethod)
                         .withInvocationWrapper(InvocationWrapper.class, "transform")
                         .build();
 
             } else if (invokableMethod.getJavaMember().getName().contains("staticPing")) {
-                staticInvocationWrapperInvoker = ((WeldInvokerBuilder<Invoker<SimpleBean, ?>>) pmb
-                        .createInvoker(invokableMethod))
+                staticInvocationWrapperInvoker = pmb.createInvoker(invokableMethod)
                         .withInvocationWrapper(InvocationWrapper.class, "transform")
                         .build();
             }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/transformers/input/ObservingExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/transformers/input/ObservingExtension.java
@@ -5,10 +5,9 @@ import java.util.Collection;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.Extension;
-import jakarta.enterprise.inject.spi.ProcessManagedBean;
 import jakarta.enterprise.invoke.Invoker;
 
-import org.jboss.weld.invoke.WeldInvokerBuilder;
+import org.jboss.weld.bootstrap.event.WeldProcessManagedBean;
 import org.junit.Assert;
 
 public class ObservingExtension implements Extension {
@@ -39,23 +38,23 @@ public class ObservingExtension implements Extension {
         return noTransformer;
     }
 
-    public void observe(@Observes ProcessManagedBean<ActualBean> pmb) {
+    public void observe(@Observes WeldProcessManagedBean<ActualBean> pmb) {
         Collection<AnnotatedMethod<? super ActualBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(2, invokableMethods.size());
         for (AnnotatedMethod<? super ActualBean> invokableMethod : invokableMethods) {
             if (invokableMethod.getJavaMember().getName().contains("ping")) {
                 noTransformer = pmb.createInvoker(invokableMethod).build();
-                transformInstance1 = ((WeldInvokerBuilder<Invoker<ActualBean, ?>>) pmb.createInvoker(invokableMethod))
+                transformInstance1 = pmb.createInvoker(invokableMethod)
                         .withInstanceTransformer(Transformer.class, "transformInstance1")
                         .build();
-                transformInstance2 = ((WeldInvokerBuilder<Invoker<ActualBean, ?>>) pmb.createInvoker(invokableMethod))
+                transformInstance2 = pmb.createInvoker(invokableMethod)
                         .withInstanceTransformer(Transformer.class, "transformInstance2")
                         .build();
 
-                transformArg1 = ((WeldInvokerBuilder<Invoker<ActualBean, ?>>) pmb.createInvoker(invokableMethod))
+                transformArg1 = pmb.createInvoker(invokableMethod)
                         .withArgumentTransformer(0, Transformer.class, "transformArg1")
                         .build();
-                transformArg2 = ((WeldInvokerBuilder<Invoker<ActualBean, ?>>) pmb.createInvoker(invokableMethod))
+                transformArg2 = pmb.createInvoker(invokableMethod)
                         .withArgumentTransformer(0, Transformer.class, "transformArg2")
                         .build();
             }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/transformers/output/ObservingExtension.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/invokable/transformers/output/ObservingExtension.java
@@ -5,10 +5,9 @@ import java.util.Collection;
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.Extension;
-import jakarta.enterprise.inject.spi.ProcessManagedBean;
 import jakarta.enterprise.invoke.Invoker;
 
-import org.jboss.weld.invoke.WeldInvokerBuilder;
+import org.jboss.weld.bootstrap.event.WeldProcessManagedBean;
 import org.junit.Assert;
 
 public class ObservingExtension implements Extension {
@@ -44,31 +43,31 @@ public class ObservingExtension implements Extension {
         return noTransformer;
     }
 
-    public void observe(@Observes ProcessManagedBean<ActualBean> pmb) {
+    public void observe(@Observes WeldProcessManagedBean<ActualBean> pmb) {
         Collection<AnnotatedMethod<? super ActualBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(1, invokableMethods.size());
         AnnotatedMethod<? super ActualBean> invokableMethod = invokableMethods.iterator().next();
         noTransformer = pmb.createInvoker(invokableMethod).build();
-        transformReturnType1 = ((WeldInvokerBuilder<Invoker<ActualBean, ?>>) pmb.createInvoker(invokableMethod))
+        transformReturnType1 = pmb.createInvoker(invokableMethod)
                 .withReturnValueTransformer(Transformer.class, "transformReturn1")
                 .build();
-        transformReturnType2 = ((WeldInvokerBuilder<Invoker<ActualBean, ?>>) pmb.createInvoker(invokableMethod))
+        transformReturnType2 = pmb.createInvoker(invokableMethod)
                 .withReturnValueTransformer(Transformer.class, "transformReturn2")
                 .build();
     }
 
-    public void observeExceptionally(@Observes ProcessManagedBean<ExceptionalBean> pmb) {
+    public void observeExceptionally(@Observes WeldProcessManagedBean<ExceptionalBean> pmb) {
         Collection<AnnotatedMethod<? super ExceptionalBean>> invokableMethods = pmb.getAnnotatedBeanClass().getMethods();
         Assert.assertEquals(1, invokableMethods.size());
         AnnotatedMethod<? super ExceptionalBean> invokableMethod = invokableMethods.iterator().next();
 
-        transformException1 = ((WeldInvokerBuilder<Invoker<ExceptionalBean, ?>>) pmb.createInvoker(invokableMethod))
+        transformException1 = pmb.createInvoker(invokableMethod)
                 .withExceptionTransformer(Transformer.class, "transformException1")
                 .build();
-        transformException2 = ((WeldInvokerBuilder<Invoker<ExceptionalBean, ?>>) pmb.createInvoker(invokableMethod))
+        transformException2 = pmb.createInvoker(invokableMethod)
                 .withExceptionTransformer(Transformer.class, "transformException2")
                 .build();
-        transformException3 = ((WeldInvokerBuilder<Invoker<ExceptionalBean, ?>>) pmb.createInvoker(invokableMethod))
+        transformException3 = pmb.createInvoker(invokableMethod)
                 .withExceptionTransformer(Transformer.class, "transformException3")
                 .build();
     }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionInvoker.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionInvoker.java
@@ -30,7 +30,6 @@ class ExtensionInvoker {
         for (Class<? extends BuildCompatibleExtension> extensionClass : extensions) {
             SkipIfPortableExtensionPresent skip = extensionClass.getAnnotation(SkipIfPortableExtensionPresent.class);
             if (skip != null) {
-                // TODO only if the corresponding portable extension exists!
                 continue;
             }
 

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionMethodParameterType.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionMethodParameterType.java
@@ -20,6 +20,7 @@ import jakarta.enterprise.lang.model.declarations.ClassInfo;
 import jakarta.enterprise.lang.model.declarations.FieldInfo;
 import jakarta.enterprise.lang.model.declarations.MethodInfo;
 
+import org.jboss.weld.invoke.WeldInvokerFactory;
 import org.jboss.weld.lite.extension.translator.logging.LiteExtensionTranslatorLogger;
 
 enum ExtensionMethodParameterType {
@@ -39,6 +40,7 @@ enum ExtensionMethodParameterType {
     OBSERVER_INFO(ObserverInfo.class, true, ExtensionPhase.REGISTRATION),
 
     INVOKER_FACTORY(InvokerFactory.class, false, ExtensionPhase.REGISTRATION),
+    WELD_INVOKER_FACTORY(WeldInvokerFactory.class, false, ExtensionPhase.REGISTRATION),
 
     SYNTHETIC_COMPONENTS(SyntheticComponents.class, false, ExtensionPhase.SYNTHESIS),
 

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/ExtensionPhaseRegistration.java
@@ -155,7 +155,7 @@ class ExtensionPhaseRegistration extends ExtensionPhaseBase {
 
     @Override
     Object argumentForExtensionMethod(ExtensionMethodParameterType type, java.lang.reflect.Method method) {
-        if (type == ExtensionMethodParameterType.INVOKER_FACTORY) {
+        if (type == ExtensionMethodParameterType.INVOKER_FACTORY || type == ExtensionMethodParameterType.WELD_INVOKER_FACTORY) {
             return new InvokerFactoryImpl(beanManager);
         } else if (type == ExtensionMethodParameterType.TYPES) {
             return new TypesImpl(beanManager);

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/InvokerFactoryImpl.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/InvokerFactoryImpl.java
@@ -4,7 +4,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
 import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
-import jakarta.enterprise.inject.build.compatible.spi.InvokerFactory;
 import jakarta.enterprise.inject.build.compatible.spi.InvokerInfo;
 import jakarta.enterprise.inject.spi.AnnotatedMethod;
 import jakarta.enterprise.inject.spi.AnnotatedType;
@@ -12,15 +11,16 @@ import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.Decorator;
 import jakarta.enterprise.inject.spi.Interceptor;
-import jakarta.enterprise.invoke.InvokerBuilder;
 import jakarta.enterprise.lang.model.declarations.MethodInfo;
 
 import org.jboss.weld.bean.ClassBean;
 import org.jboss.weld.exceptions.DeploymentException;
 import org.jboss.weld.invokable.InvokerInfoBuilder;
 import org.jboss.weld.invokable.TargetMethod;
+import org.jboss.weld.invoke.WeldInvokerBuilder;
+import org.jboss.weld.invoke.WeldInvokerFactory;
 
-class InvokerFactoryImpl implements InvokerFactory {
+class InvokerFactoryImpl implements WeldInvokerFactory {
     private final BeanManager beanManager;
 
     InvokerFactoryImpl(BeanManager beanManager) {
@@ -28,7 +28,7 @@ class InvokerFactoryImpl implements InvokerFactory {
     }
 
     @Override
-    public InvokerBuilder<InvokerInfo> createInvoker(BeanInfo bean, MethodInfo method) {
+    public WeldInvokerBuilder<InvokerInfo> createInvoker(BeanInfo bean, MethodInfo method) {
         Bean<?> cdiBean = ((BeanInfoImpl) bean).cdiBean;
         if (!(cdiBean instanceof ClassBean)) {
             throw new DeploymentException("Cannot build invoker for a bean which is not a managed bean: " + cdiBean);


### PR DESCRIPTION
PR is still WIP and will require new Weld API version (see https://github.com/weld/api/pull/191)

Contains:
* Logging changes so that we use proper `Logger` interface
* Implement changes allowing to use Weld APIs without the need to type cast
* Remove leftover playground classes
  * After some more thinking I decided we should keep them in; might save a headache or two in the future
* Documentation changes - we should mention the new API in our docs
* Revisit deployment validation of lookups and see if we could perform it differently
  * This is IMO done correctly
  * invokers do not use classical `InjectionPoint` (which is correct due to their nature) and validating them separately through `WeldInstance` works just fine
  * Notably, this should respect the BM-per-archive structure that Weld uses and should correctly indicate if some of the beans isn't available in given bean archive
* Update the micro benchmark setup to use latest API
  * Done in `https://github.com/weld/weld-core-benchmarks/tree/invokableMethods`
  * This of course need Weld core release before it's mergeable