### PR TITLE
Fix outdated references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To build Weld simply run
 Upgrading Weld in WildFly
 -------------------------
 
-Firstly, set the `JBOSS_HOME` environment property to point to your WildFly installation which already contains Weld 3 in older version:
+Firstly, set the `JBOSS_HOME` environment property to point to your WildFly installation:
 
 > $ export JBOSS_HOME=/opt/wildfly
 

--- a/docs/reference/src/main/asciidoc/contexts.asciidoc
+++ b/docs/reference/src/main/asciidoc/contexts.asciidoc
@@ -325,7 +325,7 @@ public interface WeldManager extends BeanManager {
 ==== Example of context propagation
 
 There is a concise example in a form of a test in our code showing how to propagate all built-in contexts.
-This doc only contains an excerpt from it, you can look link:https://github.com/weld/core/blob/master/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation[here] to get the full picture.
+This doc only contains an excerpt from it, you can look link:https://github.com/weld/core/blob/main/tests-arquillian/src/test/java/org/jboss/weld/tests/contexts/propagation[here] to get the full picture.
 
 Following code shows a service that provides an extra thread onto which you offload a `Callable<T>` that uses beans from currently active context.
 The service activates contexts, propagates state from original thread, executes task and cleans up.
@@ -340,7 +340,6 @@ public class ContextPropagationService {
     public static <T> Future<T> propagateContextsAndSubmitTask(Callable<T> task) {
         // gather all the contexts we want to propagate and the instances in them
         Map<Class<? extends Annotation>, Collection<ContextualInstance<Object>>> scopeToContextualInstances = new HashMap<>();
-        WeldManager get = CDI.current().select(WeldManager.class).get();
         for (WeldAlterableContext context : CDI.current().select(WeldManager.class).get().getActiveWeldAlterableContexts()) {
             scopeToContextualInstances.put(context.getScope(), context.getAllContextualInstances());
         }
@@ -349,11 +348,14 @@ public class ContextPropagationService {
 
             @Override
             public T call() throws Exception {
-                // Get WeldManager,get instances of @Bound contexts for request, session and conversation scopes
+                // Get WeldManager and @Bound context instances for request, session and conversation scopes
                 WeldManager weldManager = CDI.current().select(WeldManager.class).get();
-                BoundRequestContext requestContext = weldManager.instance().select(BoundRequestContext.class, BoundLiteral.INSTANCE).get();
-                BoundSessionContext sessionContext = weldManager.instance().select(BoundSessionContext.class, BoundLiteral.INSTANCE).get();
-                BoundConversationContext conversationContext = weldManager.instance().select(BoundConversationContext.class, BoundLiteral.INSTANCE).get();
+                BoundRequestContext requestContext = weldManager.instance()
+                    .select(BoundRequestContext.class, BoundLiteral.INSTANCE).get();
+                BoundSessionContext sessionContext = weldManager.instance()
+                    .select(BoundSessionContext.class, BoundLiteral.INSTANCE).get();
+                BoundConversationContext conversationContext = weldManager.instance()
+                    .select(BoundConversationContext.class, BoundLiteral.INSTANCE).get();
 
                 // We will be using bound contexts, prepare backing structures for contexts
                 Map<String, Object> sessionMap = new HashMap<>();

--- a/docs/reference/src/main/asciidoc/environments.asciidoc
+++ b/docs/reference/src/main/asciidoc/environments.asciidoc
@@ -183,15 +183,16 @@ Jetty 12 and newer are supported. Context activation/deactivation and dependency
 No further configuration is needed when starting Jetty as an embedded webapp server from within another Java program.
 However, if you’re using a Jetty standalone instance, there is one more configuration step that is required.
 
-===== Jetty `ee10-cdi` Module
+===== Jetty CDI Module
 
-The Weld/Jetty integration uses the Jetty `ee10-cdi` module.
-To activate this module in Jetty, the argument `--add-modules=ee10-cdi` needs to be added to the
+The Weld/Jetty integration uses a Jetty CDI module.
+The module name depends on which Jakarta EE version you target: `ee10-cdi` for Jakarta EE 10 (Jetty 12.0.x) or `ee11-cdi` for Jakarta EE 11 (Jetty 12.1.x).
+To activate this module in Jetty, the argument `--add-modules=ee10-cdi` (or `ee11-cdi`) needs to be added to the
 command line, which can be done for a standard distribution by running the commands:
 
 -------------------------
 cd $JETTY_BASE
-java -jar $JETTY_HOME/start.jar --add-modules=ee10-cdi
+java -jar $JETTY_HOME/start.jar --add-modules=ee11-cdi
 -------------------------
 
 ==== Undertow


### PR DESCRIPTION
Update context propagation example, fix `master` to `main` link, and update Jetty section with `ee10-cdi`/`ee11-cdi` modules.