### PR TITLE
Fix duplicate server-log artifact name in relaxed mode CI job

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -260,13 +260,13 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: test-reports-cdi-tck-jdk${{matrix.java.name}}-incontainer-relaxed
+          name: test-reports-incontainer-relaxed-jdk${{matrix.java.name}}
           path: 'test-reports.tgz'
       - name: Upload server log artifact (if maven failed)
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: server-log-cdi-tck-jdk${{matrix.java.name}}
+          name: server-log-incontainer-relaxed-jdk${{matrix.java.name}}
           path: 'server-log.tgz'
       - name: Build with Maven, no WildFly
         run: |
@@ -279,7 +279,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: failure()
         with:
-          name: test-reports-cdi-tck-jdk${{matrix.java.name}}-relaxed
+          name: test-reports-no-container-relaxed-jdk${{matrix.java.name}}
           path: 'test-reports.tgz'
 
   # Weld no-container tests, includes junit, Weld SE tests plus CDI TCKs and integration tests that don't require EE container


### PR DESCRIPTION
Tiny CI fix where upon multiple failures, some logs would not be uploaded correctly because of clashing names.