### PR TITLE
WELD-2808 Allow injection of `ELAwareBeanManager`

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerBean.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/BeanManagerBean.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.BeanContainer;
 import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.enterprise.inject.spi.el.ELAwareBeanManager;
 
 import org.jboss.weld.bean.BeanIdentifiers;
 import org.jboss.weld.bean.StringBeanIdentifier;
@@ -30,7 +31,8 @@ import org.jboss.weld.util.collections.Arrays2;
 
 public class BeanManagerBean extends AbstractBuiltInBean<BeanManagerProxy> {
 
-    private static final Set<Type> TYPES = Arrays2.<Type> asSet(Object.class, BeanContainer.class, BeanManager.class);
+    private static final Set<Type> TYPES = Arrays2.<Type> asSet(Object.class, BeanContainer.class, BeanManager.class,
+            ELAwareBeanManager.class);
 
     public BeanManagerBean(BeanManagerImpl manager) {
         super(new StringBeanIdentifier(BeanIdentifiers.forBuiltInBean(manager, BeanManager.class, null)), manager,

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/el/injection/ELAwareBeanManagerInjectionTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/el/injection/ELAwareBeanManagerInjectionTest.java
@@ -1,0 +1,69 @@
+package org.jboss.weld.tests.el.injection;
+
+import java.util.Set;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.ValueExpression;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.el.ELAwareBeanManager;
+import jakarta.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.weld.manager.BeanManagerImpl;
+import org.jboss.weld.test.util.Utils;
+import org.jboss.weld.test.util.el.EL;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test the injection of ELAwareBeanManager.
+ *
+ * @author Andrew Rouse
+ */
+@RunWith(Arquillian.class)
+public class ELAwareBeanManagerInjectionTest {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(ELAwareBeanManagerInjectionTest.class))
+                .addPackage(ELAwareBeanManagerInjectionTest.class.getPackage())
+                .addClass(EL.class)
+                .addPackages(true, ExpressionFactory.class.getPackage());
+    }
+
+    @Inject
+    private BeanManagerImpl beanManager;
+
+    @Inject
+    private ELAwareInjectionBean bean;
+
+    @Test
+    public void testInjection() {
+        ELAwareBeanManager elBm = bean.getElAwareBeanManager();
+        Assert.assertNotNull("elBm", elBm);
+
+        ELResolver elResolver = elBm.getELResolver();
+        Assert.assertNotNull("elResolver", elResolver);
+
+        // Attempt to use the resolver
+        ExpressionFactory exprFactory = EL.EXPRESSION_FACTORY;
+        ELContext elContext = EL.createELContext(beanManager);
+
+        ValueExpression exp = exprFactory.createValueExpression(elContext, "Result: ${testbean.value}", String.class);
+        String value = exp.getValue(elContext);
+        Assert.assertEquals("Result: hello", value);
+
+        // Use it as a regular BeanManager (e.g. look up a bean)
+        Set<Bean<?>> beans = beanManager.getBeans(ELAwareTestBean.class);
+        Assert.assertEquals(1, beans.size());
+        Bean<?> bean = beans.stream().findFirst().get();
+        Assert.assertEquals("testbean", bean.getName());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/el/injection/ELAwareInjectionBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/el/injection/ELAwareInjectionBean.java
@@ -1,0 +1,16 @@
+package org.jboss.weld.tests.el.injection;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.spi.el.ELAwareBeanManager;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class ELAwareInjectionBean {
+
+    @Inject
+    private ELAwareBeanManager elAwareBeanManager;
+
+    public ELAwareBeanManager getElAwareBeanManager() {
+        return elAwareBeanManager;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/el/injection/ELAwareTestBean.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/el/injection/ELAwareTestBean.java
@@ -1,0 +1,13 @@
+package org.jboss.weld.tests.el.injection;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
+
+@Named("testbean")
+@ApplicationScoped
+public class ELAwareTestBean {
+
+    public String getValue() {
+        return "hello";
+    }
+}


### PR DESCRIPTION
Allow `ELAwareBeanManager` to be injected, as [required in the Web Profile spec](https://jakarta.ee/specifications/webprofile/11/jakarta-webprofile-spec-11.0-m4#obtaining-elawarebeanmanager)

For [WELD-2808](https://issues.redhat.com/browse/WELD-2808)