### PR TITLE
Weld-2772 Allow to register BCE in Weld SE without discovery

### DIFF
--- a/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/SecurityActions.java
+++ b/environments/common/src/main/java/org/jboss/weld/environment/deployment/discovery/jandex/SecurityActions.java
@@ -22,6 +22,7 @@ import java.security.PrivilegedActionException;
 
 import org.jboss.weld.exceptions.WeldException;
 import org.jboss.weld.security.ConstructorNewInstanceAction;
+import org.jboss.weld.security.GetDeclaredConstructorAction;
 import org.jboss.weld.security.NewInstanceAction;
 
 /**
@@ -38,15 +39,17 @@ final class SecurityActions {
      * @throws InstantiationException
      * @throws IllegalAccessException
      */
-    static <T> T newInstance(Class<T> javaClass) throws InstantiationException, IllegalAccessException {
+    static <T> T newInstance(Class<T> javaClass)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         if (System.getSecurityManager() != null) {
             try {
-                return AccessController.doPrivileged(NewInstanceAction.of(javaClass));
+                return AccessController.doPrivileged(
+                        NewInstanceAction.of(AccessController.doPrivileged(GetDeclaredConstructorAction.of(javaClass))));
             } catch (PrivilegedActionException e) {
                 throw new WeldException(e.getCause());
             }
         } else {
-            return javaClass.newInstance();
+            return javaClass.getDeclaredConstructor().newInstance();
         }
     }
 

