### PR TITLE
Bump CDI TCK version and Weld API version (bringing in CDI 5.0 CR1)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <weld.api.bom.version>7.0.Beta2</weld.api.bom.version>
+        <weld.api.bom.version>7.0.CR1</weld.api.bom.version>
         <gpg.plugin.version>3.2.8</gpg.plugin.version>
         <nexus.staging.plugin.version>1.7.0</nexus.staging.plugin.version>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <arquillian.tomcat.version>1.2.5.Final</arquillian.tomcat.version>
         <atinject.tck.version>2.0.1</atinject.tck.version>
         <!-- Version of the CDI 4.1 TCK release -->
-        <cdi.tck.version>5.0.0.Beta1</cdi.tck.version>
+        <cdi.tck.version>5.0.0.CR1</cdi.tck.version>
         <!-- Version of the Jakarta Platform TCK 4.1 release -->
         <platform.tck.version>11.0.3</platform.tck.version>
         <!-- By default, each mvn profile uses corresponding file from TCK repo, see jboss-tck-runner/pom.xml -->
@@ -90,7 +90,7 @@
         <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.10.2</spotbugs-annotations-version>
         <testng.version>7.9.0</testng.version>
-        <weld.api.version>7.0.Beta2</weld.api.version>
+        <weld.api.version>7.0.CR1</weld.api.version>
         <wildfly.arquillian.version>5.1.0.Final</wildfly.arquillian.version>
     </properties>
 


### PR DESCRIPTION
This will probably fail and will need to be merged with other PRs that have fixes WRT to incoming changes.