### PR TITLE
Use absolute path in BOM version verification check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
                                 <configuration>
                                     <target>
                                         <property name="weld.api.search.string" value="&lt;weld.api.bom.version&gt;${weld.api.version}&lt;/weld.api.bom.version&gt;" />
-                                        <property name="bom.pom.file.path" value="bom${file.separator}pom.xml" />
+                                        <property name="bom.pom.file.path" value="${project.basedir}${file.separator}bom${file.separator}pom.xml" />
                                         <echo message="Verify Weld API used in ${bom.pom.file.path} matches ${weld.api.version}" />
                                         <fail message="Invalid Weld API version used in BOM pom.xml">
                                             <condition>


### PR DESCRIPTION
The previous solution wasn't working if you invoked makes with `-f` from another directory. 
This should fix it.