### PR TITLE
Remove stale smallrye-common BOM workaround, bump TestNG to 7.12.0

### DIFF
--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -27,7 +27,6 @@
     <properties>
         <tomcat.version>11.0.22</tomcat.version>
         <jetty.version>12.1.10</jetty.version>
-        <smallrye.common.version>2.19.0</smallrye.common.version>
         <websockets.api>2.2.0</websockets.api>
         <undertow.version>2.3.24.Final</undertow.version>
     </properties>
@@ -93,16 +92,6 @@
                 <artifactId>jakarta.websocket-api</artifactId>
                 <version>${websockets.api}</version>
                 <scope>test</scope>
-            </dependency>
-
-            <!-- Used by JBoss logmanager and Undertow-servlet dependencies in different versions, this unified them-->
-            <!-- Attempt to remove once we use jboss-logmanager > 3.1.2.Final -->
-            <dependency>
-                <groupId>io.smallrye.common</groupId>
-                <artifactId>smallrye-common-bom</artifactId>
-                <version>${smallrye.common.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
         </dependencies>

--- a/jboss-tck-runner/src/test/tck/tck-tests-web.xml
+++ b/jboss-tck-runner/src/test/tck/tck-tests-web.xml
@@ -14,7 +14,7 @@
         <listener class-name="org.testng.reporters.SuiteHTMLReporter"/>
         <listener class-name="org.testng.reporters.FailedReporter"/>
         <listener class-name="org.testng.reporters.XMLReporter"/>
-        <listener class-name="org.testng.reporters.EmailableReporter"/>
+        <listener class-name="org.testng.reporters.EmailableReporter2"/>
         <listener class-name="org.testng.reporters.TestHTMLReporter" />
     </listeners>
 

--- a/jboss-tck-runner/src/test/tck/tck-tests.xml
+++ b/jboss-tck-runner/src/test/tck/tck-tests.xml
@@ -12,7 +12,7 @@
         <listener class-name="org.testng.reporters.SuiteHTMLReporter"/>
         <listener class-name="org.testng.reporters.FailedReporter"/>
         <listener class-name="org.testng.reporters.XMLReporter"/>
-        <listener class-name="org.testng.reporters.EmailableReporter"/>
+        <listener class-name="org.testng.reporters.EmailableReporter2"/>
         <listener class-name="org.testng.reporters.TestHTMLReporter" />
     </listeners>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <shrinkwrap.resolver.version>3.3.7</shrinkwrap.resolver.version>
         <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.10.2</spotbugs-annotations-version>
-        <testng.version>7.9.0</testng.version>
+        <testng.version>7.12.0</testng.version>
         <weld.api.version>7.0.Beta2</weld.api.version>
         <wildfly.arquillian.version>5.1.0.Final</wildfly.arquillian.version>
     </properties>


### PR DESCRIPTION
CDI TCK uses this TestNG version but seems to ship with wrong XML files (`EmailableReporter` was removed).

This should stay as a draft until it is fixed in CDI TCK, see https://github.com/jakartaee/cdi-tck/pull/731