--- a/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
+++ b/environments/se/core/src/main/java/org/jboss/weld/environment/se/Weld.java
@@ -1153,7 +1153,8 @@ public class Weld extends SeContainerInitializer implements ContainerInstanceFac
         if (!allBce.isEmpty()) {
             try {
                 result.add(new MetadataImpl<Extension>(
-                        new LiteExtensionTranslator(allBce, Thread.currentThread().getContextClassLoader()),
+                        SecurityActions.newInstance(SecurityActions.getDeclaredConstructor(LiteExtensionTranslator.class,
+                                Collection.class, ClassLoader.class), allBce, Thread.currentThread().getContextClassLoader()),
                         SYNTHETIC_LOCATION_PREFIX + LiteExtensionTranslator.class.getName()));
             } catch (Exception e) {
                 throw new RuntimeException(e);

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/none/NoExtensionFoundTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/none/NoExtensionFoundTest.java
@@ -17,8 +17,6 @@
 
 package org.jboss.weld.environment.se.test.extension.build.compatible.none;
 
-import jakarta.enterprise.inject.spi.Extension;
-
 import org.jboss.arquillian.container.se.api.ClassPath;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -38,13 +36,13 @@ import org.junit.runner.RunWith;
  * added to the deployment.
  */
 @RunWith(Arquillian.class)
-public class TestNoExtensionFound {
+public class NoExtensionFoundTest {
 
     @Deployment
     public static Archive<?> getDeployment() {
         return ClassPath.builder()
-                .add(ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(TestNoExtensionFound.class))
-                        .addPackage(TestNoExtensionFound.class.getPackage()))
+                .add(ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(NoExtensionFoundTest.class))
+                        .addPackage(NoExtensionFoundTest.class.getPackage()))
                 .build();
     }
 

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/DiscoveredBce.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/DiscoveredBce.java
@@ -1,0 +1,39 @@
+package org.jboss.weld.environment.se.test.extension.build.compatible.registered;
+
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Discovery;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.Validation;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+public class DiscoveredBce implements BuildCompatibleExtension {
+    public static int TIMES_INVOKED = 0;
+
+    @Discovery
+    public void discovery() {
+        TIMES_INVOKED++;
+    }
+
+    @Enhancement(types = SomeBean.class)
+    public void enhancement(ClassInfo c) {
+        TIMES_INVOKED++;
+    }
+
+    @Registration(types = SomeBean.class)
+    public void registration(BeanInfo b) {
+        TIMES_INVOKED++;
+    }
+
+    @Synthesis
+    public void synthesis() {
+        TIMES_INVOKED++;
+    }
+
+    @Validation
+    public void validation() {
+        TIMES_INVOKED++;
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/ExtensionRegisteredManuallyTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/ExtensionRegisteredManuallyTest.java
@@ -1,0 +1,40 @@
+package org.jboss.weld.environment.se.test.extension.build.compatible.registered;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ExtensionRegisteredManuallyTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ClassPath.builder()
+                .add(ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ExtensionRegisteredManuallyTest.class))
+                        .addPackage(ExtensionRegisteredManuallyTest.class.getPackage()))
+                .build();
+    }
+
+    @Test
+    public void testManuallyAddedBce() {
+        ManuallyRegisteredBce.TIMES_INVOKED = 0;
+        try (WeldContainer container = new Weld().addBuildCompatibleExtensions(ManuallyRegisteredBce.class).initialize()) {
+            // assert the deployment is fine, DummyBean should be resolvable
+            Assert.assertTrue(container.select(SomeBean.class).isResolvable());
+            // LiteExtensionTranslator should be present
+            Assert.assertTrue(container.select(LiteExtensionTranslator.class).isResolvable());
+            // assert that BCE was invoked correctly
+            Assert.assertEquals(5, ManuallyRegisteredBce.TIMES_INVOKED);
+        }
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/ManuallyRegisteredBce.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/ManuallyRegisteredBce.java
@@ -1,0 +1,39 @@
+package org.jboss.weld.environment.se.test.extension.build.compatible.registered;
+
+import jakarta.enterprise.inject.build.compatible.spi.BeanInfo;
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+import jakarta.enterprise.inject.build.compatible.spi.Discovery;
+import jakarta.enterprise.inject.build.compatible.spi.Enhancement;
+import jakarta.enterprise.inject.build.compatible.spi.Registration;
+import jakarta.enterprise.inject.build.compatible.spi.Synthesis;
+import jakarta.enterprise.inject.build.compatible.spi.Validation;
+import jakarta.enterprise.lang.model.declarations.ClassInfo;
+
+public class ManuallyRegisteredBce implements BuildCompatibleExtension {
+    public static int TIMES_INVOKED = 0;
+
+    @Discovery
+    public void discovery() {
+        TIMES_INVOKED++;
+    }
+
+    @Enhancement(types = SomeBean.class)
+    public void enhancement(ClassInfo c) {
+        TIMES_INVOKED++;
+    }
+
+    @Registration(types = SomeBean.class)
+    public void registration(BeanInfo b) {
+        TIMES_INVOKED++;
+    }
+
+    @Synthesis
+    public void synthesis() {
+        TIMES_INVOKED++;
+    }
+
+    @Validation
+    public void validation() {
+        TIMES_INVOKED++;
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/RegisteredAndDiscoveredExtensionsTest.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/RegisteredAndDiscoveredExtensionsTest.java
@@ -1,0 +1,63 @@
+package org.jboss.weld.environment.se.test.extension.build.compatible.registered;
+
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
+
+import org.jboss.arquillian.container.se.api.ClassPath;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.environment.se.Weld;
+import org.jboss.weld.environment.se.WeldContainer;
+import org.jboss.weld.lite.extension.translator.LiteExtensionTranslator;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class RegisteredAndDiscoveredExtensionsTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ClassPath.builder()
+                .add(ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ExtensionRegisteredManuallyTest.class))
+                        .addPackage(ExtensionRegisteredManuallyTest.class.getPackage())
+                        .addAsServiceProvider(BuildCompatibleExtension.class, DiscoveredBce.class))
+                .build();
+    }
+
+    @Test
+    public void testDiscoveryAndExplicitAddition() {
+        ManuallyRegisteredBce.TIMES_INVOKED = 0;
+        DiscoveredBce.TIMES_INVOKED = 0;
+        try (WeldContainer container = new Weld().addBuildCompatibleExtensions(ManuallyRegisteredBce.class).initialize()) {
+            // assert the deployment is fine, DummyBean should be resolvable
+            Assert.assertTrue(container.select(SomeBean.class).isResolvable());
+            // LiteExtensionTranslator should be present
+            Assert.assertTrue(container.select(LiteExtensionTranslator.class).isResolvable());
+            // assert that manually added BCE was invoked correctly
+            Assert.assertEquals(5, ManuallyRegisteredBce.TIMES_INVOKED);
+            // assert that discovered BCE was invoked correctly
+            Assert.assertEquals(5, DiscoveredBce.TIMES_INVOKED);
+        }
+    }
+
+    @Test
+    public void testAddingAlreadyDiscoveredExtension() {
+        ManuallyRegisteredBce.TIMES_INVOKED = 0;
+        DiscoveredBce.TIMES_INVOKED = 0;
+        try (WeldContainer container = new Weld().addBuildCompatibleExtensions(DiscoveredBce.class, ManuallyRegisteredBce.class)
+                .initialize()) {
+            // assert the deployment is fine, DummyBean should be resolvable
+            Assert.assertTrue(container.select(SomeBean.class).isResolvable());
+            // LiteExtensionTranslator should be present
+            Assert.assertTrue(container.select(LiteExtensionTranslator.class).isResolvable());
+            // assert that manually added BCE was invoked correctly
+            Assert.assertEquals(5, ManuallyRegisteredBce.TIMES_INVOKED);
+            // despite being added manually and also discovered, it should only use a single instance of this extension
+            Assert.assertEquals(5, DiscoveredBce.TIMES_INVOKED);
+        }
+    }
+}

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/SomeBean.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/extension/build/compatible/registered/SomeBean.java
@@ -1,0 +1,7 @@
+package org.jboss.weld.environment.se.test.extension.build.compatible.registered;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class SomeBean {
+}

