### PR TITLE
Switch CI from WildFly Preview to standard WildFly nightly

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -24,13 +24,11 @@ jobs:
           distribution: 'temurin'
       - name: Download WildFly
         run: |
-          wget https://ci.wildfly.org/guestAuth/repository/download/WF_WildflyPreviewNightly/latest.lastSuccessful/wildfly-preview-latest-SNAPSHOT.zip
-          unzip wildfly-preview-latest-SNAPSHOT.zip
-          # wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastSuccessful/wildfly-latest-SNAPSHOT.zip
-          # unzip wildfly-latest-SNAPSHOT.zip
+          wget https://ci.wildfly.org/guestAuth/repository/download/WF_Nightly/latest.lastSuccessful/wildfly-latest-SNAPSHOT.zip
+          unzip wildfly-latest-SNAPSHOT.zip
           # ZIP contains two more ZIPs, sources and actual WFLY
-          # rm wildfly-*-src.zip
-          # rm wildfly-latest-SNAPSHOT.zip
+          rm wildfly-*-src.zip
+          rm wildfly-latest-SNAPSHOT.zip
           unzip wildfly-*.zip -d container
           cd container
           mv ./* wildfly/

--- a/jboss-as/pom.xml
+++ b/jboss-as/pom.xml
@@ -191,21 +191,6 @@
                                         <replaceregexp file="${jsf.injection.dir}/module.xml" match="path=&quot;weld-jsf.*?&quot;" replace="path=&quot;weld-jsf-${weld.update.version}.jar&quot;" byline="true" />
                                         <replaceregexp file="${jsf.injection.dir}/module.xml" match="path=&quot;weld-core-jsf.*?&quot;" replace="path=&quot;weld-jsf-${weld.update.version}.jar&quot;" byline="true" />
 
-                                        <echo>
-
-                                            =========================================================================
-
-                                            Copying standalone-activemq-embedded.xml
-
-                                            =========================================================================
-
-                                        </echo>
-
-                                        <copy todir="${jboss.home}/standalone/configuration" overwrite="true">
-                                            <fileset dir="${jboss.home}/docs//examples/configs">
-                                                <include name="standalone-activemq-embedded.xml" />
-                                            </fileset>
-                                        </copy>
                                     </target>
                                 </configuration>
                             </execution>

--- a/jboss-tck-runner/src/test/wildfly8/arquillian.xml
+++ b/jboss-tck-runner/src/test/wildfly8/arquillian.xml
@@ -10,9 +10,8 @@
 
     <container qualifier="wildfly-23" default="true">
         <configuration>
-            <!-- This config file includes embedded JMS broker -->
-            <!-- NOTE: this file is by default located in $WILDFLY_HOME/docs/examples/ -->
-            <property name="serverConfig">standalone-activemq-embedded.xml</property>
+            <!-- This config file includes messaging subsystem with embedded JMS broker -->
+            <property name="serverConfig">standalone-full.xml</property>
             <property name="javaVmArguments">-Xms128m -Xmx1g -ea -DcdiTckExcludeDummy=true ${gc.args} ${additional.vm.args} ${jacoco.agent}</property>
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>

--- a/tests-arquillian/src/test/resources/wildfly-arquillian.xml
+++ b/tests-arquillian/src/test/resources/wildfly-arquillian.xml
@@ -12,9 +12,8 @@
 
     <container qualifier="jboss-as-7" default="true">
         <configuration>
-            <!-- This config file includes embedded JMS broker -->
-            <!-- NOTE: this file is by default located in $WILDFLY_HOME/docs/examples/ -->
-            <property name="serverConfig">standalone-activemq-embedded.xml</property>
+            <!-- This config file includes messaging subsystem with embedded JMS broker -->
+            <property name="serverConfig">standalone-full.xml</property>
             <!-- ARQ-649 workaround -->
             <property name="outputToConsole">false</property>
             <property name="allowConnectingToRunningServer">true</property>


### PR DESCRIPTION
Standard WildFly nightly no longer ships
`standalone-activemq-embedded.xml` in `docs/examples/configs/`. Replace it with `standalone-full.xml` which is part of the standard configuration and includes the messaging subsystem with embedded broker.