### PR TITLE
WELD-2245 Prevent ClassCastException when proxy of method with generic type variable return type returns itself

### DIFF
--- a/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyMethodHandler.java
+++ b/impl/src/main/java/org/jboss/weld/bean/proxy/ProxyMethodHandler.java
@@ -19,6 +19,7 @@ package org.jboss.weld.bean.proxy;
 
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.lang.reflect.TypeVariable;
 
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.PassivationCapable;
@@ -107,9 +108,13 @@ public class ProxyMethodHandler implements MethodHandler, Serializable, Metadata
             }
             Object instance = beanInstance.getInstance();
             Object result = beanInstance.invoke(instance, thisMethod, args);
-            // if the method returns this and the return type matches the proxy type, return the proxy instead
-            // to prevent the bean instance escaping
-            if (result != null && result == instance && (thisMethod.getReturnType().isAssignableFrom(self.getClass()))) {
+            // to prevent the bean instance escaping, return the proxy instead
+            // if the method returns this
+            if ((result != null) && (result == instance) &&
+            // and the return type is not generic
+                    !(thisMethod.getGenericReturnType() instanceof TypeVariable) &&
+                    // and the return type matches the proxy type
+                    thisMethod.getReturnType().isAssignableFrom(self.getClass())) {
                 return self;
             }
             return result;

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Alpha.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Alpha.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright The Weld Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.weld.tests.proxy;
+
+public interface Alpha<T> {
+    Alpha<T> returnSelf();
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/AlphaImpl.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/AlphaImpl.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright The Weld Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.weld.tests.proxy;
+
+public class AlphaImpl implements Alpha<String> {
+    @Override
+    public Alpha<String> returnSelf() {
+        return this;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Bam.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Bam.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright The Weld Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.weld.tests.proxy;
+
+interface Bam {
+    Foo asFoo();
+
+    <T> T as(Class<T> type);
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/BamProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/BamProducer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright The Weld Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.weld.tests.proxy;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
+
+@Dependent
+public class BamProducer {
+    @Produces
+    @Named("bam")
+    @ApplicationScoped
+    Bam produceBam() {
+        return new Foo();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Foo.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/Foo.java
@@ -23,7 +23,7 @@ import jakarta.inject.Named;
 
 @Named
 @RequestScoped
-class Foo implements Serializable, Bar {
+class Foo implements Serializable, Bar, Bam {
     public static final String MESSAGE = "Hi";
 
     public String getRealMsg(int param1, long param2, double param3, boolean param4, char param5, float param7, short param8) {
@@ -36,4 +36,14 @@ class Foo implements Serializable, Bar {
         return MESSAGE;
     }
 
+    @Override
+    public Foo asFoo() {
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> T as(Class<T> type) {
+        return (T) this;
+    }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/ProxyTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/ProxyTest.java
@@ -17,6 +17,7 @@
 package org.jboss.weld.tests.proxy;
 
 import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.util.TypeLiteral;
 import jakarta.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -70,7 +71,7 @@ public class ProxyTest {
      * The proxy hashCode should be equal to the class hashCode (see WELD-695)
      */
     @Test
-    public void testHashCodeImplmentation() {
+    public void testHashCodeImplementation() {
         Bean<?> bean = beanManager.resolve(beanManager.getBeans("baz"));
         Baz baz = (Baz) beanManager.getReference(bean, Baz.class, beanManager.createCreationalContext(bean));
         Assert.assertTrue(baz.hashCode() == baz.getClass().hashCode());
@@ -81,7 +82,7 @@ public class ProxyTest {
     }
 
     @Test
-    public void testEqualsImplmentation() {
+    public void testEqualsImplementation() {
         Bean<?> bean = beanManager.resolve(beanManager.getBeans("baz"));
         Baz baz1 = (Baz) beanManager.getReference(bean, Baz.class, beanManager.createCreationalContext(bean));
         Baz baz2 = (Baz) beanManager.getReference(bean, Baz.class, beanManager.createCreationalContext(bean));
@@ -98,10 +99,34 @@ public class ProxyTest {
         Bean<?> bean = beanManager.resolve(beanManager.getBeans("wobble"));
         Wobble wobble = (Wobble) beanManager.getReference(bean, Wobble.class, beanManager.createCreationalContext(bean));
         Assert.assertSame(wobble, wobble.getThis());
-        // package private classes have a diffent code path
+        // package private classes have a different code path
         // as they do not use direct bytecode invocation
         bean = beanManager.resolve(beanManager.getBeans("wibble"));
         Wibble wibble = (Wibble) beanManager.getReference(bean, Wibble.class, beanManager.createCreationalContext(bean));
         Assert.assertSame(wibble, wibble.getThis());
+    }
+
+    @Test
+    public void testBeanInstanceCanEscapeIfReturnTypeIncompatible() {
+        Bean<?> bean = beanManager.resolve(beanManager.getBeans("bam"));
+        Bam bam = (Bam) beanManager.getReference(bean, Bam.class, beanManager.createCreationalContext(bean));
+        Assert.assertNotNull(bam.asFoo());
+        // no java.lang.ClassCastException is thrown
+    }
+
+    @Test
+    public void testBeanInstanceCanEscapeIfReturnTypeIsATypeVariable() {
+        Bean<?> bean = beanManager.resolve(beanManager.getBeans("bam"));
+        Bam bam = (Bam) beanManager.getReference(bean, Bam.class, beanManager.createCreationalContext(bean));
+        Foo bamAsFoo = bam.as(Foo.class);
+        Assert.assertNotNull(bamAsFoo);
+        // no java.lang.ClassCastException is thrown
+    }
+
+    @Test
+    public void testBeanInstanceDoesNotEscapeIfReturnTypeIsParameterized() {
+        Alpha<String> alpha = beanManager.createInstance().select(new TypeLiteral<Alpha<String>>() {
+        }).get();
+        Assert.assertSame(alpha, alpha.returnSelf());
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/StringAlphaProducer.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/proxy/StringAlphaProducer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The Weld Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.jboss.weld.tests.proxy;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Produces;
+
+@Dependent
+public class StringAlphaProducer {
+    @Produces
+    @ApplicationScoped
+    Alpha<String> produceStringAlpha() {
+        return new AlphaImpl();
+    }
+}


### PR DESCRIPTION
Cherry pick of https://github.com/weld/core/pull/3303 for the 6.0 branch.

The changes we landed on were small enough in the end so I figured it should be safe to include this in 6.x as well.