### PR TITLE
[WELD-2800] Don't use jar cache in ServiceLoader.loadServiceFile

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
+++ b/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
@@ -175,7 +175,8 @@ public class ServiceLoader<S> implements Iterable<Metadata<S>> {
         InputStream is = null;
         try {
             URLConnection jarConnection = serviceFile.openConnection();
-            //Don't cache the file (avoids file leaks on GlassFish).
+            //Don't cache the file; in combination with Windows OS, this can cause file leaks on some EE servers (GlassFish)
+            // See WELD-2800 for more details
             jarConnection.setUseCaches(false);
             is = jarConnection.getInputStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));

--- a/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
+++ b/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.net.URL;
+import java.net.URLConnection;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
@@ -173,7 +174,10 @@ public class ServiceLoader<S> implements Iterable<Metadata<S>> {
     private void loadServiceFile(URL serviceFile) {
         InputStream is = null;
         try {
-            is = serviceFile.openStream();
+            URLConnection jarConnection = serviceFile.openConnection();
+            //Don't cache the file (avoids file leaks on GlassFish).
+            jarConnection.setUseCaches(false);
+            is = jarConnection.getInputStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             String serviceClassName = null;
             int i = 0;


### PR DESCRIPTION
This should resolve https://issues.redhat.com/browse/WELD-2800

`java.net.URL.openStream` uses a jar cache. Thus the jar file is kept in memory as long as the Glassfish server is alive, and thus the jar file in "glassfish\domains\domain1\applications" cannot be deleted on windows when the app is undeployed.

Workaround: set `URLConnection.setUseCaches(false)` before accessing the InputStream:

```java
URLConnection jarConnection = serviceFile.openConnection();
jarConnection.setUseCaches(false);
is = jarConnection.getInputStream();
```


I pushed it to the 5.1 branch as GlassFish 7.0.18 uses Weld 5.1.3.Final, and I hope that this fix makes it to next Glassfish.

I don't have much git experience and never pushed to a branch, so please be patient with me if I did this wrong ;-)