### PR TITLE
Update CI and dependabot config for master to main rename

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,13 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 15
-  target-branch: master
+  target-branch: main
 - package-ecosystem: maven
   directory: "/"
   schedule:
     interval: weekly
   open-pull-requests-limit: 15
-  target-branch: master
+  target-branch: main
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -2,7 +2,7 @@ name: Weld CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     # Do not run for non-code changes
     paths-ignore:
       - '.gitignore'
@@ -44,7 +44,7 @@ jobs:
           path: ~/.m2/repository
           # Caching is an automated pre/post action that installs the cache if the key exists and exports the cache
           # after the job is done. In this case we refresh the cache monthly (by changing key) to avoid unlimited growth.
-          key: q2maven-master-${{ steps.get-date.outputs.date }}
+          key: q2maven-main-${{ steps.get-date.outputs.date }}
       - name: Build Weld SNAPSHOT
         run: mvn clean install -DskipTests -Dno-format -B -V -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       - name: Patch WildFly


### PR DESCRIPTION
## Summary
- Update CI workflow PR trigger branch from `master` to `main`
- Update CI workflow Maven cache key from `q2maven-master-` to `q2maven-main-`
- Update both dependabot target branches from `master` to `main`