### PR TITLE
Undertow update combined

### DIFF
--- a/environments/se/pom.xml
+++ b/environments/se/pom.xml
@@ -24,7 +24,7 @@
     </description>
 
    <properties>
-      <undertow.version>2.3.23.Final</undertow.version>
+      <undertow.version>2.4.0.Final</undertow.version>
    </properties>
 
    <dependencyManagement>

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/shutdown/hook/Foo.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/shutdown/hook/Foo.java
@@ -43,7 +43,7 @@ public class Foo {
 
     @PreDestroy
     public void destroy() {
-        try (InputStream in = new URL("http", "localhost", UNDERTOW_PORT, "test").openStream()) {
+        try (InputStream in = new URL("http", "localhost", UNDERTOW_PORT, "/test").openStream()) {
             // Sending HTTP GET request
         } catch (IOException e) {
             e.printStackTrace();

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -29,7 +29,7 @@
         <jetty.version>12.1.8</jetty.version>
         <smallrye.common.version>2.18.1</smallrye.common.version>
         <websockets.api>2.2.0</websockets.api>
-        <undertow.version>2.3.23.Final</undertow.version>
+        <undertow.version>2.3.24.Final</undertow.version>
     </properties>
 
     <!-- Import the BOMs -->


### PR DESCRIPTION
Superseeds #3322 #3326 and #3343
On top of that, adds a fix for a test that was only passing because previous versions of Undertow were more lenient.