### PR TITLE
Bump weld parent 58

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -2,4 +2,5 @@ name: Weld Core release
 release:
   current-version: 7.0.0.CR1
   next-version: 7.0.0-SNAPSHOT
-  
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss.weld</groupId>
         <artifactId>weld-parent</artifactId>
-        <version>57</version>
+        <version>58</version>
     </parent>
 
 


### PR DESCRIPTION
I forgot to bump the parent version here which is an issue since we won't have updated release plugin otherwise.
This should amend it.