### PR TITLE
Fix Javadoc link formatting in ContextNotActiveException

### DIFF
--- a/impl/src/main/java/org/jboss/weld/contexts/ContextNotActiveException.java
+++ b/impl/src/main/java/org/jboss/weld/contexts/ContextNotActiveException.java
@@ -23,7 +23,7 @@ import org.jboss.weld.exceptions.WeldExceptionStringMessage;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
- * A localized message version of the {@linkjakarta.enterprise.context.ContextNotActiveException}.
+ * A localized message version of the {@link jakarta.enterprise.context.ContextNotActiveException}.
  *
  * @author David Allen
  */


### PR DESCRIPTION
A missing space caused the tag to not be rendered correctly.