### PR TITLE
Fix plugin execution order in osgi module

### DIFF
--- a/bundles/osgi/pom.xml
+++ b/bundles/osgi/pom.xml
@@ -247,6 +247,12 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- The gpg plugin is here just to ensure order of execution *after* shade plugin -->
+            <!-- It does nothing in a standard build and the whole configuration of this plugin remains in Weld parent -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -362,7 +368,7 @@
         <connection>scm:git:git@github.com:weld/core.git</connection>
         <developerConnection>scm:git:git@github.com:weld/core.git</developerConnection>
         <url>scm:git:git@github.com:weld/core.git</url>
-        <tag>5.0.0-SNAPSHOT</tag>
+        <tag>6.0.0-SNAPSHOT</tag>
     </scm>
 
 </project>


### PR DESCRIPTION
This should be the cause of the recent release failure - the order of these plugin wasn't explicit and some Maven change prompted ordering change leading to signing files before the shade plugin did it's changes on them.