### PR TITLE
Please consider this PR as bug report.

### DIFF
--- a/impl/src/main/java/org/jboss/weld/xml/BeansXmlValidator.java
+++ b/impl/src/main/java/org/jboss/weld/xml/BeansXmlValidator.java
@@ -138,7 +138,7 @@ public class BeansXmlValidator implements ErrorHandler {
                 xsds.add(source);
             }
         }
-        return xsds.toArray(EMPTY_SOURCE_ARRAY);
+        ;return xsds.toArray(EMPTY_SOURCE_ARRAY);
     }
 
     private static StreamSource loadXsd(String name, ClassLoader classLoader) {


### PR DESCRIPTION
Array of type javax.xml.transform.Source[] expected, but javax.xml.transform.stream.StreamSource[] found Added a harmless semicolon to pinpoint the line