### PR TITLE
WELD-2796 For built-in beans, the proxy's originalClass should be the implemented type

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyFactory.java
@@ -405,7 +405,16 @@ public class ProxyFactory<T> {
             proxyClassName = proxyClassName.replaceFirst(JAKARTA, WELD_PROXY_PREFIX);
         }
         Class<T> proxyClass = null;
-        Class<?> originalClass = bean != null ? bean.getBeanClass() : proxiedBeanType;
+        Class<?> originalClass;
+        if (bean == null) {
+            originalClass = proxiedBeanType;
+        } else {
+            if (bean instanceof AbstractBuiltInBean<?>) {
+                originalClass = ((AbstractBuiltInBean<?>) bean).getType();
+            } else {
+                originalClass = bean.getBeanClass();
+            }
+        }
         BeanLogger.LOG.generatingProxyClass(proxyClassName);
         try {
             // First check to see if we already have this proxy class


### PR DESCRIPTION
This will affect the behavior in WFLY where we retrieve a module based on the original class, see https://github.com/wildfly/wildfly/blob/main/weld/subsystem/src/main/java/org/jboss/as/weld/services/bootstrap/ProxyServicesImpl.java#L187

In case of `ServletContextBeanTest`, one can observe that with this change we would now place the proxy into user deployment instead of into Weld module. As a result, such proxy cannot be reused in another deployments and repeated test executions on a running WFLY instance will trigger repeated proxy creations.