### PR TITLE
Fix typo

### DIFF
--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -285,7 +285,7 @@ available:
 * Managed beans with `@PostConstruct` and `@PreDestroy` lifecycle
 callbacks
 * Dependency injection with qualifiers and alternatives
-* `@Application`, `@Dependent` and `@Singleton` scopes
+* `@ApplicationScoped`, `@Dependent` and `@Singleton` scopes
 * Interceptors and decorators
 * Stereotypes
 * Events


### PR DESCRIPTION
Change `@Application` to `@ApplicationScoped` in one place. There is no `@Application` annotation.