### PR TITLE
Adapt CDI provider tests to recent changes

### DIFF
--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/provider/custom/TestCDI.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/provider/custom/TestCDI.java
@@ -38,7 +38,7 @@ public class TestCDI extends CDI<Object> {
      * value directly in a subclass. However, it was probably not intended for the subclass to be able to do this.
      */
     public static void unsetCDIProvider() {
-        configuredProvider = null;
+        providerState.set(initialState());
     }
 
     @Override

--- a/environments/servlet/tests/base/src/main/java/org/jboss/weld/environment/servlet/test/provider/TestCDI.java
+++ b/environments/servlet/tests/base/src/main/java/org/jboss/weld/environment/servlet/test/provider/TestCDI.java
@@ -38,7 +38,7 @@ public class TestCDI extends CDI<Object> {
      * value directly in a subclass. However, it was probably not intended for the subclass to be able to do this.
      */
     public static void unsetCDIProvider() {
-        configuredProvider = null;
+        providerState.set(initialState());
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
     <dependencyManagement>
 
         <dependencies>
+            <!-- TODO remove once Weld API updates CDI API dependency -->
+            <dependency>
+                <groupId>jakarta.cdi</groupId>
+                <artifactId>jakarta.cdi-api</artifactId>
+                <version>5.0.0.Beta2-SNAPSHOT</version>
+            </dependency>
+
             <!--Optional BCEL classes dependency-->
             <dependency>
                 <groupId>org.apache.bcel</groupId>


### PR DESCRIPTION
Adapts the testing to changes done in https://github.com/jakartaee/cdi/pull/996


First commit is to be removed once there is a CDI version in Central that we can bring in via Weld API.
Kept as draft until then.