### PR TITLE
 [WELD-2800] Don't use jar cache in ServiceLoader.loadServiceFile

### DIFF
--- a/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
+++ b/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
@@ -173,7 +173,8 @@ public class ServiceLoader<S> implements Iterable<Metadata<S>> {
         InputStream is = null;
         try {
             URLConnection jarConnection = serviceFile.openConnection();
-            //Don't cache the file (avoids file leaks on GlassFish).
+            //Don't cache the file; in combination with Windows OS, this can cause file leaks on some EE servers (GlassFish)
+            // See WELD-2800 for more details
             jarConnection.setUseCaches(false);
             is = jarConnection.getInputStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));

--- a/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
+++ b/impl/src/main/java/org/jboss/weld/util/ServiceLoader.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -171,7 +172,10 @@ public class ServiceLoader<S> implements Iterable<Metadata<S>> {
     private void loadServiceFile(URL serviceFile) {
         InputStream is = null;
         try {
-            is = serviceFile.openStream();
+            URLConnection jarConnection = serviceFile.openConnection();
+            //Don't cache the file (avoids file leaks on GlassFish).
+            jarConnection.setUseCaches(false);
+            is = jarConnection.getInputStream();
             BufferedReader reader = new BufferedReader(new InputStreamReader(is, "UTF-8"));
             String serviceClassName = null;
             int i = 0;


### PR DESCRIPTION
Weld 6 counterpart for https://github.com/weld/core/pull/3069