--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/SecurityActions.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/SecurityActions.java
@@ -24,6 +24,7 @@ import java.security.PrivilegedActionException;
 
 import org.jboss.weld.exceptions.WeldException;
 import org.jboss.weld.security.ConstructorNewInstanceAction;
+import org.jboss.weld.security.GetDeclaredConstructorAction;
 import org.jboss.weld.security.MethodLookupAction;
 import org.jboss.weld.security.NewInstanceAction;
 
@@ -41,15 +42,17 @@ final class SecurityActions {
      * @throws InstantiationException
      * @throws IllegalAccessException
      */
-    static <T> T newInstance(Class<T> javaClass) throws InstantiationException, IllegalAccessException {
+    static <T> T newInstance(Class<T> javaClass)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
         if (System.getSecurityManager() != null) {
             try {
-                return AccessController.doPrivileged(NewInstanceAction.of(javaClass));
+                return AccessController.doPrivileged(
+                        NewInstanceAction.of(AccessController.doPrivileged(GetDeclaredConstructorAction.of(javaClass))));
             } catch (PrivilegedActionException e) {
                 throw new WeldException(e.getCause());
             }
         } else {
-            return javaClass.newInstance();
+            return javaClass.getDeclaredConstructor().newInstance();
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/DecorationHelper.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/DecorationHelper.java
@@ -17,6 +17,7 @@
 
 package org.jboss.weld.bean.proxy;
 
+import java.lang.reflect.InvocationTargetException;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.LinkedList;
@@ -128,7 +129,7 @@ public class DecorationHelper<T> implements PrivilegedAction<T> {
     public T run() {
         try {
             return instantiator.newInstance(proxyClassForDecorator);
-        } catch (InstantiationException e) {
+        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             throw new DefinitionException(BeanLogger.LOG.proxyInstantiationFailed(this), e.getCause());
         } catch (IllegalAccessException e) {
             throw new DefinitionException(BeanLogger.LOG.proxyInstantiationBeanAccessFailed(this), e.getCause());

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/DefaultProxyInstantiator.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/DefaultProxyInstantiator.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.bean.proxy;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
 import jakarta.enterprise.inject.spi.Bean;
@@ -39,8 +40,9 @@ public final class DefaultProxyInstantiator implements ProxyInstantiator {
     }
 
     @Override
-    public <T> T newInstance(Class<T> clazz) throws InstantiationException, IllegalAccessException {
-        return clazz.newInstance();
+    public <T> T newInstance(Class<T> clazz)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
+        return clazz.getDeclaredConstructor().newInstance();
     }
 
     @Override

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -386,7 +387,7 @@ public class ProxyFactory<T> implements PrivilegedAction<T> {
                 return newInstantiator.newInstance(proxyClass);
             }
             return proxyInstantiator.newInstance(proxyClass);
-        } catch (InstantiationException e) {
+        } catch (InstantiationException | NoSuchMethodException | InvocationTargetException e) {
             throw new DefinitionException(BeanLogger.LOG.proxyInstantiationFailed(this), e.getCause());
         } catch (IllegalAccessException e) {
             throw new DefinitionException(BeanLogger.LOG.proxyInstantiationBeanAccessFailed(this), e.getCause());

--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyInstantiator.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyInstantiator.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.bean.proxy;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import jakarta.enterprise.inject.spi.Bean;
@@ -34,7 +35,7 @@ import org.jboss.weld.util.reflection.Reflections;
 /**
  * Implementations of this interface are capable of creating instances of a given proxy class. This can either be done simply by
  * calling
- * {@link Class#newInstance()} or using more advanced mechanism (e.g. sun.misc.Unsafe)
+ * {@code clazz.getDeclaredConstructor().newInstance()} or using more advanced mechanism (e.g. sun.misc.Unsafe)
  *
  * @author Jozef Hartinger
  *
@@ -52,7 +53,8 @@ public interface ProxyInstantiator extends Service {
      * @param clazz the class
      * @return an instance of a proxy class
      */
-    <T> T newInstance(Class<T> clazz) throws InstantiationException, IllegalAccessException;
+    <T> T newInstance(Class<T> clazz)
+            throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException;
 
     /**
      * Validate, whether the given constructor is sufficient for a class to be proxyable.
@@ -137,7 +139,7 @@ public interface ProxyInstantiator extends Service {
         }
 
         private static ProxyInstantiator newInstance(String implementation)
-                throws InstantiationException, IllegalAccessException {
+                throws InstantiationException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
             if (DefaultProxyInstantiator.class.getName().equals(implementation)) {
                 return DefaultProxyInstantiator.INSTANCE;
             }
@@ -146,7 +148,7 @@ public interface ProxyInstantiator extends Service {
             if (clazz == null) {
                 throw new WeldException("Unable to load ProxyInstantiator implementation: " + implementation);
             }
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         }
     }
 

--- a/impl/src/main/java/org/jboss/weld/injection/Exceptions.java
+++ b/impl/src/main/java/org/jboss/weld/injection/Exceptions.java
@@ -23,6 +23,7 @@ import java.security.PrivilegedActionException;
 import jakarta.enterprise.inject.CreationException;
 
 import org.jboss.weld.exceptions.WeldException;
+import org.jboss.weld.security.GetDeclaredConstructorAction;
 import org.jboss.weld.security.NewInstanceAction;
 
 class Exceptions {
@@ -36,8 +37,8 @@ class Exceptions {
         } else {
             RuntimeException e;
             try {
-
-                e = AccessController.doPrivileged(NewInstanceAction.of(exceptionToThrow));
+                e = AccessController.doPrivileged(
+                        NewInstanceAction.of(AccessController.doPrivileged(GetDeclaredConstructorAction.of(exceptionToThrow))));
             } catch (PrivilegedActionException ex) {
                 throw new WeldException(ex.getCause());
             }

--- a/impl/src/main/java/org/jboss/weld/security/NewInstanceAction.java
+++ b/impl/src/main/java/org/jboss/weld/security/NewInstanceAction.java
@@ -16,20 +16,27 @@
  */
 package org.jboss.weld.security;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.security.PrivilegedExceptionAction;
 
 public class NewInstanceAction<T> extends AbstractGenericReflectionAction<T> implements PrivilegedExceptionAction<T> {
 
-    public static <T> NewInstanceAction<T> of(Class<T> javaClass) {
-        return new NewInstanceAction<T>(javaClass);
+    public static <T> NewInstanceAction<T> of(Constructor<T> constructor, Object... params) {
+        return new NewInstanceAction<T>(constructor, params);
     }
 
-    public NewInstanceAction(Class<T> javaClass) {
-        super(javaClass);
+    private final Constructor<T> constructor;
+    private final Object[] params;
+
+    public NewInstanceAction(Constructor<T> constructor, Object... params) {
+        super(constructor.getDeclaringClass());
+        this.constructor = constructor;
+        this.params = params;
     }
 
     @Override
-    public T run() throws InstantiationException, IllegalAccessException {
-        return javaClass.newInstance();
+    public T run() throws InvocationTargetException, InstantiationException, IllegalAccessException {
+        return constructor.newInstance(params);
     }
 }

--- a/impl/src/test/java/org/jboss/weld/tests/unit/security/ReflectionTest.java
+++ b/impl/src/test/java/org/jboss/weld/tests/unit/security/ReflectionTest.java
@@ -197,7 +197,8 @@ public class ReflectionTest {
 
     @Test
     public void testNewInstance() throws PrivilegedActionException {
-        Assert.assertNotNull(AccessController.doPrivileged(NewInstanceAction.of(TestObject.class)));
+        Assert.assertNotNull(AccessController.doPrivileged(
+                NewInstanceAction.of(AccessController.doPrivileged(GetDeclaredConstructorAction.of(TestObject.class)))));
     }
 
     @Test

--- a/modules/ejb/src/main/java/org/jboss/weld/module/ejb/SessionBeanProxyInstantiator.java
+++ b/modules/ejb/src/main/java/org/jboss/weld/module/ejb/SessionBeanProxyInstantiator.java
@@ -31,6 +31,7 @@ import org.jboss.weld.exceptions.WeldException;
 import org.jboss.weld.injection.producer.Instantiator;
 import org.jboss.weld.logging.BeanLogger;
 import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.security.GetDeclaredConstructorAction;
 import org.jboss.weld.security.NewInstanceAction;
 
 /**
@@ -51,7 +52,8 @@ class SessionBeanProxyInstantiator<T> implements Instantiator<T> {
     @Override
     public T newInstance(CreationalContext<T> ctx, BeanManagerImpl manager) {
         try {
-            T instance = AccessController.doPrivileged(NewInstanceAction.of(proxyClass));
+            T instance = AccessController.doPrivileged(
+                    NewInstanceAction.of(AccessController.doPrivileged(GetDeclaredConstructorAction.of(proxyClass))));
             if (!bean.getScope().equals(Dependent.class)) {
                 ctx.push(instance);
             }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/extension/AbstractInterceptor.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/extension/AbstractInterceptor.java
@@ -71,7 +71,7 @@ public abstract class AbstractInterceptor<T> implements Interceptor<T> {
     @SuppressWarnings("unchecked")
     public T create(CreationalContext<T> creationalContext) {
         try {
-            return (T) getBeanClass().newInstance();
+            return (T) getBeanClass().getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException("Error creating an instance of " + getBeanClass());
         }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/lhotse/fst/GenericDAO.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/lhotse/fst/GenericDAO.java
@@ -45,7 +45,7 @@ public abstract class GenericDAO<T extends Entity> implements DAO<T> {
             throw new IllegalArgumentException("Null id");
 
         try {
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/tb/GenericDAO.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/interceptors/tb/GenericDAO.java
@@ -47,7 +47,7 @@ public abstract class GenericDAO<T extends Entity> implements DAO<T> {
             throw new IllegalArgumentException("No Tx marker!");
 
         try {
-            return clazz.newInstance();
+            return clazz.getDeclaredConstructor().newInstance();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/LiteExtensionTranslator.java
+++ b/weld-lite-extension-translator/src/main/java/org/jboss/weld/lite/extension/translator/LiteExtensionTranslator.java
@@ -3,6 +3,7 @@ package org.jboss.weld.lite.extension.translator;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import jakarta.annotation.Priority;
@@ -42,7 +43,16 @@ public class LiteExtensionTranslator implements jakarta.enterprise.inject.spi.Ex
         this(BuildCompatibleExtensionLoader.getBuildCompatibleExtensions(), Thread.currentThread().getContextClassLoader());
     }
 
+    /**
+     * Deprecated, use {@link LiteExtensionTranslator#LiteExtensionTranslator(Collection, ClassLoader)}
+     */
+    @Deprecated
     public LiteExtensionTranslator(List<Class<? extends BuildCompatibleExtension>> buildCompatibleExtensions, ClassLoader cl) {
+        this((Collection<Class<? extends BuildCompatibleExtension>>) buildCompatibleExtensions, cl);
+    }
+
+    public LiteExtensionTranslator(Collection<Class<? extends BuildCompatibleExtension>> buildCompatibleExtensions,
+            ClassLoader cl) {
         this.util = new ExtensionInvoker(buildCompatibleExtensions);
         this.cl = cl;
         // clear out information about extensions we found, this is to prevent issues in test environments where this


### PR DESCRIPTION
Add the ability to manually register BCE in Weld SE without the need to perform discovery.

I believe this should eventually bubble up to `SeContainerInitializer` and be part of the CDI SE API (cc @Ladicek; this is something I mentioned a [long] while ago)
We already have similar methods in place for portable extensions.