### PR TITLE
Release script - checkout tag before building docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         git push
         git push --tags
         cd dist
+        git checkout ${{steps.metadata.outputs.current-version}}
         gradle -PweldVersion=${{steps.metadata.outputs.current-version}} -PweldPath=${GITHUB_WORKSPACE}
     - name: Upload dist ZIP file
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This fixes the doc from Beta4 release to look like it's for SNAPSHOT.
Other parts should be correct.