### PR TITLE
Consolidated CDI 5.0 CR1 changes

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -210,6 +210,31 @@ jobs:
           name: server-log-cdi-tck-jdk${{matrix.java.name}}
           path: 'server-log.tgz'
 
+  # CDI API signature test
+  # The JDK version used for signature verification is pinned in sigtest/pom.xml via maven.compiler.release
+  sigtest:
+    name: "CDI Signature Test"
+    runs-on: ubuntu-latest
+    needs: initial-build
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: 21
+          distribution: 'temurin'
+      - name: Download Maven Repo
+        uses: actions/download-artifact@v8
+        with:
+          name: maven-repo
+          path: .
+      - name: Extract Maven Repo
+        shell: bash
+        run: tar -xzf maven-repo.tgz -C ~
+      - name: Run Signature Test
+        run: mvn verify -Dsigtest -Dno-format -pl sigtest
+
   # relaxed mode, w/ and w/o Wildfly, single JDK version
   relaxed-mode-test:
     name: "Relaxed mode testing - JDK ${{matrix.java.name}}"

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <weld.api.bom.version>7.0.Beta2</weld.api.bom.version>
+        <weld.api.bom.version>7.0.CR1</weld.api.bom.version>
         <gpg.plugin.version>3.2.8</gpg.plugin.version>
         <nexus.staging.plugin.version>1.7.0</nexus.staging.plugin.version>
         <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/

