### PR TITLE
Update dependencies and fix test compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
     interval: monthly
   open-pull-requests-limit: 15
   target-branch: master
+  ignore:
+  - dependency-name: "org.testng:testng"
+    versions: ["> 7.9.0"]

--- a/environments/se/pom.xml
+++ b/environments/se/pom.xml
@@ -24,7 +24,7 @@
     </description>
 
    <properties>
-      <undertow.version>2.3.18.Final</undertow.version>
+      <undertow.version>2.4.1.Final</undertow.version>
    </properties>
 
    <dependencyManagement>

--- a/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/shutdown/hook/Foo.java
+++ b/environments/se/tests/src/test/java/org/jboss/weld/environment/se/test/shutdown/hook/Foo.java
@@ -43,7 +43,7 @@ public class Foo {
 
     @PreDestroy
     public void destroy() {
-        try (InputStream in = new URL("http", "localhost", UNDERTOW_PORT, "test").openStream()) {
+        try (InputStream in = new URL("http", "localhost", UNDERTOW_PORT, "/test").openStream()) {
             // Sending HTTP GET request
         } catch (IOException e) {
             e.printStackTrace();

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -28,7 +28,7 @@
         <tomcat.version>11.0.22</tomcat.version>
         <jetty.version>12.1.10</jetty.version>
         <websockets.api>2.2.0</websockets.api>
-        <undertow.version>2.3.18.Final</undertow.version>
+        <undertow.version>2.3.24.Final</undertow.version>
     </properties>
 
     <!-- Import the BOMs -->

--- a/pom.xml
+++ b/pom.xml
@@ -73,14 +73,14 @@
         <htmlunit.version>2.70.0</htmlunit.version>
         <jacoco.version>0.8.15</jacoco.version>
         <jandex.version>3.6.0</jandex.version>
-        <jakarta.activation.version>2.1.3</jakarta.activation.version>
+        <jakarta.activation.version>2.1.4</jakarta.activation.version>
         <jakarta.el.version>6.0.1</jakarta.el.version>
         <glassfish.jakarta.el.version>5.0.0-M1</glassfish.jakarta.el.version>
         <jakarta.jms.api.version>3.1.0</jakarta.jms.api.version>
         <jsf.api.version>4.1.2</jsf.api.version>
         <jboss.logging.version>3.6.3.Final</jboss.logging.version>
         <jboss.logging.processor.version>3.0.4.Final</jboss.logging.processor.version>
-        <jboss.logmanager.version>3.1.2.Final</jboss.logmanager.version>
+        <jboss.logmanager.version>3.2.2.Final</jboss.logmanager.version>
         <jsf.impl.version>4.1.9</jsf.impl.version>
         <jsp.api.version>4.0.0</jsp.api.version>
         <jstl.api.version>3.0.2</jstl.api.version>
@@ -89,7 +89,7 @@
         <shrinkwrap.resolver.version>3.3.7</shrinkwrap.resolver.version>
         <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.10.2</spotbugs-annotations-version>
-        <testng.version>7.12.0</testng.version>
+        <testng.version>7.9.0</testng.version>
         <weld.api.version>6.0.Final</weld.api.version>
         <wildfly.arquillian.version>5.1.0.Final</wildfly.arquillian.version>
     </properties>


### PR DESCRIPTION
Consolidate dependabot updates: bump `undertow-core` to 2.4.1.Final, `undertow-servlet` to 2.3.24.Final, `jakarta.activation-api` to 2.1.4, and `jboss-logmanager` to 3.2.2.Final to resolve `smallrye-common` version conflict.

Fix `Foo.destroy()` URL path for Undertow 2.4.x compatibility.
Revert `testng` to 7.9.0 to match CDI TCK.