### PR TITLE
My attempt to fix e.getClass().equals(BeanManager.class), where Strin…

### DIFF
--- a/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/BeanManagerResourceBindingListener.java
+++ b/environments/servlet/core/src/main/java/org/jboss/weld/environment/servlet/BeanManagerResourceBindingListener.java
@@ -54,7 +54,7 @@ public class BeanManagerResourceBindingListener implements ServletContextListene
                 while (entries.hasMoreElements()) {
                     try {
                         NameClassPair e = entries.next();
-                        if (e.getName().equals(BEAN_MANAGER_JNDI_NAME) && e.getClassName().equals(BeanManager.class)) {
+                        if (e.getName().equals(BEAN_MANAGER_JNDI_NAME) && e.getClass().equals(BeanManager.class)) {
                             present = true;
                             break;
                         }


### PR DESCRIPTION
…g is compared with Class. However, two parts combined with && looks ridiculous. There is no class, which is subtype of both NameClassPair and BeanManager. Please consider this PR as bug report