### PR TITLE
Add CDI API signature test module

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -210,6 +210,31 @@ jobs:
           name: server-log-cdi-tck-jdk${{matrix.java.name}}
           path: 'server-log.tgz'
 
+  # CDI API signature test
+  # The JDK version used for signature verification is pinned in sigtest/pom.xml via maven.compiler.release
+  sigtest:
+    name: "CDI Signature Test"
+    runs-on: ubuntu-latest
+    needs: initial-build
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v8
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Run Signature Test
+        run: mvn verify -Dsigtest -Dno-format -pl sigtest
+
   # relaxed mode, w/ and w/o Wildfly, single JDK version
   relaxed-mode-test:
     name: "Relaxed mode testing - JDK ${{matrix.java.name}}"

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <arquillian.tomcat.version>1.2.4.Final</arquillian.tomcat.version>
         <atinject.tck.version>2.0.1</atinject.tck.version>
         <!-- Version of the CDI 4.1 TCK release -->
-        <cdi.tck.version>5.0.0.Beta1</cdi.tck.version>
+        <cdi.tck.version>5.0.0.Beta2-SNAPSHOT</cdi.tck.version>
         <!-- Version of the Jakarta Platform TCK 4.1 release -->
         <platform.tck.version>11.0.3</platform.tck.version>
         <!-- By default, each mvn profile uses corresponding file from TCK repo, see jboss-tck-runner/pom.xml -->
@@ -521,6 +521,17 @@
             </activation>
             <modules>
                 <module>jboss-tck-runner</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>sigtest</id>
+            <activation>
+                <property>
+                    <name>sigtest</name>
+                </property>
+            </activation>
+            <modules>
+                <module>sigtest</module>
             </modules>
         </profile>
         <profile>

--- a/sigtest/pom.xml
+++ b/sigtest/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>weld-core-parent</artifactId>
+        <groupId>org.jboss.weld</groupId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>weld-sigtest</artifactId>
+    <packaging>jar</packaging>
+    <name>CDI API Signature Test</name>
+    <description>Verifies CDI API signatures against the TCK signature file</description>
+
+    <properties>
+        <!-- Used to select the correct JDK-specific sigfile artifact (classifier=jdk${value})
+             and by sigtest-maven-plugin to resolve JDK class signatures via -BootCP -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-sigfile</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.cdi</groupId>
+                                    <artifactId>jakarta.cdi-tck-core-impl</artifactId>
+                                    <version>${cdi.tck.version}</version>
+                                    <type>sigfile</type>
+                                    <classifier>jdk${maven.compiler.release}</classifier>
+                                    <overWrite>true</overWrite>
+                                    <destFileName>cdi-api.sigfile</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>sigtest</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <action>strictcheck</action>
+                    <sigfile>${project.build.directory}/cdi-api.sigfile</sigfile>
+                    <packages>jakarta.decorator,jakarta.enterprise.**,jakarta.interceptor</packages>
+                    <report>${project.build.directory}/cdi-sig-report.txt</report>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Separate module activated via -Dsigtest, with a CI job on JDK 17.


This will be failing until the `SNAPSHOT` version gets removed.
There is a pending TCK PR that changes some of the details for this, hence we will wait for a release.