--- a/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/provider/custom/TestCDI.java
+++ b/environments/se/core/src/test/java/org/jboss/weld/environment/se/test/provider/custom/TestCDI.java
@@ -38,7 +38,7 @@ public class TestCDI extends CDI<Object> {
      * value directly in a subclass. However, it was probably not intended for the subclass to be able to do this.
      */
     public static void unsetCDIProvider() {
-        configuredProvider = null;
+        providerState.set(initialState());
     }
 
     @Override

--- a/environments/servlet/pom.xml
+++ b/environments/servlet/pom.xml
@@ -27,7 +27,6 @@
     <properties>
         <tomcat.version>11.0.24</tomcat.version>
         <jetty.version>12.1.11</jetty.version>
-        <smallrye.common.version>2.20.0</smallrye.common.version>
         <websockets.api>2.2.0</websockets.api>
         <undertow.version>2.3.25.Final</undertow.version>
     </properties>
@@ -93,16 +92,6 @@
                 <artifactId>jakarta.websocket-api</artifactId>
                 <version>${websockets.api}</version>
                 <scope>test</scope>
-            </dependency>
-
-            <!-- Used by JBoss logmanager and Undertow-servlet dependencies in different versions, this unified them-->
-            <!-- Attempt to remove once we use jboss-logmanager > 3.1.2.Final -->
-            <dependency>
-                <groupId>io.smallrye.common</groupId>
-                <artifactId>smallrye-common-bom</artifactId>
-                <version>${smallrye.common.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
             </dependency>
 
         </dependencies>

--- a/environments/servlet/tests/base/src/main/java/org/jboss/weld/environment/servlet/test/provider/TestCDI.java
+++ b/environments/servlet/tests/base/src/main/java/org/jboss/weld/environment/servlet/test/provider/TestCDI.java
@@ -38,7 +38,7 @@ public class TestCDI extends CDI<Object> {
      * value directly in a subclass. However, it was probably not intended for the subclass to be able to do this.
      */
     public static void unsetCDIProvider() {
-        configuredProvider = null;
+        providerState.set(initialState());
     }
 
     @Override

--- a/impl/src/main/java/org/jboss/weld/bean/builtin/AbstractFacade.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/AbstractFacade.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.Set;
 
 import jakarta.enterprise.context.spi.CreationalContext;
@@ -40,10 +41,21 @@ public abstract class AbstractFacade<T, X> {
     protected static Type getFacadeType(InjectionPoint injectionPoint) {
         Type genericType = injectionPoint.getType();
         if (genericType instanceof ParameterizedType) {
-            return ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            Type typeArgument = ((ParameterizedType) genericType).getActualTypeArguments()[0];
+            if (typeArgument instanceof WildcardType) {
+                return getWildcardBound((WildcardType) typeArgument);
+            }
+            return typeArgument;
         } else {
             throw new IllegalStateException(BeanLogger.LOG.typeParameterMustBeConcrete(injectionPoint));
         }
+    }
+
+    private static Type getWildcardBound(WildcardType wildcard) {
+        if (wildcard.getLowerBounds().length > 0) {
+            return wildcard.getLowerBounds()[0];
+        }
+        return wildcard.getUpperBounds()[0];
     }
 
     private final BeanManagerImpl beanManager;

--- a/impl/src/main/java/org/jboss/weld/bean/builtin/InstanceImpl.java
+++ b/impl/src/main/java/org/jboss/weld/bean/builtin/InstanceImpl.java
@@ -24,7 +24,9 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.ref.WeakReference;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
@@ -89,6 +91,7 @@ public class InstanceImpl<T> extends AbstractFacade<T, Instance<T>> implements W
     private InstanceImpl(InjectionPoint injectionPoint, CreationalContext<? super T> creationalContext,
             BeanManagerImpl beanManager) {
         super(injectionPoint, creationalContext, beanManager);
+        checkInstanceTypeArgument(injectionPoint);
 
         if (injectionPoint.getQualifiers().isEmpty() && Object.class.equals(getType())) {
             // Do not prefetch the beans for Instance<Object> with no qualifiers
@@ -109,6 +112,16 @@ public class InstanceImpl<T> extends AbstractFacade<T, Instance<T>> implements W
         // qualifiers and type
         this.ip = new DynamicLookupInjectionPoint(getInjectionPoint(), getType(), getQualifiers());
         this.ejbSupport = beanManager.getServices().get(EjbSupport.class);
+    }
+
+    private static void checkInstanceTypeArgument(InjectionPoint injectionPoint) {
+        Type type = injectionPoint.getType();
+        if (type instanceof ParameterizedType) {
+            Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
+            if (typeArg instanceof WildcardType && ((WildcardType) typeArg).getLowerBounds().length > 0) {
+                throw BeanLogger.LOG.instanceTypeArgumentWithLowerBound(injectionPoint);
+            }
+        }
     }
 
     public T get() {

--- a/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
+++ b/impl/src/main/java/org/jboss/weld/bootstrap/Validator.java
@@ -886,20 +886,56 @@ public class Validator implements Service {
                             Formats.formatAsStackTraceElement(injectionPoint));
                 }
                 if (parameterizedType.getActualTypeArguments()[0] instanceof WildcardType) {
-                    throw ValidatorLogger.LOG.injectionPointHasWildcard(injectionPoint,
-                            Formats.formatAsStackTraceElement(injectionPoint));
+                    WildcardType wildcard = (WildcardType) parameterizedType.getActualTypeArguments()[0];
+                    if (!isAllowedWildcard(wildcard, type)) {
+                        throw ValidatorLogger.LOG.injectionPointHasWildcard(injectionPoint,
+                                Formats.formatAsStackTraceElement(injectionPoint));
+                    }
                 }
             } else if (type.equals(Event.class) && parameterizedType.getRawType().equals(Instance.class)) {
-                // check for wildcard in Event injected via Instance -> @Inject Instance<Event<?>>
+                // Instance<X> or Instance<? extends X> where X is an invalid Event type is a definition error
                 Type instanceTypeArgument = parameterizedType.getActualTypeArguments()[0];
-                if (instanceTypeArgument instanceof ParameterizedType
-                        && ((ParameterizedType) instanceTypeArgument).getRawType().equals(Event.class)
-                        && ((ParameterizedType) instanceTypeArgument).getActualTypeArguments()[0] instanceof WildcardType) {
+                Type resolvedType = instanceTypeArgument;
+                if (instanceTypeArgument instanceof WildcardType) {
+                    WildcardType wildcard = (WildcardType) instanceTypeArgument;
+                    if (wildcard.getUpperBounds().length > 0) {
+                        resolvedType = wildcard.getUpperBounds()[0];
+                    }
+                }
+                if (isInvalidEventType(resolvedType)) {
                     throw ValidatorLogger.LOG.injectionPointHasWildcard(injectionPoint,
                             Formats.formatAsStackTraceElement(injectionPoint));
                 }
             }
         }
+    }
+
+    private static boolean isAllowedWildcard(WildcardType wildcard, Class<?> facadeType) {
+        if (facadeType.equals(Event.class)) {
+            // Event<? super X> is allowed, Event<?> and Event<? extends X> are not
+            return wildcard.getLowerBounds().length > 0;
+        }
+        if (facadeType.equals(Instance.class)) {
+            // Instance<? extends X> and Instance<?> are allowed, Instance<? super X> is not
+            return wildcard.getLowerBounds().length == 0;
+        }
+        return false;
+    }
+
+    private static boolean isInvalidEventType(Type type) {
+        if (type instanceof Class<?> && Event.class.equals(type)) {
+            return true;
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType) type;
+            if (Event.class.equals(pt.getRawType())) {
+                Type typeArg = pt.getActualTypeArguments()[0];
+                if (typeArg instanceof WildcardType) {
+                    return ((WildcardType) typeArg).getLowerBounds().length == 0;
+                }
+            }
+        }
+        return false;
     }
 
     public static void checkBeanMetadataInjectionPoint(Object bean, InjectionPoint ip, Type expectedTypeArgument) {

--- a/impl/src/main/java/org/jboss/weld/event/EventImpl.java
+++ b/impl/src/main/java/org/jboss/weld/event/EventImpl.java
@@ -22,7 +22,9 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
@@ -74,8 +76,19 @@ public class EventImpl<T> extends AbstractFacade<T, WeldEvent<T>> implements Wel
 
     private EventImpl(InjectionPoint injectionPoint, BeanManagerImpl beanManager) {
         super(injectionPoint, null, beanManager);
+        checkEventTypeArgument(injectionPoint);
         this.injectionPointTypeHierarchy = new HierarchyDiscovery(getType());
         this.cachedObservers = new ConcurrentHashMap<Class<?>, CachedObservers>(DEFAULT_CACHE_CAPACITY);
+    }
+
+    private static void checkEventTypeArgument(InjectionPoint injectionPoint) {
+        Type type = injectionPoint.getType();
+        if (type instanceof ParameterizedType) {
+            Type typeArg = ((ParameterizedType) type).getActualTypeArguments()[0];
+            if (typeArg instanceof WildcardType && ((WildcardType) typeArg).getLowerBounds().length == 0) {
+                throw EventLogger.LOG.eventTypeArgumentWithoutLowerBound(injectionPoint);
+            }
+        }
     }
 
     /**

--- a/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/BeanLogger.java
@@ -561,4 +561,7 @@ public interface BeanLogger extends WeldLogger {
     @LogMessage(level = Level.ERROR)
     @Message(id = 1581, value = "Error invoking AutoCloseable.close() on an instance {0} of {1}", format = Format.MESSAGE_FORMAT)
     void errorAutoClosing(Object param1, Object param2);
+
+    @Message(id = 1582, value = "Instance type argument must not be a wildcard with lower bound: {0}", format = Format.MESSAGE_FORMAT)
+    IllegalArgumentException instanceTypeArgumentWithLowerBound(Object injectionPoint);
 }

--- a/impl/src/main/java/org/jboss/weld/logging/EventLogger.java
+++ b/impl/src/main/java/org/jboss/weld/logging/EventLogger.java
@@ -115,4 +115,7 @@ public interface EventLogger extends WeldLogger {
 
     @Message(id = 422, value = "WeldEvent.select(Type subtype, Annotation... qualifiers) can be invoked only on an instance of WeldEvent<Object>.", format = Format.MESSAGE_FORMAT)
     IllegalStateException selectByTypeOnlyWorksOnObject();
+
+    @Message(id = 423, value = "Event type argument must not be a wildcard without lower bound: {0}", format = Format.MESSAGE_FORMAT)
+    IllegalArgumentException eventTypeArgumentWithoutLowerBound(Object injectionPoint);
 }

--- a/jboss-tck-runner/src/test/tck/tck-tests-web.xml
+++ b/jboss-tck-runner/src/test/tck/tck-tests-web.xml
@@ -14,7 +14,7 @@
         <listener class-name="org.testng.reporters.SuiteHTMLReporter"/>
         <listener class-name="org.testng.reporters.FailedReporter"/>
         <listener class-name="org.testng.reporters.XMLReporter"/>
-        <listener class-name="org.testng.reporters.EmailableReporter"/>
+        <listener class-name="org.testng.reporters.EmailableReporter2"/>
         <listener class-name="org.testng.reporters.TestHTMLReporter" />
     </listeners>
 

--- a/jboss-tck-runner/src/test/tck/tck-tests.xml
+++ b/jboss-tck-runner/src/test/tck/tck-tests.xml
@@ -12,7 +12,7 @@
         <listener class-name="org.testng.reporters.SuiteHTMLReporter"/>
         <listener class-name="org.testng.reporters.FailedReporter"/>
         <listener class-name="org.testng.reporters.XMLReporter"/>
-        <listener class-name="org.testng.reporters.EmailableReporter"/>
+        <listener class-name="org.testng.reporters.EmailableReporter2"/>
         <listener class-name="org.testng.reporters.TestHTMLReporter" />
     </listeners>
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <shrinkwrap.resolver.version>3.3.7</shrinkwrap.resolver.version>
         <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.10.2</spotbugs-annotations-version>
-        <testng.version>7.9.0</testng.version>
+        <testng.version>7.12.0</testng.version>
         <weld.api.version>7.0.CR1</weld.api.version>
         <wildfly.arquillian.version>5.1.0.Final</wildfly.arquillian.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <arquillian.tomcat.version>1.2.5.Final</arquillian.tomcat.version>
         <atinject.tck.version>2.0.1</atinject.tck.version>
         <!-- Version of the CDI 4.1 TCK release -->
-        <cdi.tck.version>5.0.0.Beta1</cdi.tck.version>
+        <cdi.tck.version>5.0.0.CR1</cdi.tck.version>
         <!-- Version of the Jakarta Platform TCK 4.1 release -->
         <platform.tck.version>11.0.3</platform.tck.version>
         <!-- By default, each mvn profile uses corresponding file from TCK repo, see jboss-tck-runner/pom.xml -->
@@ -90,7 +90,7 @@
         <spotbugs-maven-plugin.version>4.10.2.0</spotbugs-maven-plugin.version>
         <spotbugs-annotations-version>4.10.2</spotbugs-annotations-version>
         <testng.version>7.9.0</testng.version>
-        <weld.api.version>7.0.Beta2</weld.api.version>
+        <weld.api.version>7.0.CR1</weld.api.version>
         <wildfly.arquillian.version>5.1.0.Final</wildfly.arquillian.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,17 @@
             </modules>
         </profile>
         <profile>
+            <id>sigtest</id>
+            <activation>
+                <property>
+                    <name>sigtest</name>
+                </property>
+            </activation>
+            <modules>
+                <module>sigtest</module>
+            </modules>
+        </profile>
+        <profile>
             <id>examples</id>
             <activation>
                 <property>

--- a/sigtest/pom.xml
+++ b/sigtest/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <parent>
+        <artifactId>weld-core-parent</artifactId>
+        <groupId>org.jboss.weld</groupId>
+        <version>7.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>weld-sigtest</artifactId>
+    <packaging>jar</packaging>
+    <name>CDI API Signature Test</name>
+    <description>Verifies CDI API signatures against the TCK signature file</description>
+
+    <properties>
+        <!-- Used to select the correct JDK-specific sigfile artifact (classifier=jdk${value})
+             and by sigtest-maven-plugin to resolve JDK class signatures via -BootCP -->
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.install.skip>true</maven.install.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.weld</groupId>
+            <artifactId>weld-core-impl</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-sigfile</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.cdi</groupId>
+                                    <artifactId>jakarta.cdi-tck-core-impl</artifactId>
+                                    <version>${cdi.tck.version}</version>
+                                    <type>sigfile</type>
+                                    <classifier>jdk${maven.compiler.release}</classifier>
+                                    <overWrite>true</overWrite>
+                                    <destFileName>cdi-api.sigfile</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>2.6</version>
+                <executions>
+                    <execution>
+                        <id>sigtest</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <action>strictcheck</action>
+                    <sigfile>${project.build.directory}/cdi-api.sigfile</sigfile>
+                    <packages>jakarta.decorator,jakarta.enterprise.**,jakarta.interceptor</packages>
+                    <report>${project.build.directory}/cdi-sig-report.txt</report>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/BeanWithContravariantEvent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/BeanWithContravariantEvent.java
@@ -1,0 +1,16 @@
+package org.jboss.weld.tests.event.wildcard.contravariant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithContravariantEvent {
+
+    @Inject
+    Event<? super LifecycleEvent<?>> lifecycleEvents;
+
+    public void fireEvent(LifecycleEvent<?> event) {
+        lifecycleEvents.fire(event);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/BeanWithSimpleContravariantEvent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/BeanWithSimpleContravariantEvent.java
@@ -1,0 +1,16 @@
+package org.jboss.weld.tests.event.wildcard.contravariant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithSimpleContravariantEvent {
+
+    @Inject
+    Event<? super Widget> widgetEvents;
+
+    public void fireWidget(Widget widget) {
+        widgetEvents.fire(widget);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/EventContravariantWildcardTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/EventContravariantWildcardTest.java
@@ -1,0 +1,47 @@
+package org.jboss.weld.tests.event.wildcard.contravariant;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies that {@code Event<? super X>} injection points are valid and functional.
+ * {@code Event} is naturally contravariant — you fire subtypes into it — so a
+ * lower-bounded wildcard is a legitimate use case.
+ * <p>
+ * This reproduces the scenario reported by Gavin King where Jakarta Data injects
+ * {@code Event<? super LifecycleEvent<?>>}.
+ *
+ * @see <a href="https://github.com/jakartaee/cdi/issues/888">CDI #888</a>
+ */
+@RunWith(Arquillian.class)
+public class EventContravariantWildcardTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(EventContravariantWildcardTest.class))
+                .addClasses(BeanWithContravariantEvent.class, LifecycleEvent.class, LifecycleEventObserver.class,
+                        BeanWithSimpleContravariantEvent.class, Widget.class, WidgetObserver.class);
+    }
+
+    @Test
+    public void testParameterizedContravariantEventWildcard(BeanWithContravariantEvent bean,
+            LifecycleEventObserver observer) {
+        bean.fireEvent(new LifecycleEvent<>("test"));
+        assertTrue("LifecycleEvent should have been observed", observer.isObserved());
+    }
+
+    @Test
+    public void testSimpleContravariantEventWildcard(BeanWithSimpleContravariantEvent bean,
+            WidgetObserver observer) {
+        bean.fireWidget(new Widget("test"));
+        assertTrue("Widget event should have been observed", observer.isObserved());
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/LifecycleEvent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/LifecycleEvent.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.event.wildcard.contravariant;
+
+public class LifecycleEvent<T> {
+
+    private final T payload;
+
+    public LifecycleEvent(T payload) {
+        this.payload = payload;
+    }
+
+    public T getPayload() {
+        return payload;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/LifecycleEventObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/LifecycleEventObserver.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.event.wildcard.contravariant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+@ApplicationScoped
+public class LifecycleEventObserver {
+
+    private boolean observed = false;
+
+    public void onLifecycleEvent(@Observes LifecycleEvent<?> event) {
+        observed = true;
+    }
+
+    public boolean isObserved() {
+        return observed;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/Widget.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/Widget.java
@@ -1,0 +1,14 @@
+package org.jboss.weld.tests.event.wildcard.contravariant;
+
+public class Widget {
+
+    private final String name;
+
+    public Widget(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/WidgetObserver.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/contravariant/WidgetObserver.java
@@ -1,0 +1,18 @@
+package org.jboss.weld.tests.event.wildcard.contravariant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+
+@ApplicationScoped
+public class WidgetObserver {
+
+    private boolean observed = false;
+
+    public void onWidget(@Observes Widget event) {
+        observed = true;
+    }
+
+    public boolean isObserved() {
+        return observed;
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/covariant/BeanWithCovariantEvent.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/covariant/BeanWithCovariantEvent.java
@@ -1,0 +1,12 @@
+package org.jboss.weld.tests.event.wildcard.covariant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithCovariantEvent {
+
+    @Inject
+    Event<? extends Widget> covariantEvent;
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/covariant/EventCovariantWildcardTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/covariant/EventCovariantWildcardTest.java
@@ -1,0 +1,35 @@
+package org.jboss.weld.tests.event.wildcard.covariant;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies that {@code Event<? extends X>} injection points are rejected.
+ * Covariant wildcards on Event are useless because you cannot call
+ * {@code fire()} on them.
+ *
+ * @see <a href="https://github.com/jakartaee/cdi/issues/888">CDI #888</a>
+ */
+@RunWith(Arquillian.class)
+public class EventCovariantWildcardTest {
+
+    @Deployment
+    @ShouldThrowException(DefinitionException.class)
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(EventCovariantWildcardTest.class))
+                .addClasses(BeanWithCovariantEvent.class, Widget.class);
+    }
+
+    @Test
+    public void testCovariantEventWildcardRejected() {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/covariant/Widget.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/event/wildcard/covariant/Widget.java
@@ -1,0 +1,4 @@
+package org.jboss.weld.tests.event.wildcard.covariant;
+
+public class Widget {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/BeanWithCovariantEventInstance.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/BeanWithCovariantEventInstance.java
@@ -1,15 +1,12 @@
 package org.jboss.weld.tests.instance.wildcard;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 @ApplicationScoped
-public class BeanWithWildcardInstance {
+public class BeanWithCovariantEventInstance {
     @Inject
-    Instance<?> wildInstance;
-
-    public Instance<?> getWildInstance() {
-        return wildInstance;
-    }
+    Instance<? extends Event<String>> covariantEventInstance;
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/BeanWithRawEventInstance.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/BeanWithRawEventInstance.java
@@ -1,15 +1,13 @@
 package org.jboss.weld.tests.instance.wildcard;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 @ApplicationScoped
-public class BeanWithWildcardInstance {
+public class BeanWithRawEventInstance {
     @Inject
-    Instance<?> wildInstance;
-
-    public Instance<?> getWildInstance() {
-        return wildInstance;
-    }
+    @SuppressWarnings("rawtypes")
+    Instance<Event> rawEventInstance;
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/BeanWithWildcardRawEventInstance.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/BeanWithWildcardRawEventInstance.java
@@ -1,15 +1,13 @@
 package org.jboss.weld.tests.instance.wildcard;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 @ApplicationScoped
-public class BeanWithWildcardInstance {
+public class BeanWithWildcardRawEventInstance {
     @Inject
-    Instance<?> wildInstance;
-
-    public Instance<?> getWildInstance() {
-        return wildInstance;
-    }
+    @SuppressWarnings("rawtypes")
+    Instance<? extends Event> wildcardRawEventInstance;
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/InstanceWithCovariantEventTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/InstanceWithCovariantEventTest.java
@@ -2,8 +2,6 @@ package org.jboss.weld.tests.instance.wildcard;
 
 import static org.junit.Assert.assertNotNull;
 
-import jakarta.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
@@ -13,21 +11,20 @@ import org.jboss.weld.test.util.Utils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+/**
+ * Instance<? extends Event<String>> should be allowed since Event<String> is a valid Event injection point.
+ */
 @RunWith(Arquillian.class)
-public class InstanceWithWildcardTest {
+public class InstanceWithCovariantEventTest {
 
     @Deployment
     public static Archive<?> getDeployment() {
-        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(InstanceWithWildcardTest.class))
-                .addClass(BeanWithWildcardInstance.class);
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(InstanceWithCovariantEventTest.class))
+                .addClass(BeanWithCovariantEventInstance.class);
     }
 
-    @Inject
-    BeanWithWildcardInstance bean;
-
     @Test
-    public void testInstanceWithWildcard() {
+    public void testInstanceWithCovariantEvent(BeanWithCovariantEventInstance bean) {
         assertNotNull(bean);
-        assertNotNull(bean.getWildInstance());
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/InstanceWithRawEventTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/InstanceWithRawEventTest.java
@@ -1,10 +1,9 @@
 package org.jboss.weld.tests.instance.wildcard;
 
-import static org.junit.Assert.assertNotNull;
-
-import jakarta.inject.Inject;
+import jakarta.enterprise.inject.spi.DefinitionException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.BeanArchive;
@@ -14,20 +13,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class InstanceWithWildcardTest {
+public class InstanceWithRawEventTest {
 
     @Deployment
+    @ShouldThrowException(DefinitionException.class)
     public static Archive<?> getDeployment() {
-        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(InstanceWithWildcardTest.class))
-                .addClass(BeanWithWildcardInstance.class);
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(InstanceWithRawEventTest.class))
+                .addClass(BeanWithRawEventInstance.class);
     }
 
-    @Inject
-    BeanWithWildcardInstance bean;
-
     @Test
-    public void testInstanceWithWildcard() {
-        assertNotNull(bean);
-        assertNotNull(bean.getWildInstance());
+    public void testInstanceWithRawEvent() {
+        // should throw definition exception
     }
 }

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/InstanceWithWildcardRawEventTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/InstanceWithWildcardRawEventTest.java
@@ -1,0 +1,29 @@
+package org.jboss.weld.tests.instance.wildcard;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class InstanceWithWildcardRawEventTest {
+
+    @Deployment
+    @ShouldThrowException(DefinitionException.class)
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(InstanceWithWildcardRawEventTest.class))
+                .addClass(BeanWithWildcardRawEventInstance.class);
+    }
+
+    @Test
+    public void testInstanceWithWildcardRawEvent() {
+        // should throw definition exception
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/contravariant/BeanWithContravariantInstance.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/contravariant/BeanWithContravariantInstance.java
@@ -1,0 +1,12 @@
+package org.jboss.weld.tests.instance.wildcard.contravariant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithContravariantInstance {
+
+    @Inject
+    Instance<? super Widget> contravariantInstance;
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/contravariant/InstanceContravariantWildcardTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/contravariant/InstanceContravariantWildcardTest.java
@@ -1,0 +1,36 @@
+package org.jboss.weld.tests.instance.wildcard.contravariant;
+
+import jakarta.enterprise.inject.spi.DefinitionException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.ShouldThrowException;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies that {@code Instance<? super X>} injection points are rejected.
+ * Contravariant wildcards on Instance are useless because Instance is
+ * naturally covariant.
+ *
+ * @see <a href="https://github.com/jakartaee/cdi/issues/888">CDI #888</a>
+ */
+@RunWith(Arquillian.class)
+public class InstanceContravariantWildcardTest {
+
+    @Deployment
+    @ShouldThrowException(DefinitionException.class)
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class,
+                Utils.getDeploymentNameAsHash(InstanceContravariantWildcardTest.class))
+                .addClasses(BeanWithContravariantInstance.class, Widget.class);
+    }
+
+    @Test
+    public void testContravariantInstanceWildcardRejected() {
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/contravariant/Widget.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/contravariant/Widget.java
@@ -1,0 +1,4 @@
+package org.jboss.weld.tests.instance.wildcard.contravariant;
+
+public class Widget {
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/covariant/BeanWithCovariantInstance.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/covariant/BeanWithCovariantInstance.java
@@ -1,0 +1,20 @@
+package org.jboss.weld.tests.instance.wildcard.covariant;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class BeanWithCovariantInstance {
+
+    @Inject
+    Instance<? extends Widget> covariantInstance;
+
+    public boolean isResolvable() {
+        return covariantInstance.isResolvable();
+    }
+
+    public Widget get() {
+        return covariantInstance.get();
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/covariant/InstanceCovariantWildcardTest.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/covariant/InstanceCovariantWildcardTest.java
@@ -1,0 +1,37 @@
+package org.jboss.weld.tests.instance.wildcard.covariant;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.BeanArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.weld.test.util.Utils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Verifies that {@code Instance<? extends X>} injection points are valid and
+ * functional. Instance is naturally covariant so an upper-bounded wildcard is
+ * a legitimate use case.
+ *
+ * @see <a href="https://github.com/jakartaee/cdi/issues/888">CDI #888</a>
+ */
+@RunWith(Arquillian.class)
+public class InstanceCovariantWildcardTest {
+
+    @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(BeanArchive.class, Utils.getDeploymentNameAsHash(InstanceCovariantWildcardTest.class))
+                .addClasses(BeanWithCovariantInstance.class, Widget.class);
+    }
+
+    @Test
+    public void testCovariantInstanceWildcardDeploys(BeanWithCovariantInstance bean) {
+        assertTrue("Instance<? extends Widget> should be resolvable", bean.isResolvable());
+        Widget widget = bean.get();
+        assertNotNull("Instance.get() should return a Widget", widget);
+    }
+}

--- a/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/covariant/Widget.java
+++ b/tests-arquillian/src/test/java/org/jboss/weld/tests/instance/wildcard/covariant/Widget.java
@@ -1,0 +1,17 @@
+package org.jboss.weld.tests.instance.wildcard.covariant;
+
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
+public class Widget {
+
+    private final String name;
+
+    public Widget() {
+        this.name = "default";
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
Consolidates the following PRs:
- #3461 - Bump CDI TCK version and Weld API version (bringing in CDI 5.0 CR1)
- #3455 - Adapt CDI provider tests to recent changes
- #3418 - Remove stale smallrye-common BOM workaround, bump TestNG to 7.12.0
- #3365 - Add CDI API signature test module
- #3364 - Allow contravariant wildcards in Event and covariant wildcards in Instance

Fixes #3362
Fixes #3366